### PR TITLE
Track A: Integrate effect estimation and off-policy prediction into engine loop

### DIFF
--- a/causal_optimizer/engine/loop.py
+++ b/causal_optimizer/engine/loop.py
@@ -8,8 +8,11 @@ from __future__ import annotations
 
 import logging
 import uuid
-from typing import Any, Callable, Protocol
+from typing import Any, Protocol
 
+import numpy as np
+
+from causal_optimizer.predictor.off_policy import OffPolicyPredictor
 from causal_optimizer.types import (
     CausalGraph,
     ExperimentLog,
@@ -19,6 +22,14 @@ from causal_optimizer.types import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Minimum requirements for statistical evaluation
+_MIN_EXPERIMENTS = 5
+_MIN_KEPT = 2
+_MIN_DISCARDED = 2
+_N_BOOTSTRAP = 1000
+_ALPHA_EARLY = 0.1  # permissive threshold for < 20 experiments
+_ALPHA_LATE = 0.05  # stricter threshold for >= 20 experiments
 
 
 class ExperimentRunner(Protocol):
@@ -49,6 +60,7 @@ class ExperimentEngine:
         objective_name: str = "objective",
         minimize: bool = True,
         causal_graph: CausalGraph | None = None,
+        max_skips: int = 3,
     ) -> None:
         self.search_space = search_space
         self.runner = runner
@@ -57,6 +69,8 @@ class ExperimentEngine:
         self.causal_graph = causal_graph
         self.log = ExperimentLog()
         self._phase: str = "exploration"
+        self._predictor = OffPolicyPredictor()
+        self._max_skips = max_skips
 
     def run_experiment(self, parameters: dict[str, Any]) -> ExperimentResult:
         """Execute a single experiment and log the result."""
@@ -79,6 +93,10 @@ class ExperimentEngine:
             metadata={"phase": self._phase},
         )
         self.log.results.append(result)
+
+        # Fit the off-policy predictor with updated history
+        self._predictor.fit(self.log, self.search_space, self.objective_name)
+
         return result
 
     def suggest_next(self) -> dict[str, Any]:
@@ -101,8 +119,33 @@ class ExperimentEngine:
         )
 
     def step(self) -> ExperimentResult:
-        """Run one iteration: suggest → run → log → update."""
-        parameters = self.suggest_next()
+        """Run one iteration: suggest → check predictor → run → log → update.
+
+        Uses the off-policy predictor to skip experiments that are predicted
+        to have poor outcomes (with high confidence). If an experiment is
+        skipped, a new suggestion is generated, up to max_skips times.
+        """
+        skips = 0
+        while True:
+            parameters = self.suggest_next()
+
+            # Check if the predictor recommends skipping this experiment
+            if skips < self._max_skips and not self._predictor.should_run_experiment(parameters):
+                skips += 1
+                logger.info(
+                    f"Off-policy predictor recommends skipping experiment "
+                    f"(skip {skips}/{self._max_skips}), suggesting new parameters"
+                )
+                continue
+
+            if skips >= self._max_skips:
+                logger.info(
+                    f"Reached max skips ({self._max_skips}), "
+                    f"running experiment regardless of prediction"
+                )
+
+            break
+
         result = self.run_experiment(parameters)
         self._update_phase()
         return result
@@ -121,8 +164,78 @@ class ExperimentEngine:
             )
         return self.log
 
+    def _is_improvement_significant(self, current_objective: float) -> bool | None:
+        """Check if the current objective is a statistically significant improvement.
+
+        Uses bootstrap confidence intervals on the distribution of kept objectives
+        to determine if the current value represents a real improvement over noise.
+
+        Returns:
+            True if improvement is statistically significant.
+            False if the change is within noise.
+            None if insufficient data for statistical evaluation (fall back to greedy).
+        """
+        n_total = len(self.log.results)
+        kept = [
+            r.metrics.get(self.objective_name)
+            for r in self.log.results
+            if r.status == ExperimentStatus.KEEP
+            and r.metrics.get(self.objective_name) is not None
+        ]
+        discarded = [
+            r.metrics.get(self.objective_name)
+            for r in self.log.results
+            if r.status == ExperimentStatus.DISCARD
+            and r.metrics.get(self.objective_name) is not None
+        ]
+
+        # Not enough history for statistical evaluation
+        if n_total < _MIN_EXPERIMENTS or len(kept) < _MIN_KEPT or len(discarded) < _MIN_DISCARDED:
+            return None
+
+        kept_arr = np.array(kept)
+        best_objective = float(np.min(kept_arr) if self.minimize else np.max(kept_arr))
+
+        # Bootstrap the difference: current_objective - best_objective
+        # For minimization, a negative difference means improvement
+        observed_diff = current_objective - best_objective
+
+        rng = np.random.default_rng(seed=None)
+        bootstrap_diffs = np.empty(_N_BOOTSTRAP)
+        for i in range(_N_BOOTSTRAP):
+            boot_sample = rng.choice(kept_arr, size=len(kept_arr), replace=True)
+            boot_best = float(np.min(boot_sample) if self.minimize else np.max(boot_sample))
+            bootstrap_diffs[i] = current_objective - boot_best
+
+        # Adaptive alpha: permissive early, stricter later
+        alpha = _ALPHA_EARLY if n_total < 20 else _ALPHA_LATE
+
+        if self.minimize:
+            # For minimization: improvement means current < best (negative diff)
+            # Check if the observed diff is significantly negative
+            # (below the lower bound of the bootstrap CI)
+            threshold = float(np.percentile(bootstrap_diffs, 100 * alpha))
+            is_significant = observed_diff < threshold
+        else:
+            # For maximization: improvement means current > best (positive diff)
+            # Check if the observed diff is significantly positive
+            # (above the upper bound of the bootstrap CI)
+            threshold = float(np.percentile(bootstrap_diffs, 100 * (1 - alpha)))
+            is_significant = observed_diff > threshold
+
+        logger.debug(
+            f"Statistical evaluation: diff={observed_diff:.6f}, "
+            f"threshold={threshold:.6f}, alpha={alpha}, significant={is_significant}"
+        )
+
+        return is_significant
+
     def _evaluate_status(self, metrics: dict[str, float]) -> ExperimentStatus:
-        """Determine if this result should be kept."""
+        """Determine if this result should be kept.
+
+        Uses bootstrap-based statistical testing when enough history is available.
+        Falls back to simple greedy comparison otherwise.
+        """
         current_objective = metrics.get(self.objective_name)
         if current_objective is None:
             return ExperimentStatus.CRASH
@@ -131,11 +244,38 @@ class ExperimentEngine:
         if best is None:
             return ExperimentStatus.KEEP
 
+        # Try statistical evaluation first
+        sig_result = self._is_improvement_significant(current_objective)
+        if sig_result is not None:
+            if sig_result:
+                logger.info("Statistical evaluation: significant improvement detected — KEEP")
+                return ExperimentStatus.KEEP
+            else:
+                # Not statistically significant, but still check greedy
+                # (the statistical test may be conservative)
+                best_objective = best.metrics.get(self.objective_name, float("inf"))
+                is_better = (
+                    current_objective < best_objective
+                    if self.minimize
+                    else current_objective > best_objective
+                )
+                if is_better:
+                    logger.info(
+                        "Statistical evaluation: not significant, "
+                        "but greedy improvement detected — KEEP"
+                    )
+                    return ExperimentStatus.KEEP
+                else:
+                    logger.info("Statistical evaluation: no improvement — DISCARD")
+                    return ExperimentStatus.DISCARD
+
+        # Fall back to greedy comparison when insufficient data
         best_objective = best.metrics.get(self.objective_name, float("inf"))
         if self.minimize:
-            return ExperimentStatus.KEEP if current_objective < best_objective else ExperimentStatus.DISCARD
+            is_better = current_objective < best_objective
         else:
-            return ExperimentStatus.KEEP if current_objective > best_objective else ExperimentStatus.DISCARD
+            is_better = current_objective > best_objective
+        return ExperimentStatus.KEEP if is_better else ExperimentStatus.DISCARD
 
     def _update_phase(self) -> None:
         """Transition between optimization phases based on experiment count."""

--- a/tests/unit/test_effect_estimation_integration.py
+++ b/tests/unit/test_effect_estimation_integration.py
@@ -1,0 +1,280 @@
+"""Tests for bootstrap-based statistical evaluation in keep/discard decisions."""
+
+from typing import Any
+
+from causal_optimizer.engine.loop import ExperimentEngine
+from causal_optimizer.types import (
+    ExperimentResult,
+    ExperimentStatus,
+    SearchSpace,
+    Variable,
+    VariableType,
+)
+
+
+def make_search_space() -> SearchSpace:
+    return SearchSpace(variables=[
+        Variable(name="x", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+        Variable(name="y", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+    ])
+
+
+class QuadraticRunner:
+    """f(x, y) = x^2 + y^2, minimum at origin."""
+
+    def run(self, parameters: dict[str, Any]) -> dict[str, float]:
+        x = parameters.get("x", 0.0)
+        y = parameters.get("y", 0.0)
+        return {"objective": x**2 + y**2}
+
+
+class FixedRunner:
+    """Runner that returns a pre-set sequence of objectives."""
+
+    def __init__(self, objectives: list[float]) -> None:
+        self._objectives = list(objectives)
+        self._index = 0
+
+    def run(self, parameters: dict[str, Any]) -> dict[str, float]:
+        val = self._objectives[self._index % len(self._objectives)]
+        self._index += 1
+        return {"objective": val}
+
+
+def _seed_engine_with_history(
+    engine: ExperimentEngine,
+    kept_values: list[float],
+    discarded_values: list[float],
+) -> None:
+    """Add synthetic history to the engine log without running experiments."""
+    for i, val in enumerate(kept_values):
+        result = ExperimentResult(
+            experiment_id=f"kept-{i}",
+            parameters={"x": float(i), "y": 0.0},
+            metrics={"objective": val},
+            status=ExperimentStatus.KEEP,
+            metadata={"phase": "exploration"},
+        )
+        engine.log.results.append(result)
+
+    for i, val in enumerate(discarded_values):
+        result = ExperimentResult(
+            experiment_id=f"disc-{i}",
+            parameters={"x": float(i + 10), "y": 0.0},
+            metrics={"objective": val},
+            status=ExperimentStatus.DISCARD,
+            metadata={"phase": "exploration"},
+        )
+        engine.log.results.append(result)
+
+
+class TestGreedyFallback:
+    """With too few experiments, greedy behavior should be preserved."""
+
+    def test_first_experiment_always_kept(self):
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        result = engine.run_experiment({"x": 1.0, "y": 2.0})
+        assert result.status == ExperimentStatus.KEEP
+
+    def test_greedy_with_few_experiments(self):
+        """With < 5 experiments, _is_improvement_significant returns None (greedy)."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        # Run 3 experiments — not enough for statistical evaluation
+        r1 = engine.run_experiment({"x": 3.0, "y": 4.0})  # 25
+        r2 = engine.run_experiment({"x": 1.0, "y": 1.0})  # 2 — better
+        r3 = engine.run_experiment({"x": 4.0, "y": 4.0})  # 32 — worse
+
+        assert r1.status == ExperimentStatus.KEEP
+        assert r2.status == ExperimentStatus.KEEP
+        assert r3.status == ExperimentStatus.DISCARD
+
+    def test_insufficient_kept_or_discarded(self):
+        """Even with >= 5 experiments, need at least 2 KEEP and 2 DISCARD."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        # All improving so all KEEP — no DISCARD examples
+        vals = [50.0, 40.0, 30.0, 20.0, 10.0]
+        runner = FixedRunner(vals)
+        engine.runner = runner
+
+        for _ in range(5):
+            engine.run_experiment({"x": 0.0, "y": 0.0})
+
+        # _is_improvement_significant should return None
+        result = engine._is_improvement_significant(5.0)
+        assert result is None
+
+    def test_is_improvement_significant_returns_none_with_few_data(self):
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        # Only 2 experiments — nowhere near enough
+        engine.run_experiment({"x": 3.0, "y": 0.0})
+        engine.run_experiment({"x": 4.0, "y": 0.0})
+
+        result = engine._is_improvement_significant(1.0)
+        assert result is None
+
+
+class TestStatisticalEvaluation:
+    """With enough history, statistical evaluation should be used."""
+
+    def test_statistical_path_used_with_enough_history(self):
+        """With >= 5 experiments, >= 2 KEEP and >= 2 DISCARD, statistical check fires."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+
+        # Seed history: 3 KEEP, 3 DISCARD
+        _seed_engine_with_history(
+            engine,
+            kept_values=[1.0, 2.0, 3.0],
+            discarded_values=[10.0, 15.0, 20.0],
+        )
+
+        # _is_improvement_significant should return a bool, not None
+        result = engine._is_improvement_significant(0.1)
+        assert result is not None
+
+    def test_clear_improvement_is_kept(self):
+        """A clear improvement (much better than best) should be kept."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+            minimize=True,
+        )
+
+        # Seed with kept values around 5-10 and discarded around 15-20
+        _seed_engine_with_history(
+            engine,
+            kept_values=[5.0, 6.0, 7.0],
+            discarded_values=[15.0, 18.0, 20.0],
+        )
+
+        # A value of 0.5 is clearly better than best (5.0)
+        metrics = {"objective": 0.5}
+        status = engine._evaluate_status(metrics)
+        assert status == ExperimentStatus.KEEP
+
+    def test_noise_level_change_discarded(self):
+        """A change within noise level should be discarded."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+            minimize=True,
+        )
+
+        # Seed with very tight kept values and some discarded
+        _seed_engine_with_history(
+            engine,
+            kept_values=[5.0, 5.0, 5.0],
+            discarded_values=[10.0, 12.0, 15.0],
+        )
+
+        # A value of 12.0 is worse than best (5.0) — should be discarded
+        metrics = {"objective": 12.0}
+        status = engine._evaluate_status(metrics)
+        assert status == ExperimentStatus.DISCARD
+
+    def test_maximization_clear_improvement(self):
+        """For maximization, higher values should be kept."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+            minimize=False,
+        )
+
+        _seed_engine_with_history(
+            engine,
+            kept_values=[10.0, 12.0, 15.0],
+            discarded_values=[2.0, 3.0, 5.0],
+        )
+
+        # 50.0 is clearly better for maximization
+        metrics = {"objective": 50.0}
+        status = engine._evaluate_status(metrics)
+        assert status == ExperimentStatus.KEEP
+
+    def test_maximization_worse_value_discarded(self):
+        """For maximization, lower values should be discarded."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+            minimize=False,
+        )
+
+        _seed_engine_with_history(
+            engine,
+            kept_values=[10.0, 12.0, 15.0],
+            discarded_values=[2.0, 3.0, 5.0],
+        )
+
+        # 1.0 is clearly worse for maximization
+        metrics = {"objective": 1.0}
+        status = engine._evaluate_status(metrics)
+        assert status == ExperimentStatus.DISCARD
+
+    def test_adaptive_alpha_early(self):
+        """With < 20 experiments, alpha=0.1 (more permissive)."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+            minimize=True,
+        )
+
+        # 6 total experiments (< 20) — should use alpha=0.1
+        _seed_engine_with_history(
+            engine,
+            kept_values=[5.0, 6.0, 7.0],
+            discarded_values=[15.0, 18.0, 20.0],
+        )
+
+        assert len(engine.log.results) < 20
+        # The method should work without errors
+        result = engine._is_improvement_significant(0.1)
+        assert isinstance(result, bool)
+
+    def test_adaptive_alpha_late(self):
+        """With >= 20 experiments, alpha=0.05 (stricter)."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+            minimize=True,
+        )
+
+        # Create 20+ experiments
+        _seed_engine_with_history(
+            engine,
+            kept_values=[5.0 + i * 0.1 for i in range(10)],
+            discarded_values=[15.0 + i * 0.5 for i in range(12)],
+        )
+
+        assert len(engine.log.results) >= 20
+        result = engine._is_improvement_significant(0.1)
+        assert isinstance(result, bool)
+
+    def test_crash_still_returned_for_missing_objective(self):
+        """Missing objective should still return CRASH regardless of history."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+
+        _seed_engine_with_history(
+            engine,
+            kept_values=[5.0, 6.0, 7.0],
+            discarded_values=[15.0, 18.0, 20.0],
+        )
+
+        status = engine._evaluate_status({"other_metric": 1.0})
+        assert status == ExperimentStatus.CRASH

--- a/tests/unit/test_off_policy_integration.py
+++ b/tests/unit/test_off_policy_integration.py
@@ -1,0 +1,202 @@
+"""Tests for off-policy predictor integration into the engine loop."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+from causal_optimizer.engine.loop import ExperimentEngine
+from causal_optimizer.predictor.off_policy import OffPolicyPredictor
+from causal_optimizer.types import (
+    SearchSpace,
+    Variable,
+    VariableType,
+)
+
+
+def make_search_space() -> SearchSpace:
+    return SearchSpace(variables=[
+        Variable(name="x", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+        Variable(name="y", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+    ])
+
+
+class QuadraticRunner:
+    """f(x, y) = x^2 + y^2, minimum at origin."""
+
+    def run(self, parameters: dict[str, Any]) -> dict[str, float]:
+        x = parameters.get("x", 0.0)
+        y = parameters.get("y", 0.0)
+        return {"objective": x**2 + y**2}
+
+
+class TestPredictorInitialization:
+    """Test that the predictor is properly initialized."""
+
+    def test_predictor_created_on_init(self):
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        assert isinstance(engine._predictor, OffPolicyPredictor)
+
+    def test_max_skips_default(self):
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        assert engine._max_skips == 3
+
+    def test_max_skips_custom(self):
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+            max_skips=5,
+        )
+        assert engine._max_skips == 5
+
+
+class TestPredictorFitting:
+    """Test that the predictor is fitted after each experiment."""
+
+    def test_predictor_fit_called_after_run_experiment(self):
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        engine._predictor = MagicMock(spec=OffPolicyPredictor)
+        engine._predictor.should_run_experiment.return_value = True
+
+        engine.run_experiment({"x": 1.0, "y": 2.0})
+
+        engine._predictor.fit.assert_called_once_with(
+            engine.log, engine.search_space, "objective"
+        )
+
+    def test_predictor_fit_called_multiple_times(self):
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        engine._predictor = MagicMock(spec=OffPolicyPredictor)
+        engine._predictor.should_run_experiment.return_value = True
+
+        engine.run_experiment({"x": 1.0, "y": 2.0})
+        engine.run_experiment({"x": 2.0, "y": 3.0})
+        engine.run_experiment({"x": 0.5, "y": 0.5})
+
+        assert engine._predictor.fit.call_count == 3
+
+
+class TestPredictorSkipping:
+    """Test that the predictor can recommend skipping experiments."""
+
+    def test_predictor_allows_experiment(self):
+        """When predictor says run, experiment runs normally."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        engine._predictor = MagicMock(spec=OffPolicyPredictor)
+        engine._predictor.should_run_experiment.return_value = True
+        engine._predictor.fit.return_value = None
+
+        result = engine.step()
+        assert result is not None
+        assert len(engine.log.results) == 1
+
+    def test_predictor_skips_then_runs(self):
+        """When predictor skips once then allows, second suggestion runs."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        engine._predictor = MagicMock(spec=OffPolicyPredictor)
+        # First call: skip. Second call: run.
+        engine._predictor.should_run_experiment.side_effect = [False, True]
+        engine._predictor.fit.return_value = None
+
+        result = engine.step()
+        assert result is not None
+        assert len(engine.log.results) == 1
+        # should_run_experiment called twice (once skipped, once allowed)
+        assert engine._predictor.should_run_experiment.call_count == 2
+
+    def test_max_skips_prevents_infinite_loop(self):
+        """When predictor always says skip, max_skips limits the loop."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+            max_skips=3,
+        )
+        engine._predictor = MagicMock(spec=OffPolicyPredictor)
+        # Always skip — but max_skips should break the loop
+        engine._predictor.should_run_experiment.return_value = False
+        engine._predictor.fit.return_value = None
+
+        result = engine.step()
+        assert result is not None
+        assert len(engine.log.results) == 1
+        # should_run_experiment called max_skips times, then we run anyway
+        # (3 skips + the final call is not checked because we break)
+        assert engine._predictor.should_run_experiment.call_count == 3
+
+    def test_max_skips_zero_always_runs(self):
+        """With max_skips=0, experiments always run regardless of predictor."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+            max_skips=0,
+        )
+        engine._predictor = MagicMock(spec=OffPolicyPredictor)
+        engine._predictor.should_run_experiment.return_value = False
+        engine._predictor.fit.return_value = None
+
+        result = engine.step()
+        assert result is not None
+        # Predictor not even consulted since max_skips=0
+        assert engine._predictor.should_run_experiment.call_count == 0
+
+
+class TestEarlyExperimentsAlwaysRun:
+    """Before min_history, the predictor has no model and always says run."""
+
+    def test_early_experiments_always_run(self):
+        """With < min_history experiments, predictor returns True (run)."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        # The real predictor with min_history=5 should always say run
+        # when we have fewer than 5 experiments
+        for _ in range(4):
+            result = engine.step()
+            assert result is not None
+
+        assert len(engine.log.results) == 4
+
+    def test_predictor_model_is_none_early(self):
+        """Before enough data, the predictor model should be None."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        # Initially, no model fitted
+        assert engine._predictor._model is None
+
+        # Run 2 experiments (below min_history of 5)
+        engine.run_experiment({"x": 1.0, "y": 2.0})
+        engine.run_experiment({"x": 2.0, "y": 3.0})
+        assert engine._predictor._model is None
+
+
+class TestIntegrationStepLoop:
+    """Integration tests for the full step loop with predictor."""
+
+    def test_full_loop_with_predictor(self):
+        """Run a full loop and verify predictor doesn't break anything."""
+        engine = ExperimentEngine(
+            search_space=make_search_space(),
+            runner=QuadraticRunner(),
+        )
+        log = engine.run_loop(n_experiments=8)
+        assert len(log.results) == 8
+        assert log.best_result is not None


### PR DESCRIPTION
## Summary
- Integrate bootstrap-based statistical testing into keep/discard decisions (Task 1a)
- Integrate OffPolicyPredictor for observation-intervention tradeoff (Task 1b)
- Add tests for both integration points

## Changes
- engine/loop.py: Add statistical significance check in _evaluate_status, add predictor fit/check in step loop
- tests/: New integration tests for effect estimation and off-policy prediction

## Test plan
- [ ] All existing tests pass
- [ ] New statistical evaluation tests pass
- [ ] New off-policy integration tests pass
- [ ] Ruff lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)