### PR TITLE
Track A: Integrate screening at phase transitions and MAP-Elites diversity tracking

### DIFF
--- a/causal_optimizer/engine/loop.py
+++ b/causal_optimizer/engine/loop.py
@@ -10,6 +10,10 @@ import logging
 import uuid
 from typing import Any, Callable, Protocol
 
+import numpy as np
+
+from causal_optimizer.designer.screening import ScreeningDesigner, ScreeningResult
+from causal_optimizer.evolution.map_elites import MAPElites
 from causal_optimizer.types import (
     CausalGraph,
     ExperimentLog,
@@ -49,6 +53,7 @@ class ExperimentEngine:
         objective_name: str = "objective",
         minimize: bool = True,
         causal_graph: CausalGraph | None = None,
+        descriptor_names: list[str] | None = None,
     ) -> None:
         self.search_space = search_space
         self.runner = runner
@@ -57,6 +62,14 @@ class ExperimentEngine:
         self.causal_graph = causal_graph
         self.log = ExperimentLog()
         self._phase: str = "exploration"
+        self._screening_result: ScreeningResult | None = None
+        self._screened_focus_variables: list[str] | None = None
+        self._descriptor_names = descriptor_names
+        self._archive: MAPElites | None = (
+            MAPElites(descriptor_names, minimize=minimize)
+            if descriptor_names
+            else None
+        )
 
     def run_experiment(self, parameters: dict[str, Any]) -> ExperimentResult:
         """Execute a single experiment and log the result."""
@@ -79,6 +92,14 @@ class ExperimentEngine:
             metadata={"phase": self._phase},
         )
         self.log.results.append(result)
+
+        # Add to MAP-Elites archive if configured
+        if self._archive is not None and self._descriptor_names:
+            fitness = metrics.get(self.objective_name, float("inf"))
+            descriptors = self._extract_descriptors(metrics)
+            if descriptors:
+                self._archive.add(result, fitness, descriptors)
+
         return result
 
     def suggest_next(self) -> dict[str, Any]:
@@ -87,9 +108,31 @@ class ExperimentEngine:
         Uses the current phase to determine strategy:
         - exploration: DoE-based screening
         - optimization: CBO with causal graph
-        - exploitation: best-neighborhood search
+        - exploitation: best-neighborhood search (with MAP-Elites diversity)
         """
         from causal_optimizer.optimizer.suggest import suggest_parameters
+
+        # In exploitation phase, 50% of the time sample from MAP-Elites archive
+        if (
+            self._phase == "exploitation"
+            and self._archive is not None
+            and self._archive.archive
+        ):
+            rng = np.random.default_rng()
+            if rng.random() < 0.5:
+                elite = self._archive.sample_elite()
+                if elite is not None:
+                    logger.info("Sampling from MAP-Elites archive for diversity")
+                    return suggest_parameters(
+                        search_space=self.search_space,
+                        experiment_log=self.log,
+                        causal_graph=self.causal_graph,
+                        phase=self._phase,
+                        minimize=self.minimize,
+                        objective_name=self.objective_name,
+                        screened_variables=self._screened_focus_variables,
+                        base_parameters=elite.parameters,
+                    )
 
         return suggest_parameters(
             search_space=self.search_space,
@@ -98,6 +141,7 @@ class ExperimentEngine:
             phase=self._phase,
             minimize=self.minimize,
             objective_name=self.objective_name,
+            screened_variables=self._screened_focus_variables,
         )
 
     def step(self) -> ExperimentResult:
@@ -140,9 +184,56 @@ class ExperimentEngine:
     def _update_phase(self) -> None:
         """Transition between optimization phases based on experiment count."""
         n = len(self.log.results)
+        old_phase = self._phase
+
         if n < 10:
             self._phase = "exploration"
         elif n < 50:
             self._phase = "optimization"
         else:
             self._phase = "exploitation"
+
+        # Run screening when transitioning from exploration to optimization
+        if old_phase == "exploration" and self._phase == "optimization":
+            self._run_screening()
+
+    def _run_screening(self) -> None:
+        """Run screening analysis to identify important variables."""
+        designer = ScreeningDesigner(self.search_space)
+        result = designer.screen(self.log, self.objective_name)
+        self._screening_result = result
+
+        if result.important_variables:
+            self._screened_focus_variables = result.important_variables
+            logger.info(
+                "Screening identified important variables: %s",
+                result.important_variables,
+            )
+        else:
+            # No important variables found — extend exploration
+            self._phase = "exploration"
+            self._screened_focus_variables = None
+            logger.info(
+                "Screening found no important variables above threshold; "
+                "extending exploration phase"
+            )
+
+        if result.interactions:
+            logger.info(
+                "Screening identified interactions: %s",
+                list(result.interactions.keys()),
+            )
+
+        logger.info("Screening summary:\n%s", result.summary)
+
+    def _extract_descriptors(
+        self, metrics: dict[str, float]
+    ) -> dict[str, float]:
+        """Extract descriptor values from metrics for MAP-Elites."""
+        if not self._descriptor_names:
+            return {}
+        return {
+            name: metrics[name]
+            for name in self._descriptor_names
+            if name in metrics
+        }

--- a/causal_optimizer/optimizer/suggest.py
+++ b/causal_optimizer/optimizer/suggest.py
@@ -25,17 +25,28 @@ def suggest_parameters(
     phase: str = "exploration",
     minimize: bool = True,
     objective_name: str = "objective",
+    screened_variables: list[str] | None = None,
+    base_parameters: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Suggest next experiment parameters based on current phase and history."""
+    """Suggest next experiment parameters based on current phase and history.
+
+    Args:
+        screened_variables: Variables identified as important by screening.
+            Complements graph-based focus variables (intersection if both available).
+        base_parameters: Base parameters to perturb from (e.g., from MAP-Elites elite).
+            Used in exploitation phase instead of the overall best.
+    """
     if phase == "exploration":
         return _suggest_exploration(search_space, experiment_log)
     elif phase == "optimization":
         return _suggest_optimization(
-            search_space, experiment_log, causal_graph, minimize, objective_name
+            search_space, experiment_log, causal_graph, minimize, objective_name,
+            screened_variables=screened_variables,
         )
     elif phase == "exploitation":
         return _suggest_exploitation(
-            search_space, experiment_log, minimize, objective_name
+            search_space, experiment_log, minimize, objective_name,
+            base_parameters=base_parameters,
         )
     else:
         return _suggest_exploration(search_space, experiment_log)
@@ -58,18 +69,34 @@ def _suggest_optimization(
     causal_graph: CausalGraph | None,
     minimize: bool,
     objective_name: str,
+    screened_variables: list[str] | None = None,
 ) -> dict[str, Any]:
     """Optimization: Bayesian optimization with optional causal guidance.
 
     If a causal graph is available, uses it to identify which variables
-    to prioritize (ancestors of the objective in the DAG).
+    to prioritize (ancestors of the objective in the DAG). Screening results
+    complement the graph-based focus.
     """
     df = experiment_log.to_dataframe()
     if len(df) < 3:
         return _suggest_exploration(search_space, experiment_log)
 
     # Identify which variables to focus on
-    focus_variables = _get_focus_variables(search_space, causal_graph, objective_name)
+    graph_focus = _get_focus_variables(search_space, causal_graph, objective_name)
+
+    # Combine graph-based and screening-based focus variables
+    if screened_variables is not None and causal_graph is not None:
+        # Both available: use intersection (variables both sources agree on)
+        focus_variables = [v for v in graph_focus if v in screened_variables]
+        # Fall back to union if intersection is empty
+        if not focus_variables:
+            focus_variables = list(set(graph_focus) | set(screened_variables))
+    elif screened_variables is not None:
+        # Only screening available (no graph)
+        focus_variables = screened_variables
+    else:
+        # Only graph (or default)
+        focus_variables = graph_focus
 
     # Try Bayesian optimization via Ax
     try:
@@ -86,14 +113,18 @@ def _suggest_exploitation(
     experiment_log: ExperimentLog,
     minimize: bool,
     objective_name: str,
+    base_parameters: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Exploitation: perturb the best known configuration."""
-    best = experiment_log.best_result
-    if best is None:
-        return _random_sample(search_space)
+    """Exploitation: perturb the best known configuration or a provided base."""
+    if base_parameters is not None:
+        params = dict(base_parameters)
+    else:
+        best = experiment_log.best_result
+        if best is None:
+            return _random_sample(search_space)
+        params = dict(best.parameters)
 
     rng = np.random.default_rng()
-    params = dict(best.parameters)
 
     # Perturb one or two variables slightly
     n_perturb = rng.integers(1, min(3, len(search_space.variables)) + 1)

--- a/tests/unit/test_map_elites_integration.py
+++ b/tests/unit/test_map_elites_integration.py
@@ -1,0 +1,201 @@
+"""Tests for MAP-Elites integration in the experiment engine."""
+
+from typing import Any
+
+from causal_optimizer.engine.loop import ExperimentEngine
+from causal_optimizer.evolution.map_elites import MAPElites
+from causal_optimizer.types import (
+    ExperimentResult,
+    ExperimentStatus,
+    SearchSpace,
+    Variable,
+    VariableType,
+)
+
+
+def make_search_space() -> SearchSpace:
+    return SearchSpace(variables=[
+        Variable(name="x", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+        Variable(name="y", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+    ])
+
+
+class MetricRunner:
+    """Runner that returns objective plus descriptor metrics."""
+
+    def run(self, parameters: dict[str, Any]) -> dict[str, float]:
+        x = parameters.get("x", 0.0)
+        y = parameters.get("y", 0.0)
+        return {
+            "objective": x**2 + y**2,
+            "total_spend": abs(x) + abs(y),
+            "channel_diversity": abs(x - y),
+        }
+
+
+def test_archive_created_when_descriptor_names_provided():
+    """Archive should be created when descriptor_names are given."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+    assert engine._archive is not None
+    assert isinstance(engine._archive, MAPElites)
+    assert engine._archive.descriptor_names == ["total_spend", "channel_diversity"]
+
+
+def test_archive_is_none_when_no_descriptor_names():
+    """Archive should be None when no descriptor_names are given."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+    )
+    assert engine._archive is None
+
+
+def test_results_added_to_archive_after_experiment():
+    """Results should be added to the archive after each experiment."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+
+    assert len(engine._archive.archive) == 0
+
+    engine.run_experiment({"x": 1.0, "y": 2.0})
+
+    assert len(engine._archive.archive) > 0
+
+
+def test_multiple_experiments_populate_archive():
+    """Running multiple experiments should add diverse entries to archive."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+
+    engine.run_experiment({"x": 1.0, "y": 1.0})
+    engine.run_experiment({"x": 4.0, "y": 0.0})
+    engine.run_experiment({"x": 0.0, "y": 4.0})
+
+    # Should have some entries (possibly different cells)
+    assert len(engine._archive.archive) >= 1
+
+
+def test_exploitation_can_sample_from_archive():
+    """In exploitation phase, the engine should be able to sample from archive."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+
+    # Populate archive with some results
+    for i in range(5):
+        engine.run_experiment({"x": float(i), "y": float(i)})
+
+    assert len(engine._archive.archive) > 0
+
+    # Verify archive can sample
+    elite = engine._archive.sample_elite()
+    assert elite is not None
+    assert isinstance(elite, ExperimentResult)
+
+
+def test_extract_descriptors():
+    """_extract_descriptors should extract the right keys from metrics."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+
+    metrics = {
+        "objective": 5.0,
+        "total_spend": 3.0,
+        "channel_diversity": 1.0,
+        "extra_metric": 99.0,
+    }
+
+    descriptors = engine._extract_descriptors(metrics)
+    assert descriptors == {"total_spend": 3.0, "channel_diversity": 1.0}
+
+
+def test_extract_descriptors_missing_keys():
+    """_extract_descriptors should skip missing descriptor keys."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "nonexistent"],
+    )
+
+    metrics = {"objective": 5.0, "total_spend": 3.0}
+    descriptors = engine._extract_descriptors(metrics)
+    assert descriptors == {"total_spend": 3.0}
+
+
+def test_map_elites_add_and_sample():
+    """Basic MAPElites add/sample operations."""
+    archive = MAPElites(
+        descriptor_names=["d1", "d2"],
+        n_bins=5,
+        minimize=True,
+    )
+
+    result = ExperimentResult(
+        experiment_id="test_1",
+        parameters={"x": 1.0},
+        metrics={"objective": 5.0},
+        status=ExperimentStatus.KEEP,
+    )
+
+    added = archive.add(result, fitness=5.0, descriptors={"d1": 0.5, "d2": 0.5})
+    assert added is True
+    assert len(archive.archive) == 1
+
+    sampled = archive.sample_elite()
+    assert sampled is not None
+    assert sampled.experiment_id == "test_1"
+
+
+def test_map_elites_keeps_better_fitness():
+    """MAPElites should keep the better result in a cell."""
+    archive = MAPElites(
+        descriptor_names=["d1"],
+        n_bins=5,
+        minimize=True,
+    )
+
+    r1 = ExperimentResult(
+        experiment_id="worse",
+        parameters={"x": 1.0},
+        metrics={"objective": 10.0},
+        status=ExperimentStatus.KEEP,
+    )
+    r2 = ExperimentResult(
+        experiment_id="better",
+        parameters={"x": 0.5},
+        metrics={"objective": 2.0},
+        status=ExperimentStatus.KEEP,
+    )
+
+    archive.add(r1, fitness=10.0, descriptors={"d1": 0.5})
+    archive.add(r2, fitness=2.0, descriptors={"d1": 0.5})
+
+    sampled = archive.sample_elite()
+    assert sampled is not None
+    assert sampled.experiment_id == "better"
+
+
+def test_archive_not_populated_without_descriptor_names():
+    """Without descriptor_names, no archive operations should happen."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+    )
+
+    engine.run_experiment({"x": 1.0, "y": 2.0})
+    assert engine._archive is None

--- a/tests/unit/test_screening_integration.py
+++ b/tests/unit/test_screening_integration.py
@@ -1,0 +1,140 @@
+"""Tests for screening integration at phase transitions."""
+
+import logging
+from typing import Any
+
+from causal_optimizer.designer.screening import ScreeningResult
+from causal_optimizer.engine.loop import ExperimentEngine
+from causal_optimizer.types import (
+    ExperimentResult,
+    ExperimentStatus,
+    SearchSpace,
+    Variable,
+    VariableType,
+)
+
+
+def make_search_space() -> SearchSpace:
+    return SearchSpace(variables=[
+        Variable(name="x", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+        Variable(name="y", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+        Variable(name="z", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+    ])
+
+
+class QuadraticRunner:
+    """f(x, y, z) = x^2 + y^2 + 0.001*z (z is unimportant)."""
+
+    def run(self, parameters: dict[str, Any]) -> dict[str, float]:
+        x = parameters.get("x", 0.0)
+        y = parameters.get("y", 0.0)
+        z = parameters.get("z", 0.0)
+        return {"objective": x**2 + y**2 + 0.001 * z}
+
+
+def test_screening_runs_at_exploration_to_optimization_transition():
+    """Screening should run when transitioning from exploration to optimization."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    assert engine._screening_result is None
+    assert engine._screened_focus_variables is None
+
+    # Run 10 experiments to trigger transition
+    engine.run_loop(n_experiments=10)
+
+    # Screening should have run
+    assert engine._screening_result is not None
+    assert isinstance(engine._screening_result, ScreeningResult)
+
+
+def test_screened_focus_variables_are_stored():
+    """Screened focus variables should be stored on the engine."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    engine.run_loop(n_experiments=10)
+
+    # Should have screening result with at least the main_effects dict populated
+    assert engine._screening_result is not None
+    assert isinstance(engine._screening_result.main_effects, dict)
+
+    # If important variables were found, they should be stored
+    if engine._screening_result.important_variables:
+        assert engine._screened_focus_variables is not None
+        assert len(engine._screened_focus_variables) > 0
+
+
+def test_screening_with_insufficient_data_returns_empty():
+    """Screening with very few results should return empty gracefully."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    # Manually trigger screening with no data
+    engine._run_screening()
+
+    assert engine._screening_result is not None
+    # With no data, should return empty main_effects
+    assert isinstance(engine._screening_result.main_effects, dict)
+    # Phase should remain exploration (extended) since no important vars found
+    assert engine._phase == "exploration"
+
+
+def test_screening_results_are_logged(caplog):
+    """Screening results should be logged."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    with caplog.at_level(logging.INFO, logger="causal_optimizer.engine.loop"):
+        engine.run_loop(n_experiments=10)
+
+    # Should log screening summary
+    screening_logs = [r for r in caplog.records if "creening" in r.message]
+    assert len(screening_logs) > 0
+
+
+def test_screening_does_not_run_without_phase_transition():
+    """Screening should not run if we stay in the same phase."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    # Run only 5 experiments — still in exploration
+    engine.run_loop(n_experiments=5)
+    assert engine._phase == "exploration"
+    assert engine._screening_result is None
+
+
+def test_no_important_vars_extends_exploration():
+    """When screening finds no important variables, exploration should be extended."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    # Manually set log with insufficient variation to find important vars
+    for i in range(10):
+        result = ExperimentResult(
+            experiment_id=f"test_{i}",
+            parameters={"x": 0.0, "y": 0.0, "z": 0.0},
+            metrics={"objective": 0.0},
+            status=ExperimentStatus.KEEP,
+            metadata={"phase": "exploration"},
+        )
+        engine.log.results.append(result)
+
+    # Trigger screening — all variables should have ~0 importance
+    engine._run_screening()
+
+    # Since no important variables found, phase should stay exploration
+    assert engine._phase == "exploration"
+    assert engine._screened_focus_variables is None


### PR DESCRIPTION
## Summary
- Run ScreeningDesigner at exploration→optimization transition (Task 1d)
- Integrate MAP-Elites archive for diversity tracking (Task 1e)
- Screened focus variables complement causal graph-based focus
- Exploitation phase samples from diverse elites

## Changes
- engine/loop.py: Add screening at phase transition, MAP-Elites archive management
- optimizer/suggest.py: Add screened_variables and base_parameters params
- tests/: New integration tests for screening and MAP-Elites

## Test plan
- [x] All existing tests pass (34/34)
- [x] Screening integration tests pass (6 tests)
- [x] MAP-Elites integration tests pass (10 tests)
- [x] Ruff lint passes (no new errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR integrates two new capabilities into the experiment engine: (1) running `ScreeningDesigner` automatically at the exploration→optimization phase transition to identify important variables, and (2) maintaining a MAP-Elites archive for diversity-aware sampling during exploitation. The MAP-Elites integration is clean and well-tested. However, there are two logic bugs that undermine the correctness and performance of the screening integration.

- **Repeated screening on every step (critical):** When `_run_screening()` finds no important variables it resets `self._phase = "exploration"`. Because `_update_phase()` is called on every `step()`, the exploration→optimization transition condition fires again on the very next call, triggering another full screening run. This repeats for every step from experiment 10 through 49 — up to 39 redundant random-forest fits. A guard flag (e.g. `_screening_attempted`) is needed to prevent re-triggering.
- **Screening focus variables silently ignored for Bayesian path:** In `_suggest_optimization`, the computed `focus_variables` (the carefully crafted intersection/union of graph-based and screened variables) is never forwarded to `_suggest_bayesian()`. When Ax/BoTorch is available, the screening result has zero effect on optimization — only the surrogate fallback path respects it. This makes the core Task 1d feature a no-op in production.
- MAP-Elites archive creation, population, and elite sampling are all correctly implemented and tested.
- The `screened_variables` / `base_parameters` parameters in `suggest.py` are cleanly added with proper docstrings and correct routing logic.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge: the repeated-screening bug will cause significant performance degradation in production runs, and the focus-variables dead-code issue means the primary feature of this PR has no effect when Ax is installed.
- Two logic bugs affect core functionality: screening runs up to 39 extra times per optimization run due to a phase-reset loop, and the computed focus_variables are discarded on the Bayesian optimization path making Task 1d a no-op. The MAP-Elites side is solid, but the screening integration needs fixes before merging.
- Pay close attention to `causal_optimizer/engine/loop.py` (_update_phase/_run_screening interaction) and `causal_optimizer/optimizer/suggest.py` (_suggest_optimization's focus_variables dead code).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| causal_optimizer/engine/loop.py | Adds screening at exploration→optimization transition and MAP-Elites archive management. Contains a critical bug: when screening finds no important variables, it resets the phase to "exploration", causing _update_phase() to re-trigger screening on every subsequent step (10–49), resulting in up to 39 redundant random-forest fits. |
| causal_optimizer/optimizer/suggest.py | Adds screened_variables and base_parameters parameters. The focus_variables intersection/union logic is correctly implemented for the surrogate fallback path, but focus_variables is not forwarded to _suggest_bayesian(), making screening guidance a no-op when Ax is available. |
| tests/unit/test_screening_integration.py | New integration tests for screening at phase transition. Coverage is good; tests for no-important-vars extension, logging, and insufficient data are included. Tests do not catch the repeated-screening bug because they don't instrument _run_screening call count. |
| tests/unit/test_map_elites_integration.py | New integration tests for MAP-Elites archive; covers add/sample, fitness dominance, descriptor extraction, and archive-absence scenarios. All tests appear correct and no issues found. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant L as ExperimentEngine
    participant S as ScreeningDesigner
    participant ME as MAPElites
    participant SP as suggest_parameters

    L->>L: step()
    L->>SP: suggest_next()
    alt exploitation phase AND archive non-empty AND rng < 0.5
        L->>ME: sample_elite()
        ME-->>L: elite (ExperimentResult)
        L->>SP: suggest_parameters(..., base_parameters=elite.parameters)
    else normal path
        L->>SP: suggest_parameters(..., screened_variables=...)
    end
    SP-->>L: parameters

    L->>L: run_experiment(parameters)
    L->>ME: add(result, fitness, descriptors)
    ME-->>L: accepted?

    L->>L: _update_phase()
    alt n crosses 10 AND old_phase==exploration
        L->>S: _run_screening()
        S-->>L: ScreeningResult
        alt important_variables found
            L->>L: set _screened_focus_variables
        else no important variables ⚠️
            L->>L: reset _phase = "exploration"
            Note over L: BUG: next step re-triggers screening
        end
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `causal_optimizer/optimizer/suggest.py`, line 84-108 ([link](https://github.com/datablogin/causal-optimizer/blob/43d0ef938fcf12f20f9156ea42cccc3508b3503d/causal_optimizer/optimizer/suggest.py#L84-L108)) 

   **`focus_variables` computed but silently discarded for Bayesian path**

   `focus_variables` (the intersection/union of graph-based and screened variables) is computed on lines 85–99, but `_suggest_bayesian()` does not accept a `focus_variables` argument and ignores it entirely. Only the `_suggest_surrogate()` fallback receives it. In any deployment where Ax/BoTorch is installed, the screening integration has zero effect on the optimizer — the entire purpose of Task 1d is a no-op on the hot path.

   The fix requires either threading `focus_variables` into `_suggest_bayesian()` (e.g. as a parameter constraint or warm-start hint), or at least a comment acknowledging this known limitation so future developers are not misled by the dead computation above the `try` block.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: causal_optimizer/optimizer/suggest.py
   Line: 84-108

   Comment:
   **`focus_variables` computed but silently discarded for Bayesian path**

   `focus_variables` (the intersection/union of graph-based and screened variables) is computed on lines 85–99, but `_suggest_bayesian()` does not accept a `focus_variables` argument and ignores it entirely. Only the `_suggest_surrogate()` fallback receives it. In any deployment where Ax/BoTorch is installed, the screening integration has zero effect on the optimizer — the entire purpose of Task 1d is a no-op on the hot path.

   The fix requires either threading `focus_variables` into `_suggest_bayesian()` (e.g. as a parameter constraint or warm-start hint), or at least a comment acknowledging this known limitation so future developers are not misled by the dead computation above the `try` block.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20causal_optimizer%2Foptimizer%2Fsuggest.py%0ALine%3A%2084-108%0A%0AComment%3A%0A**%60focus_variables%60%20computed%20but%20silently%20discarded%20for%20Bayesian%20path**%0A%0A%60focus_variables%60%20%28the%20intersection%2Funion%20of%20graph-based%20and%20screened%20variables%29%20is%20computed%20on%20lines%2085%E2%80%9399%2C%20but%20%60_suggest_bayesian%28%29%60%20does%20not%20accept%20a%20%60focus_variables%60%20argument%20and%20ignores%20it%20entirely.%20Only%20the%20%60_suggest_surrogate%28%29%60%20fallback%20receives%20it.%20In%20any%20deployment%20where%20Ax%2FBoTorch%20is%20installed%2C%20the%20screening%20integration%20has%20zero%20effect%20on%20the%20optimizer%20%E2%80%94%20the%20entire%20purpose%20of%20Task%201d%20is%20a%20no-op%20on%20the%20hot%20path.%0A%0AThe%20fix%20requires%20either%20threading%20%60focus_variables%60%20into%20%60_suggest_bayesian%28%29%60%20%28e.g.%20as%20a%20parameter%20constraint%20or%20warm-start%20hint%29%2C%20or%20at%20least%20a%20comment%20acknowledging%20this%20known%20limitation%20so%20future%20developers%20are%20not%20misled%20by%20the%20dead%20computation%20above%20the%20%60try%60%20block.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix in Claude Code" src="https://img.shields.io/badge/Fix_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acausal_optimizer%2Fengine%2Floop.py%3A212-219%0A**Screening%20re-runs%20on%20every%20step%20after%20phase%2010**%0A%0AWhen%20%60_run_screening%28%29%60%20finds%20no%20important%20variables%20it%20resets%20%60self._phase%20%3D%20%22exploration%22%60.%20However%2C%20%60_update_phase%28%29%60%20is%20called%20after%20*every*%20%60step%28%29%60.%20On%20the%20very%20next%20step%2C%20%60n%60%20is%20still%20%E2%89%A5%2010%20and%20%3C%2050%2C%20so%20the%20phase%20is%20again%20computed%20as%20%60%22optimization%22%60%2C%20%60old_phase%60%20is%20%60%22exploration%22%60%20%28it%20was%20just%20reset%29%2C%20and%20the%20transition%20condition%20fires%20%E2%80%94%20scheduling%20another%20expensive%20screening%20run.%20This%20repeats%20on%20every%20step%20from%20experiment%2010%20through%2049%2C%20meaning%20up%20to%2039%20redundant%20random-forest%20fits.%0A%0AA%20guard%20flag%20is%20needed%20to%20prevent%20re-screening%20once%20it%20has%20already%20been%20attempted%20for%20this%20transition%3A%0A%0A%60%60%60python%0A%20%20%20%20if%20result.important_variables%3A%0A%20%20%20%20%20%20%20%20self._screened_focus_variables%20%3D%20result.important_variables%0A%20%20%20%20%20%20%20%20logger.info%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Screening%20identified%20important%20variables%3A%20%25s%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20result.important_variables%2C%0A%20%20%20%20%20%20%20%20%29%0A%20%20%20%20else%3A%0A%20%20%20%20%20%20%20%20%23%20No%20important%20variables%20found%20%E2%80%94%20extend%20exploration%0A%20%20%20%20%20%20%20%20self._phase%20%3D%20%22exploration%22%0A%20%20%20%20%20%20%20%20self._screened_focus_variables%20%3D%20None%0A%20%20%20%20%20%20%20%20self._screening_attempted%20%3D%20True%20%20%20%23%20%3C--%20add%20this%20flag%0A%20%20%20%20%20%20%20%20logger.info%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%22Screening%20found%20no%20important%20variables%20above%20threshold%3B%20%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%22extending%20exploration%20phase%22%0A%20%20%20%20%20%20%20%20%29%0A%60%60%60%0A%0AAnd%20in%20%60_update_phase%60%3A%0A%60%60%60python%0Aif%20old_phase%20%3D%3D%20%22exploration%22%20and%20self._phase%20%3D%3D%20%22optimization%22%20and%20not%20self._screening_attempted%3A%0A%20%20%20%20self._run_screening%28%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acausal_optimizer%2Foptimizer%2Fsuggest.py%3A84-108%0A**%60focus_variables%60%20computed%20but%20silently%20discarded%20for%20Bayesian%20path**%0A%0A%60focus_variables%60%20%28the%20intersection%2Funion%20of%20graph-based%20and%20screened%20variables%29%20is%20computed%20on%20lines%2085%E2%80%9399%2C%20but%20%60_suggest_bayesian%28%29%60%20does%20not%20accept%20a%20%60focus_variables%60%20argument%20and%20ignores%20it%20entirely.%20Only%20the%20%60_suggest_surrogate%28%29%60%20fallback%20receives%20it.%20In%20any%20deployment%20where%20Ax%2FBoTorch%20is%20installed%2C%20the%20screening%20integration%20has%20zero%20effect%20on%20the%20optimizer%20%E2%80%94%20the%20entire%20purpose%20of%20Task%201d%20is%20a%20no-op%20on%20the%20hot%20path.%0A%0AThe%20fix%20requires%20either%20threading%20%60focus_variables%60%20into%20%60_suggest_bayesian%28%29%60%20%28e.g.%20as%20a%20parameter%20constraint%20or%20warm-start%20hint%29%2C%20or%20at%20least%20a%20comment%20acknowledging%20this%20known%20limitation%20so%20future%20developers%20are%20not%20misled%20by%20the%20dead%20computation%20above%20the%20%60try%60%20block.%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<sub>Last reviewed commit: 43d0ef9</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->