### PR TITLE
Track A: Integrate screening at phase transitions and MAP-Elites diversity tracking

### DIFF
--- a/causal_optimizer/engine/loop.py
+++ b/causal_optimizer/engine/loop.py
@@ -12,6 +12,8 @@ from typing import Any, Protocol
 
 import numpy as np
 
+from causal_optimizer.designer.screening import ScreeningDesigner, ScreeningResult
+from causal_optimizer.evolution.map_elites import MAPElites
 from causal_optimizer.predictor.off_policy import OffPolicyPredictor
 from causal_optimizer.types import (
     CausalGraph,
@@ -61,6 +63,7 @@ class ExperimentEngine:
         minimize: bool = True,
         causal_graph: CausalGraph | None = None,
         max_skips: int = 3,
+        descriptor_names: list[str] | None = None,
     ) -> None:
         self.search_space = search_space
         self.runner = runner
@@ -71,6 +74,14 @@ class ExperimentEngine:
         self._phase: str = "exploration"
         self._predictor = OffPolicyPredictor()
         self._max_skips = max_skips
+        self._screening_result: ScreeningResult | None = None
+        self._screened_focus_variables: list[str] | None = None
+        self._descriptor_names = descriptor_names
+        self._archive: MAPElites | None = (
+            MAPElites(descriptor_names, minimize=minimize)
+            if descriptor_names
+            else None
+        )
 
     def run_experiment(self, parameters: dict[str, Any]) -> ExperimentResult:
         """Execute a single experiment and log the result."""
@@ -97,6 +108,13 @@ class ExperimentEngine:
         # Fit the off-policy predictor with updated history
         self._predictor.fit(self.log, self.search_space, self.objective_name)
 
+        # Add to MAP-Elites archive if configured
+        if self._archive is not None and self._descriptor_names:
+            fitness = metrics.get(self.objective_name, float("inf"))
+            descriptors = self._extract_descriptors(metrics)
+            if descriptors:
+                self._archive.add(result, fitness, descriptors)
+
         return result
 
     def suggest_next(self) -> dict[str, Any]:
@@ -105,9 +123,31 @@ class ExperimentEngine:
         Uses the current phase to determine strategy:
         - exploration: DoE-based screening
         - optimization: CBO with causal graph
-        - exploitation: best-neighborhood search
+        - exploitation: best-neighborhood search (with MAP-Elites diversity)
         """
         from causal_optimizer.optimizer.suggest import suggest_parameters
+
+        # In exploitation phase, 50% of the time sample from MAP-Elites archive
+        if (
+            self._phase == "exploitation"
+            and self._archive is not None
+            and self._archive.archive
+        ):
+            rng = np.random.default_rng()
+            if rng.random() < 0.5:
+                elite = self._archive.sample_elite()
+                if elite is not None:
+                    logger.info("Sampling from MAP-Elites archive for diversity")
+                    return suggest_parameters(
+                        search_space=self.search_space,
+                        experiment_log=self.log,
+                        causal_graph=self.causal_graph,
+                        phase=self._phase,
+                        minimize=self.minimize,
+                        objective_name=self.objective_name,
+                        screened_variables=self._screened_focus_variables,
+                        base_parameters=elite.parameters,
+                    )
 
         return suggest_parameters(
             search_space=self.search_space,
@@ -116,6 +156,7 @@ class ExperimentEngine:
             phase=self._phase,
             minimize=self.minimize,
             objective_name=self.objective_name,
+            screened_variables=self._screened_focus_variables,
         )
 
     def step(self) -> ExperimentResult:
@@ -280,9 +321,56 @@ class ExperimentEngine:
     def _update_phase(self) -> None:
         """Transition between optimization phases based on experiment count."""
         n = len(self.log.results)
+        old_phase = self._phase
+
         if n < 10:
             self._phase = "exploration"
         elif n < 50:
             self._phase = "optimization"
         else:
             self._phase = "exploitation"
+
+        # Run screening when transitioning from exploration to optimization
+        if old_phase == "exploration" and self._phase == "optimization":
+            self._run_screening()
+
+    def _run_screening(self) -> None:
+        """Run screening analysis to identify important variables."""
+        designer = ScreeningDesigner(self.search_space)
+        result = designer.screen(self.log, self.objective_name)
+        self._screening_result = result
+
+        if result.important_variables:
+            self._screened_focus_variables = result.important_variables
+            logger.info(
+                "Screening identified important variables: %s",
+                result.important_variables,
+            )
+        else:
+            # No important variables found — extend exploration
+            self._phase = "exploration"
+            self._screened_focus_variables = None
+            logger.info(
+                "Screening found no important variables above threshold; "
+                "extending exploration phase"
+            )
+
+        if result.interactions:
+            logger.info(
+                "Screening identified interactions: %s",
+                list(result.interactions.keys()),
+            )
+
+        logger.info("Screening summary:\n%s", result.summary)
+
+    def _extract_descriptors(
+        self, metrics: dict[str, float]
+    ) -> dict[str, float]:
+        """Extract descriptor values from metrics for MAP-Elites."""
+        if not self._descriptor_names:
+            return {}
+        return {
+            name: metrics[name]
+            for name in self._descriptor_names
+            if name in metrics
+        }

--- a/causal_optimizer/optimizer/suggest.py
+++ b/causal_optimizer/optimizer/suggest.py
@@ -25,13 +25,23 @@ def suggest_parameters(
     phase: str = "exploration",
     minimize: bool = True,
     objective_name: str = "objective",
+    screened_variables: list[str] | None = None,
+    base_parameters: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Suggest next experiment parameters based on current phase and history."""
+    """Suggest next experiment parameters based on current phase and history.
+
+    Args:
+        screened_variables: Variables identified as important by screening.
+            Complements graph-based focus variables (intersection if both available).
+        base_parameters: Base parameters to perturb from (e.g., from MAP-Elites elite).
+            Used in exploitation phase instead of the overall best.
+    """
     if phase == "exploration":
         return _suggest_exploration(search_space, experiment_log)
     elif phase == "optimization":
         return _suggest_optimization(
-            search_space, experiment_log, causal_graph, minimize, objective_name
+            search_space, experiment_log, causal_graph, minimize, objective_name,
+            screened_variables=screened_variables,
         )
     elif phase == "exploitation":
         focus_variables = _get_focus_variables(
@@ -40,6 +50,7 @@ def suggest_parameters(
         return _suggest_exploitation(
             search_space, experiment_log, minimize, objective_name,
             focus_variables=focus_variables,
+            base_parameters=base_parameters,
         )
     else:
         return _suggest_exploration(search_space, experiment_log)
@@ -62,18 +73,32 @@ def _suggest_optimization(
     causal_graph: CausalGraph | None,
     minimize: bool,
     objective_name: str,
+    screened_variables: list[str] | None = None,
 ) -> dict[str, Any]:
     """Optimization: Bayesian optimization with optional causal guidance.
 
     If a causal graph is available, uses it to identify which variables
-    to prioritize (ancestors of the objective in the DAG).
+    to prioritize (ancestors of the objective in the DAG). Screening results
+    complement the graph-based focus.
     """
     df = experiment_log.to_dataframe()
     if len(df) < 3:
         return _suggest_exploration(search_space, experiment_log)
 
     # Identify which variables to focus on
-    focus_variables = _get_focus_variables(search_space, causal_graph, objective_name)
+    graph_focus = _get_focus_variables(search_space, causal_graph, objective_name)
+
+    # Combine graph-based and screening-based focus variables
+    if screened_variables is not None and causal_graph is not None:
+        # Both available: use intersection (variables both sources agree on)
+        focus_variables = [v for v in graph_focus if v in screened_variables]
+        # Fall back to union if intersection is empty
+        if not focus_variables:
+            focus_variables = list(set(graph_focus) | set(screened_variables))
+    elif screened_variables is not None:
+        focus_variables = screened_variables
+    else:
+        focus_variables = graph_focus
 
     # Try Bayesian optimization via Ax
     try:
@@ -94,18 +119,24 @@ def _suggest_exploitation(
     minimize: bool,
     objective_name: str,
     focus_variables: list[str] | None = None,
+    base_parameters: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Exploitation: perturb the best known configuration.
+    """Exploitation: perturb the best known configuration or a provided base.
 
     If focus_variables is provided and non-empty, only perturb variables in
     that set, keeping others at their best-known values.
+    If base_parameters is provided (e.g., from MAP-Elites), perturb those
+    instead of the overall best.
     """
-    best = experiment_log.best_result
-    if best is None:
-        return _random_sample(search_space)
+    if base_parameters is not None:
+        params = dict(base_parameters)
+    else:
+        best = experiment_log.best_result
+        if best is None:
+            return _random_sample(search_space)
+        params = dict(best.parameters)
 
     rng = np.random.default_rng()
-    params = dict(best.parameters)
 
     # Determine which variables are eligible for perturbation
     if focus_variables:

--- a/tests/unit/test_map_elites_integration.py
+++ b/tests/unit/test_map_elites_integration.py
@@ -1,0 +1,201 @@
+"""Tests for MAP-Elites integration in the experiment engine."""
+
+from typing import Any
+
+from causal_optimizer.engine.loop import ExperimentEngine
+from causal_optimizer.evolution.map_elites import MAPElites
+from causal_optimizer.types import (
+    ExperimentResult,
+    ExperimentStatus,
+    SearchSpace,
+    Variable,
+    VariableType,
+)
+
+
+def make_search_space() -> SearchSpace:
+    return SearchSpace(variables=[
+        Variable(name="x", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+        Variable(name="y", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+    ])
+
+
+class MetricRunner:
+    """Runner that returns objective plus descriptor metrics."""
+
+    def run(self, parameters: dict[str, Any]) -> dict[str, float]:
+        x = parameters.get("x", 0.0)
+        y = parameters.get("y", 0.0)
+        return {
+            "objective": x**2 + y**2,
+            "total_spend": abs(x) + abs(y),
+            "channel_diversity": abs(x - y),
+        }
+
+
+def test_archive_created_when_descriptor_names_provided():
+    """Archive should be created when descriptor_names are given."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+    assert engine._archive is not None
+    assert isinstance(engine._archive, MAPElites)
+    assert engine._archive.descriptor_names == ["total_spend", "channel_diversity"]
+
+
+def test_archive_is_none_when_no_descriptor_names():
+    """Archive should be None when no descriptor_names are given."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+    )
+    assert engine._archive is None
+
+
+def test_results_added_to_archive_after_experiment():
+    """Results should be added to the archive after each experiment."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+
+    assert len(engine._archive.archive) == 0
+
+    engine.run_experiment({"x": 1.0, "y": 2.0})
+
+    assert len(engine._archive.archive) > 0
+
+
+def test_multiple_experiments_populate_archive():
+    """Running multiple experiments should add diverse entries to archive."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+
+    engine.run_experiment({"x": 1.0, "y": 1.0})
+    engine.run_experiment({"x": 4.0, "y": 0.0})
+    engine.run_experiment({"x": 0.0, "y": 4.0})
+
+    # Should have some entries (possibly different cells)
+    assert len(engine._archive.archive) >= 1
+
+
+def test_exploitation_can_sample_from_archive():
+    """In exploitation phase, the engine should be able to sample from archive."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+
+    # Populate archive with some results
+    for i in range(5):
+        engine.run_experiment({"x": float(i), "y": float(i)})
+
+    assert len(engine._archive.archive) > 0
+
+    # Verify archive can sample
+    elite = engine._archive.sample_elite()
+    assert elite is not None
+    assert isinstance(elite, ExperimentResult)
+
+
+def test_extract_descriptors():
+    """_extract_descriptors should extract the right keys from metrics."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "channel_diversity"],
+    )
+
+    metrics = {
+        "objective": 5.0,
+        "total_spend": 3.0,
+        "channel_diversity": 1.0,
+        "extra_metric": 99.0,
+    }
+
+    descriptors = engine._extract_descriptors(metrics)
+    assert descriptors == {"total_spend": 3.0, "channel_diversity": 1.0}
+
+
+def test_extract_descriptors_missing_keys():
+    """_extract_descriptors should skip missing descriptor keys."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+        descriptor_names=["total_spend", "nonexistent"],
+    )
+
+    metrics = {"objective": 5.0, "total_spend": 3.0}
+    descriptors = engine._extract_descriptors(metrics)
+    assert descriptors == {"total_spend": 3.0}
+
+
+def test_map_elites_add_and_sample():
+    """Basic MAPElites add/sample operations."""
+    archive = MAPElites(
+        descriptor_names=["d1", "d2"],
+        n_bins=5,
+        minimize=True,
+    )
+
+    result = ExperimentResult(
+        experiment_id="test_1",
+        parameters={"x": 1.0},
+        metrics={"objective": 5.0},
+        status=ExperimentStatus.KEEP,
+    )
+
+    added = archive.add(result, fitness=5.0, descriptors={"d1": 0.5, "d2": 0.5})
+    assert added is True
+    assert len(archive.archive) == 1
+
+    sampled = archive.sample_elite()
+    assert sampled is not None
+    assert sampled.experiment_id == "test_1"
+
+
+def test_map_elites_keeps_better_fitness():
+    """MAPElites should keep the better result in a cell."""
+    archive = MAPElites(
+        descriptor_names=["d1"],
+        n_bins=5,
+        minimize=True,
+    )
+
+    r1 = ExperimentResult(
+        experiment_id="worse",
+        parameters={"x": 1.0},
+        metrics={"objective": 10.0},
+        status=ExperimentStatus.KEEP,
+    )
+    r2 = ExperimentResult(
+        experiment_id="better",
+        parameters={"x": 0.5},
+        metrics={"objective": 2.0},
+        status=ExperimentStatus.KEEP,
+    )
+
+    archive.add(r1, fitness=10.0, descriptors={"d1": 0.5})
+    archive.add(r2, fitness=2.0, descriptors={"d1": 0.5})
+
+    sampled = archive.sample_elite()
+    assert sampled is not None
+    assert sampled.experiment_id == "better"
+
+
+def test_archive_not_populated_without_descriptor_names():
+    """Without descriptor_names, no archive operations should happen."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=MetricRunner(),
+    )
+
+    engine.run_experiment({"x": 1.0, "y": 2.0})
+    assert engine._archive is None

--- a/tests/unit/test_screening_integration.py
+++ b/tests/unit/test_screening_integration.py
@@ -1,0 +1,140 @@
+"""Tests for screening integration at phase transitions."""
+
+import logging
+from typing import Any
+
+from causal_optimizer.designer.screening import ScreeningResult
+from causal_optimizer.engine.loop import ExperimentEngine
+from causal_optimizer.types import (
+    ExperimentResult,
+    ExperimentStatus,
+    SearchSpace,
+    Variable,
+    VariableType,
+)
+
+
+def make_search_space() -> SearchSpace:
+    return SearchSpace(variables=[
+        Variable(name="x", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+        Variable(name="y", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+        Variable(name="z", variable_type=VariableType.CONTINUOUS, lower=-5.0, upper=5.0),
+    ])
+
+
+class QuadraticRunner:
+    """f(x, y, z) = x^2 + y^2 + 0.001*z (z is unimportant)."""
+
+    def run(self, parameters: dict[str, Any]) -> dict[str, float]:
+        x = parameters.get("x", 0.0)
+        y = parameters.get("y", 0.0)
+        z = parameters.get("z", 0.0)
+        return {"objective": x**2 + y**2 + 0.001 * z}
+
+
+def test_screening_runs_at_exploration_to_optimization_transition():
+    """Screening should run when transitioning from exploration to optimization."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    assert engine._screening_result is None
+    assert engine._screened_focus_variables is None
+
+    # Run 10 experiments to trigger transition
+    engine.run_loop(n_experiments=10)
+
+    # Screening should have run
+    assert engine._screening_result is not None
+    assert isinstance(engine._screening_result, ScreeningResult)
+
+
+def test_screened_focus_variables_are_stored():
+    """Screened focus variables should be stored on the engine."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    engine.run_loop(n_experiments=10)
+
+    # Should have screening result with at least the main_effects dict populated
+    assert engine._screening_result is not None
+    assert isinstance(engine._screening_result.main_effects, dict)
+
+    # If important variables were found, they should be stored
+    if engine._screening_result.important_variables:
+        assert engine._screened_focus_variables is not None
+        assert len(engine._screened_focus_variables) > 0
+
+
+def test_screening_with_insufficient_data_returns_empty():
+    """Screening with very few results should return empty gracefully."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    # Manually trigger screening with no data
+    engine._run_screening()
+
+    assert engine._screening_result is not None
+    # With no data, should return empty main_effects
+    assert isinstance(engine._screening_result.main_effects, dict)
+    # Phase should remain exploration (extended) since no important vars found
+    assert engine._phase == "exploration"
+
+
+def test_screening_results_are_logged(caplog):
+    """Screening results should be logged."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    with caplog.at_level(logging.INFO, logger="causal_optimizer.engine.loop"):
+        engine.run_loop(n_experiments=10)
+
+    # Should log screening summary
+    screening_logs = [r for r in caplog.records if "creening" in r.message]
+    assert len(screening_logs) > 0
+
+
+def test_screening_does_not_run_without_phase_transition():
+    """Screening should not run if we stay in the same phase."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    # Run only 5 experiments — still in exploration
+    engine.run_loop(n_experiments=5)
+    assert engine._phase == "exploration"
+    assert engine._screening_result is None
+
+
+def test_no_important_vars_extends_exploration():
+    """When screening finds no important variables, exploration should be extended."""
+    engine = ExperimentEngine(
+        search_space=make_search_space(),
+        runner=QuadraticRunner(),
+    )
+
+    # Manually set log with insufficient variation to find important vars
+    for i in range(10):
+        result = ExperimentResult(
+            experiment_id=f"test_{i}",
+            parameters={"x": 0.0, "y": 0.0, "z": 0.0},
+            metrics={"objective": 0.0},
+            status=ExperimentStatus.KEEP,
+            metadata={"phase": "exploration"},
+        )
+        engine.log.results.append(result)
+
+    # Trigger screening — all variables should have ~0 importance
+    engine._run_screening()
+
+    # Since no important variables found, phase should stay exploration
+    assert engine._phase == "exploration"
+    assert engine._screened_focus_variables is None


### PR DESCRIPTION
## Summary
- Run ScreeningDesigner at exploration→optimization transition (Task 1d)
- Integrate MAP-Elites archive for diversity tracking (Task 1e)
- Screened focus variables complement causal graph-based focus
- Exploitation phase samples from diverse elites 50% of the time
- Rebased on top of merged PRs #1 and #2 with conflict resolution

Supersedes #3.

## Changes
- engine/loop.py: Add screening at phase transition, MAP-Elites archive management, descriptor extraction
- optimizer/suggest.py: Add screened_variables and base_parameters params (merged with PR #2's focus_variables)
- tests/: 16 new integration tests for screening and MAP-Elites

## Test plan
- [x] All 66 tests pass (including PRs #1 and #2 tests)
- [x] Screening integration tests pass (6 tests)
- [x] MAP-Elites integration tests pass (10 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)