### PR TITLE
docs: update MarketingLogAdapter docs for issues #45-47

### DIFF
--- a/thoughts/shared/docs/marketing-log-adapter.md
+++ b/thoughts/shared/docs/marketing-log-adapter.md
@@ -35,7 +35,7 @@ The adapter validates data at construction time. The following checks are applie
 - **Boundary propensity warning** — logs a warning when propensity values include 0.0 or 1.0, since IPS weights will be clipped during evaluation.
 - **Single-arm data warning** — logs a warning when all observations have the same treatment value (all 0 or all 1), because IPS weighting requires both treated and control observations for reliable estimates.
 
-Exactly one of `data` (DataFrame) or `data_path` (file path) must be provided. `data_path` accepts both CSV and `.parquet` files, detected by file extension.
+Exactly one of `data` (DataFrame) or `data_path` (file path) must be provided. `data_path` supports `.parquet` files (detected by the `.parquet` extension) and any other extension is read as CSV via `pd.read_csv()`.
 
 ## Search Variables
 
@@ -115,7 +115,7 @@ min_propensity_clip          --> policy_value
 
 This section documents engine-level behavior that directly affects how the `MarketingLogAdapter` interacts with the optimization loop. It is included here rather than in engine-level docs because users configuring this adapter are the most likely to encounter it.
 
-The off-policy predictor (`OffPolicyPredictor`) gates observational (DoWhy) causal estimation behind `obs_min_history`, which defaults to 20. When `epsilon_mode=True` is enabled on the engine, the predictor will not attempt observational estimates until the experiment log contains at least 20 results. This avoids expensive DoWhy calls on small experiment logs where there is insufficient data for reliable causal estimation. Users who enable `epsilon_mode` and wonder why observational estimates only appear after 20 experiments can adjust this threshold via the `obs_min_history` parameter on `OffPolicyPredictor`.
+The off-policy predictor (`OffPolicyPredictor`) gates observational (DoWhy) causal estimation behind `obs_min_history`, which defaults to 20. The predictor will not attempt observational estimates until the experiment log contains at least 20 results, regardless of whether `epsilon_mode` is enabled. This avoids expensive DoWhy calls on small experiment logs where there is insufficient data for reliable causal estimation. This threshold can be adjusted via the `obs_min_history` parameter on `OffPolicyPredictor`.
 
 ## Fixture Dataset
 


### PR DESCRIPTION
## Summary
- Expanded validation section to list all current checks (empty DataFrame, missing columns, NaN values, binary treatment enforcement, propensity range, boundary propensity warning, single-arm data warning, CSV/Parquet support)
- Added `zero_support`, `propensity_clip_fraction`, `max_ips_weight`, and `weight_cv` to the metrics table
- Replaced outdated limitation #5 with documentation of the zero-support pessimistic fallback behavior
- Added "Runtime Notes" section explaining `obs_min_history` gating for observational estimation

Closes #55

## Test plan
- [x] No Python source files modified — docs-only change
- [x] Lint: `ruff check .` passes
- [x] Format: `ruff format --check .` passes
- [x] Tests: 675 passed, 18 skipped
- [ ] Human review of doc accuracy against implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a documentation-only update to `thoughts/shared/docs/marketing-log-adapter.md` that expands the validation section, adds four new diagnostic metrics to the metrics table, replaces an outdated limitation entry with a detailed zero-support fallback explanation, and introduces a new "Runtime Notes" section about `obs_min_history` gating.

The majority of the changes are accurate against the implementation in `causal_optimizer/domain_adapters/marketing_logs.py` and `causal_optimizer/predictor/off_policy.py`. Two inaccuracies were found:

- **Runtime Notes section incorrectly scopes `obs_min_history` to `epsilon_mode=True`**: The gate inside `_observational_predict()` applies unconditionally — both the heuristic and epsilon prediction paths call `predict()`, which in turn calls `_observational_predict()`. The docs tell users to look at this threshold only when they "enable `epsilon_mode`", which is misleading for users operating in the default heuristic mode.
- **`data_path` format description**: Documenting the accepted formats as "CSV and `.parquet`" understates the actual behavior — any non-`.parquet` extension is silently forwarded to `pd.read_csv()`, which could accept or fail on arbitrary file types without a clear error.

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing the Runtime Notes inaccuracy; no source code is changed.
- No Python source files are modified, so there is no risk of runtime regressions. However, the Runtime Notes section contains a factually incorrect claim that ties `obs_min_history` gating to `epsilon_mode=True` exclusively, which could actively mislead users debugging missing observational estimates in the default (non-epsilon) mode. The `data_path` format description is also subtly inaccurate. These are documentation quality issues that lower the score from the maximum achievable for a docs-only PR.
- thoughts/shared/docs/marketing-log-adapter.md — Runtime Notes section (line 112–113) and data_path description (line 38).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/marketing-log-adapter.md | Documentation-only update adding validation detail, four new metrics, a zero-support fallback explanation, and a new Runtime Notes section. Most additions are accurate against the implementation, but the Runtime Notes section incorrectly ties `obs_min_history` gating to `epsilon_mode=True` when the gate is actually unconditional, and the `data_path` format description implies only CSV/Parquet are accepted when any non-parquet extension is silently passed to `pd.read_csv()`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[MarketingLogAdapter.run_experiment] --> B[Compute uplift scores]
    B --> C[Apply eligibility threshold & budget]
    C --> D[Clip propensities → propensity_clip_fraction]
    D --> E[Compute raw IPS weights]
    E --> F{weight_sum > 0?}
    F -- Yes --> G[Normalize weights\ncompute policy_value\nzero_support = 0.0]
    F -- No --> H[Pessimistic fallback\nzero_support = 1.0\npolicy_value = worst observed outcome\nlogger.warning]
    G --> I[Compute max_ips_weight & weight_cv]
    H --> I
    I --> J[Return metrics dict\npolicy_value, total_cost,\ntreated_fraction, ESS,\npropensity_clip_fraction,\nmax_ips_weight, weight_cv,\nzero_support]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Athoughts%2Fshared%2Fdocs%2Fmarketing-log-adapter.md%3A112-113%0A**%60obs_min_history%60%20gate%20is%20not%20%60epsilon_mode%60-specific**%0A%0AThe%20Runtime%20Notes%20section%20states%20that%20the%20observational%20estimate%20gate%20only%20activates%20%22when%20%60epsilon_mode%3DTrue%60%20is%20enabled%20on%20the%20engine%2C%22%20but%20that%20is%20not%20how%20the%20implementation%20works.%20The%20gate%20lives%20inside%20%60_observational_predict%28%29%60%20%28line%20370%20of%20%60predictor%2Foff_policy.py%60%29%3A%0A%0A%60%60%60python%0Aif%20len%28self._experiment_log.results%29%20%3C%20self.obs_min_history%3A%0A%20%20%20%20return%20None%0A%60%60%60%0A%0A%60_observational_predict%28%29%60%20is%20called%20by%20%60predict%28%29%60%2C%20which%20is%20invoked%20from%20**both**%20%60_should_run_heuristic%28%29%60%20%28non-epsilon%20mode%29%20and%20%60_should_run_epsilon%28%29%60%20%28epsilon%20mode%29.%20The%20%60obs_min_history%60%20threshold%20therefore%20applies%20unconditionally%20regardless%20of%20%60epsilon_mode%60.%0A%0AThe%20next%20sentence%20%28%22Users%20who%20enable%20%60epsilon_mode%60%20and%20wonder%20why%E2%80%A6%22%29%20further%20reinforces%20the%20incorrect%20impression.%20Suggest%20rewriting%20to%3A%0A%0A%3E%20The%20off-policy%20predictor%20%28%60OffPolicyPredictor%60%29%20gates%20observational%20%28DoWhy%29%20causal%20estimation%20behind%20%60obs_min_history%60%2C%20which%20defaults%20to%2020.%20The%20predictor%20will%20not%20attempt%20observational%20estimates%20until%20the%20experiment%20log%20contains%20at%20least%2020%20results%2C%20regardless%20of%20whether%20%60epsilon_mode%60%20is%20enabled.%20This%20avoids%20expensive%20DoWhy%20calls%20on%20small%20experiment%20logs%20where%20there%20is%20insufficient%20data%20for%20reliable%20causal%20estimation.%20This%20threshold%20can%20be%20adjusted%20via%20the%20%60obs_min_history%60%20parameter%20on%20%60OffPolicyPredictor%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Athoughts%2Fshared%2Fdocs%2Fmarketing-log-adapter.md%3A38%0A**Accepted%20file%20formats%20are%20broader%20than%20documented**%0A%0AThe%20docs%20say%20%60data_path%60%20accepts%20%22both%20CSV%20and%20%60.parquet%60%20files.%22%20In%20the%20implementation%20%28%60marketing_logs.py%60%20lines%2071%E2%80%9375%29%2C%20only%20the%20%60.parquet%60%20suffix%20is%20checked%20explicitly%20%E2%80%94%20every%20other%20extension%20falls%20through%20to%20%60pd.read_csv%28%29%60%3A%0A%0A%60%60%60python%0Aif%20Path%28data_path%29.suffix%20%3D%3D%20%22.parquet%22%3A%0A%20%20%20%20data%20%3D%20pd.read_parquet%28data_path%29%0Aelse%3A%0A%20%20%20%20data%20%3D%20pd.read_csv%28data_path%29%0A%60%60%60%0A%0AA%20file%20named%20%60data.tsv%60%2C%20%60data.txt%60%2C%20or%20even%20%60data.json%60%20would%20silently%20be%20passed%20to%20%60pd.read_csv%28%29%60%20%28which%20may%20succeed%20or%20fail%20depending%20on%20the%20content%29.%20Documenting%20this%20as%20%22CSV%20and%20%60.parquet%60%22%20may%20give%20users%20a%20false%20sense%20that%20other%20formats%20are%20rejected%20with%20a%20clear%20error.%20Consider%20clarifying%3A%0A%0A%60%60%60suggestion%0AExactly%20one%20of%20%60data%60%20%28DataFrame%29%20or%20%60data_path%60%20%28file%20path%29%20must%20be%20provided.%20%60data_path%60%20supports%20%60.parquet%60%20files%20%28detected%20by%20the%20%60.parquet%60%20extension%29%20and%20any%20other%20extension%20is%20read%20as%20CSV%20via%20%60pd.read_csv%28%29%60.%0A%60%60%60%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/marketing-log-adapter.md
Line: 112-113

Comment:
**`obs_min_history` gate is not `epsilon_mode`-specific**

The Runtime Notes section states that the observational estimate gate only activates "when `epsilon_mode=True` is enabled on the engine," but that is not how the implementation works. The gate lives inside `_observational_predict()` (line 370 of `predictor/off_policy.py`):

```python
if len(self._experiment_log.results) < self.obs_min_history:
    return None
```

`_observational_predict()` is called by `predict()`, which is invoked from **both** `_should_run_heuristic()` (non-epsilon mode) and `_should_run_epsilon()` (epsilon mode). The `obs_min_history` threshold therefore applies unconditionally regardless of `epsilon_mode`.

The next sentence ("Users who enable `epsilon_mode` and wonder why…") further reinforces the incorrect impression. Suggest rewriting to:

> The off-policy predictor (`OffPolicyPredictor`) gates observational (DoWhy) causal estimation behind `obs_min_history`, which defaults to 20. The predictor will not attempt observational estimates until the experiment log contains at least 20 results, regardless of whether `epsilon_mode` is enabled. This avoids expensive DoWhy calls on small experiment logs where there is insufficient data for reliable causal estimation. This threshold can be adjusted via the `obs_min_history` parameter on `OffPolicyPredictor`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/marketing-log-adapter.md
Line: 38

Comment:
**Accepted file formats are broader than documented**

The docs say `data_path` accepts "both CSV and `.parquet` files." In the implementation (`marketing_logs.py` lines 71–75), only the `.parquet` suffix is checked explicitly — every other extension falls through to `pd.read_csv()`:

```python
if Path(data_path).suffix == ".parquet":
    data = pd.read_parquet(data_path)
else:
    data = pd.read_csv(data_path)
```

A file named `data.tsv`, `data.txt`, or even `data.json` would silently be passed to `pd.read_csv()` (which may succeed or fail depending on the content). Documenting this as "CSV and `.parquet`" may give users a false sense that other formats are rejected with a clear error. Consider clarifying:

```suggestion
Exactly one of `data` (DataFrame) or `data_path` (file path) must be provided. `data_path` supports `.parquet` files (detected by the `.parquet` extension) and any other extension is read as CSV via `pd.read_csv()`.
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update MarketingLogAdapter docs fo..."](https://github.com/datablogin/causal-optimizer/commit/5f96961f426f6192a8cfc17820688ed27dab7a57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26117552)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->