### PR TITLE
feat: causal-aware candidate generation in RF surrogate fallback

### DIFF
--- a/causal_optimizer/optimizer/suggest.py
+++ b/causal_optimizer/optimizer/suggest.py
@@ -512,11 +512,15 @@ def _generate_targeted_candidates(
     eligible_parents = sorted(name for name in parents if name in var_map and name in focus_set)
 
     if not eligible_parents:
-        # No usable parents — fall back to LHS samples.
-        # Import kept inline to match the lazy-import pattern in _suggest_surrogate.
+        # No usable parents — fall back to LHS samples with offset seed so
+        # these candidates are distinct from the first LHS batch generated
+        # by _suggest_surrogate (which uses the raw seed).
         from causal_optimizer.designer.factorial import FactorialDesigner  # noqa: F811
 
-        return FactorialDesigner(search_space).latin_hypercube(n_samples=n_candidates, seed=seed)
+        fallback_seed = (seed + _TARGETED_SEED_OFFSET) if seed is not None else None
+        return FactorialDesigner(search_space).latin_hypercube(
+            n_samples=n_candidates, seed=fallback_seed
+        )
 
     candidates: list[dict[str, Any]] = []
     for _ in range(n_candidates):

--- a/tests/unit/test_causal_differentiation.py
+++ b/tests/unit/test_causal_differentiation.py
@@ -450,3 +450,51 @@ def test_targeted_candidates_respect_focus_var_filter() -> None:
         assert candidate["z"] == best.parameters["z"], (
             "Parent 'z' was perturbed despite being excluded from focus_var_names"
         )
+
+
+def test_no_parent_fallback_produces_unique_candidates() -> None:
+    """No-parent fallback must produce 100 unique candidates in causal mode.
+
+    Regression test: previously the no-parent fallback in _generate_targeted_candidates
+    used the same seed as the first LHS batch in _suggest_surrogate, producing
+    50 duplicate candidates instead of 50 fresh ones.
+    """
+    ss = _make_search_space()
+    # Graph where objective has no parents in the search space
+    graph = CausalGraph(edges=[("objective", "downstream")])
+    log = _make_experiment_log(n=15)
+
+    # Patch _suggest_surrogate internals to capture the raw candidate list
+    # before RF scoring.  We do this by calling the two generation steps directly.
+    from causal_optimizer.designer.factorial import FactorialDesigner
+    from causal_optimizer.optimizer.suggest import (
+        _CAUSAL_LHS_CANDIDATES,
+        _CAUSAL_TARGETED_CANDIDATES,
+        _generate_targeted_candidates,
+    )
+
+    seed = 42
+    best = log.best_result("objective", minimize=True)
+    assert best is not None
+
+    designer = FactorialDesigner(ss)
+    lhs_candidates = designer.latin_hypercube(n_samples=_CAUSAL_LHS_CANDIDATES, seed=seed)
+    targeted_candidates = _generate_targeted_candidates(
+        ss,
+        dict(best.parameters),
+        graph,
+        "objective",
+        focus_var_names=list(ss.variable_names),
+        n_candidates=_CAUSAL_TARGETED_CANDIDATES,
+        seed=seed,
+    )
+
+    all_candidates = lhs_candidates + targeted_candidates
+    assert len(all_candidates) == _CAUSAL_LHS_CANDIDATES + _CAUSAL_TARGETED_CANDIDATES
+
+    # Convert each candidate dict to a hashable tuple for uniqueness check
+    unique = {tuple(sorted(c.items())) for c in all_candidates}
+    assert len(unique) == len(all_candidates), (
+        f"Expected {len(all_candidates)} unique candidates but got {len(unique)}. "
+        "The no-parent fallback is producing duplicate LHS candidates."
+    )


### PR DESCRIPTION
## Summary

- When a causal graph is available, `_suggest_surrogate()` now generates 50 LHS + 50 targeted intervention candidates (perturbing 1-2 direct parents of the objective from the best config) instead of 100 pure LHS candidates
- Adds weighted parent-preference to `_suggest_exploitation()` when a causal graph is provided (70/30 weight split favoring direct parents over non-parents)
- Root cause fix for Sprint 15 benchmark finding: causal and surrogate_only strategies were indistinguishable on star graphs because `focus_variables == all_variables`

## Test plan

- [x] `test_causal_and_surrogate_produce_different_suggestions` — acceptance gate: at least 3/10 suggestion pairs differ between causal and surrogate_only with same seeds
- [x] `test_targeted_candidates_perturb_few_variables` — targeted candidates modify only 1-2 variables from the best-known config
- [x] `test_causal_graph_parents_method` — CausalGraph.parents() correctness
- [x] `test_surrogate_only_unchanged` — regression guard: surrogate_only mode unchanged
- [x] `test_suggest_parameters_passes_causal_graph_to_surrogate` — causal_graph threaded through optimization path
- [x] `test_exploitation_prefers_parents_when_causal_graph_provided` — exploitation biases toward parents
- [x] All 666 existing unit tests pass with no regressions

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the root cause behind causal and `surrogate_only` strategies being indistinguishable on star graphs (Sprint 15 finding): when a `CausalGraph` is provided, `_suggest_surrogate` now replaces half its candidate budget with targeted intervention candidates (perturbations of `best_params` along direct parents of the objective), and `_suggest_exploitation` weights parent variables 7:3 over non-parents during variable selection.\n\nKey changes:\n- **`_suggest_surrogate`**: causal mode generates 50 LHS + 50 targeted candidates via new `_generate_targeted_candidates` helper; surrogate-only mode unchanged (regression-guarded by test).\n- **`_suggest_exploitation`**: builds normalized probability weights from `causal_graph.parents()` when a graph is present; correctly falls back to uniform weights when all eligible vars are parents.\n- **`_generate_targeted_candidates`**: filters eligible parents to the intersection of search space and `focus_var_names` before perturbation, preventing silent revert by the non-focus pinning step downstream.\n- **`_perturb_variable`**: new helper for wide-range (10–30%) perturbations; documented difference from exploitation's fixed 10% scale is intentional.\n- Prior review concerns resolved: `sorted()` eliminates `PYTHONHASHSEED`-sensitive set iteration; `eligible_var_names` replaces `focus_variables or []`; 70/30 docstring updated; `focus_var_names` intersection prevents non-focus parent cloning.\n- Six new unit tests provide an acceptance gate, shape assertions, regression guard, and bias verification.

<h3>Confidence Score: 4/5</h3>

PR is safe to merge; all prior review concerns are addressed and only minor documentation inaccuracies remain.

All five concerns from the previous review round are explicitly resolved. The implementation is well-tested (6 new tests + 666 existing passing). The three remaining P2 comments are documentation-only discrepancies that do not affect runtime correctness or reproducibility.

No files require special attention; minor docstring fixes in `causal_optimizer/optimizer/suggest.py` would be a tidy follow-up.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| causal_optimizer/optimizer/suggest.py | Adds causal-aware candidate generation to `_suggest_surrogate` (50 LHS + 50 targeted), weighted parent preference to `_suggest_exploitation`, and two new helpers; prior review concerns are all addressed — only minor docstring inaccuracies remain. |
| tests/unit/test_causal_differentiation.py | Six new tests covering the acceptance gate, targeted-candidate shape, `CausalGraph.parents()` correctness, regression guard, causal_graph threading, and exploitation parent-preference bias; coverage is thorough and well-structured. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[suggest_parameters\nphase=optimization] --> B[_suggest_optimization]
    A --> C[_suggest_exploitation\ncausal_graph=graph]
    B --> D{Ax available?}
    D -- yes --> E[_suggest_bayesian]
    D -- no ImportError --> F[_suggest_surrogate\ncausal_graph=graph]
    F --> G{causal_graph\n+ best_params?}
    G -- yes --> H[50 LHS candidates\nseed=seed]
    G -- yes --> I[_generate_targeted_candidates\nn=50, seed=seed+7919]
    I --> J{eligible parents\nin focus+space?}
    J -- yes --> K[perturb 1-3 parents\nper candidate]
    J -- no --> L[fallback: LHS n=50]
    H & K & L --> M[pin non-focus vars\nto best_params]
    G -- no --> N[100 LHS candidates\noriginal behavior]
    N --> M
    M --> O[RF predict best candidate]
    C --> P{causal_graph\nnot None?}
    P -- yes --> Q[weight parents 0.7\nnon-parents 0.3]
    Q --> R[rng.choice with p=weights]
    P -- no --> S[uniform rng.choice]
    R & S --> T[perturb chosen vars\n10% scale]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Acausal_optimizer%2Foptimizer%2Fsuggest.py%3A488-492%0A**Docstring%20says%20%221%20or%202%22%20but%20up%20to%203%20parents%20can%20be%20chosen**%0A%0AThe%20docstring%20states%20%22randomly%20selects%201%20or%202%20direct%20parents%22%2C%20matching%20the%20PR%20description%20%28%22perturbing%201-2%20direct%20parents%22%29.%20However%2C%20when%20%60len%28eligible_parents%29%20%3E%3D%203%60%2C%20the%20expression%20%60rng.integers%281%2C%20min%283%2C%20len%28eligible_parents%29%29%20%2B%201%29%60%20evaluates%20to%20%60rng.integers%281%2C%204%29%60%2C%20which%20yields%20values%20in%20%60%7B1%2C%202%2C%203%7D%60.%20Three%20parents%20can%20be%20perturbed%20in%20a%20single%20candidate%2C%20making%20the%20candidate%20less%20%22targeted%22%20than%20documented.%0A%0AConsider%20either%20capping%20at%202%20explicitly%20or%20updating%20the%20docstring%20to%20reflect%20the%20actual%20range%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20Each%20candidate%20starts%20from%20*best_params*%2C%20randomly%20selects%201%20or%202%20%28up%20to%203%29%0A%20%20%20%20direct%20parents%20of%20the%20objective%2C%20and%20perturbs%20only%20those%20variables.%20%20Uses%20a%20wider%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Acausal_optimizer%2Foptimizer%2Fsuggest.py%3A500%0A**Confusing%20ternary%20expression%20%E2%80%94%20works%20correctly%20but%20is%20hard%20to%20parse**%0A%0A%60seed%20if%20seed%20is%20None%20else%20seed%20%2B%207919%60%20is%20functionally%20equivalent%20to%20%60None%20if%20seed%20is%20None%20else%20seed%20%2B%207919%60%20%28when%20%60seed%20is%20None%60%20is%20True%2C%20the%20expression%20returns%20%60seed%60%20which%20is%20already%20%60None%60%29.%20The%20standard%20form%20is%20clearer%20and%20avoids%20the%20reader%20having%20to%20work%20out%20why%20%60seed%20if%20seed%20is%20None%60%20makes%20sense%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20rng%20%3D%20np.random.default_rng%28None%20if%20seed%20is%20None%20else%20seed%20%2B%207919%29%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Acausal_optimizer%2Foptimizer%2Fsuggest.py%3A555%0A**Docstring%20says%20%22%2B%2F-1-2%22%20but%20perturbation%20by%200%20is%20possible**%0A%0A%60rng.integers%28-2%2C%203%29%60%20produces%20values%20in%20%60%7B-2%2C%20-1%2C%200%2C%201%2C%202%7D%60%20%28upper%20bound%20exclusive%29%2C%20so%20a%20delta%20of%200%20is%20possible%20%E2%80%94%20the%20candidate's%20integer%20variable%20would%20be%20unchanged.%20The%20docstring%20summary%20at%20line%20538%20%28%22Integer%3A%20%2B%2F-1-2%22%29%20implies%20the%20value%20always%20changes%20by%20at%20least%201.%20This%20is%20consistent%20with%20the%20existing%20exploitation%20code%20so%20is%20probably%20intentional%2C%20but%20the%20docstring%20should%20reflect%20the%20full%20range.%0A%0AUpdate%20the%20docstring%20from%20%60Integer%3A%20%2B%2F-1-2%60%20to%20%60Integer%3A%20delta%20in%20%7B-2%2C-1%2C0%2C1%2C2%7D%60%20%28no-op%20possible%29.%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: causal_optimizer/optimizer/suggest.py
Line: 488-492

Comment:
**Docstring says "1 or 2" but up to 3 parents can be chosen**

The docstring states "randomly selects 1 or 2 direct parents", matching the PR description ("perturbing 1-2 direct parents"). However, when `len(eligible_parents) >= 3`, the expression `rng.integers(1, min(3, len(eligible_parents)) + 1)` evaluates to `rng.integers(1, 4)`, which yields values in `{1, 2, 3}`. Three parents can be perturbed in a single candidate, making the candidate less "targeted" than documented.

Consider either capping at 2 explicitly or updating the docstring to reflect the actual range:

```suggestion
    Each candidate starts from *best_params*, randomly selects 1 or 2 (up to 3)
    direct parents of the objective, and perturbs only those variables.  Uses a wider
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: causal_optimizer/optimizer/suggest.py
Line: 500

Comment:
**Confusing ternary expression — works correctly but is hard to parse**

`seed if seed is None else seed + 7919` is functionally equivalent to `None if seed is None else seed + 7919` (when `seed is None` is True, the expression returns `seed` which is already `None`). The standard form is clearer and avoids the reader having to work out why `seed if seed is None` makes sense:

```suggestion
    rng = np.random.default_rng(None if seed is None else seed + 7919)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: causal_optimizer/optimizer/suggest.py
Line: 555

Comment:
**Docstring says "+/-1-2" but perturbation by 0 is possible**

`rng.integers(-2, 3)` produces values in `{-2, -1, 0, 1, 2}` (upper bound exclusive), so a delta of 0 is possible — the candidate's integer variable would be unchanged. The docstring summary at line 538 ("Integer: +/-1-2") implies the value always changes by at least 1. This is consistent with the existing exploitation code so is probably intentional, but the docstring should reflect the full range.

Update the docstring from `Integer: +/-1-2` to `Integer: delta in {-2,-1,0,1,2}` (no-op possible).

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["address greptile review feedback (greplo..."](https://github.com/datablogin/causal-optimizer/commit/afa7e499553a11ddb18a3b0772097703d63bde79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26472471)</sub>

<!-- /greptile_comment -->