### PR TITLE
docs: ERCOT COAST + Houston IAH benchmark report

### DIFF
--- a/thoughts/shared/docs/ercot-coast-houston-2022-2024-benchmark-report.md
+++ b/thoughts/shared/docs/ercot-coast-houston-2022-2024-benchmark-report.md
@@ -7,7 +7,7 @@
 | Report ID | `20260326-ercot_coast_houston_2022_2024` |
 | Benchmark | `predictive_energy` |
 | Date | `2026-03-26` |
-| Commit | `e6112d30c6f5a62944a8e35593cc7da24ea49643` on branch `main` |
+| Commit | `a6db2b3` on branch `sprint-16/ercot-coast-benchmark` |
 | Dataset ID | `ercot_coast_houston_2022_2024` |
 | Dataset | `/Users/robertwelborn/Projects/_local/causal-optimizer/data/ercot_coast_houston_2022_2024.parquet` |
 | Dataset Rows | `26,297` |
@@ -239,4 +239,4 @@ uv run python scripts/energy_predictive_benchmark.py \
   --output /Users/robertwelborn/Projects/_local/causal-optimizer/artifacts/ercot_coast_houston_2022_2024_results.json
 ```
 
-Commit: `e6112d30c6f5a62944a8e35593cc7da24ea49643`
+Commit: `a6db2b3` on branch `sprint-16/ercot-coast-benchmark`


### PR DESCRIPTION
## Summary

- Adds second real benchmark dataset using ERCOT COAST weather zone + NOAA Houston IAH (USW00012960) hourly weather, 2022-2024
- Runs the same predictive-energy harness (no code changes) with budgets 20/40/80 x seeds 0-4 x 3 strategies
- Results replicate NORTH_C findings: causal == surrogate_only, random marginally better, all ridge, budget barely matters
- Confirms these are systemic optimizer properties, not dataset-specific artifacts

## Key Results

| Strategy | Budget 80 Test MAE |
|----------|-------------------|
| random | 105.38 +/- 0.24 |
| surrogate_only | 105.52 +/- 0.30 |
| causal | 105.52 +/- 0.30 |

## Dataset QA

- 26,297 rows, all 6 QA gates passed
- NOAA station: USW00012960 (George Bush Intercontinental Airport, Houston)
- Full DST handling (fall-back, spring-forward, 24:00 convention)
- Timestamps unique, monotonic, saved in UTC

## Test plan

- [x] All 739 fast tests pass
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] Smoke benchmark completed (3 rows)
- [x] Full benchmark completed (45 rows)
- [x] Summary CSV generated
- [x] Report follows shared template

Closes #69

Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a second real benchmark report (`ercot-coast-houston-2022-2024-benchmark-report.md`) for the ERCOT COAST weather zone paired with NOAA Houston IAH station data, running the same `predictive_energy` harness (no code changes) and confirming that the `causal == surrogate_only` and `random > engine-based` patterns seen in NORTH_C also appear on the COAST dataset.

**What changed:**
- New 242-line benchmark report following the shared template
- Dataset: 26,297 hourly rows (2022-2024), 60/20/20 split, full DST/24:00 handling documented
- SHA256 provenance hash now populated (`1f07da6...`) — carry-over from prior NORTH_C gap resolved
- DST count corrected to "All 6 DST transitions across the 3-year dataset" — prior review concern addressed
- 45 strategy × budget × seed runs documented; all strategies converge to ridge, budget barely matters

**Issue found:**
- Observation 1 states COAST was run "With Ax/BoTorch available", whereas the NORTH_C report explicitly states "without Ax/BoTorch installed (RF surrogate fallback is active)". Engine-based strategy runtimes confirm this: COAST surrogate_only/causal run ~2-5× slower (141s vs 67s at B20), consistent with Ax/BoTorch overhead. The two benchmarks were therefore run under asymmetric optimizer configurations, which confounds the cross-benchmark conclusion that `causal == surrogate_only` is a "systemic property of the optimizer." The cross-benchmark comparison section should note this difference explicitly.

<h3>Confidence Score: 4/5</h3>

Safe to merge as a documentation report; one P1 narrative issue about asymmetric Ax/BoTorch configuration should be addressed before this report is cited as evidence for cross-benchmark conclusions.

Both previous review concerns (DST count and missing SHA256) are fully resolved. The report itself is thorough and internally consistent. The one remaining issue — Observation 1 revealing that COAST used Ax/BoTorch while NORTH_C did not — is a real interpretive gap but does not invalidate the raw data. The fix is a documentation clarification, not a re-run. Score reflects one targeted fix remaining before the cross-benchmark narrative is fully sound.

thoughts/shared/docs/ercot-coast-houston-2022-2024-benchmark-report.md — Observation 1 and the Cross-Benchmark Comparison section need a note about the Ax/BoTorch configuration difference vs NORTH_C

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/ercot-coast-houston-2022-2024-benchmark-report.md | New COAST benchmark report replicating NORTH_C structure; SHA256 and DST count issues from prior review are resolved, but Observation 1 reveals that Ax/BoTorch was active for COAST and not for NORTH_C (confirmed by 2-5× higher engine runtimes), making the cross-benchmark causal == surrogate_only comparison confounded |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ERCOT COAST Load Data\nHour-Ending CSV] --> B[Timestamp Normalisation\nHour-Ending to Interval-Start\nUS/Central to UTC\nDST / 24:00 handling]
    C[NOAA ISD Station\nUSW00012960 Houston IAH] --> D[Sub-hourly to Hourly\nTMP parse, Magnus humidity]
    B --> E[Inner Join on UTC Hour\n7 rows dropped]
    D --> E
    E --> F[Calendar Features\nhour_of_day, day_of_week, is_holiday\nderived in US/Central, stored in UTC]
    F --> G[Parquet Dataset\n26297 rows, SHA256 recorded]
    G --> H[60/20/20 Split\nTrain 15778 / Val 5259 / Test 5260]
    H --> I{Strategy}
    I --> J[random]
    I --> K[surrogate_only\nAx/BoTorch active]
    I --> L[causal\nAx/BoTorch active]
    J --> M[45 Runs\n3 Budgets x 5 Seeds x 3 Strategies]
    K --> M
    L --> M
    M --> N[All converge to Ridge\nrandom marginally better\ncausal == surrogate_only]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Athoughts%2Fshared%2Fdocs%2Fercot-coast-houston-2022-2024-benchmark-report.md%3A184-186%0A**Ax%2FBoTorch%20availability%20differs%20between%20COAST%20and%20NORTH_C%20%E2%80%94%20cross-benchmark%20comparison%20is%20confounded**%0A%0AObservation%201%20here%20states%20%22With%20Ax%2FBoTorch%20available%2C%20both%20strategies%20use%20Bayesian%20optimization%20but%20the%20causal%20graph%20prior%20does%20not%20alter%20the%20acquisition%20function%20enough%20to%20produce%20different%20suggestions.%22%20The%20NORTH_C%20report%20%28Observation%201%29%20says%20the%20opposite%3A%20%22without%20Ax%2FBoTorch%20installed%20%28RF%20surrogate%20fallback%20is%20active%29%2C%20the%20causal%20focus%20variables%20do%20not%20meaningfully%20alter%20the%20optimization%20path.%22%0A%0AThe%20runtime%20tables%20confirm%20this%20is%20a%20real%20environmental%20difference%2C%20not%20a%20phrasing%20inconsistency%3A%0A%0A%7C%20Strategy%20%7C%20NORTH_C%20B20%20%7C%20COAST%20B20%20%7C%0A%7C----------%7C-------------%7C-----------%7C%0A%7C%20surrogate_only%20%7C%2067.2%20s%20%7C%20141.7%20s%20%7C%0A%7C%20causal%20%7C%2066.9%20s%20%7C%20131.7%20s%20%7C%0A%0AEngine-based%20strategies%20are%20~2%C3%97%20slower%20on%20COAST%20at%20B20%20and%205%C3%97%20slower%20at%20B40%2FB80%2C%20consistent%20with%20Ax%2FBoTorch%20being%20active%20in%20one%20run%20but%20not%20the%20other.%0A%0AThis%20matters%20for%20the%20cross-benchmark%20conclusions.%20The%20report%20states%20the%20identical%20%60causal%20%3D%3D%20surrogate_only%60%20outcome%20%22confirms%20these%20are%20systemic%20properties%20of%20the%20optimizer%2C%22%20but%20the%20root%20causes%20are%20actually%20different%3A%0A-%20NORTH_C%3A%20RF%20surrogate%20fallback%20ignores%20causal%20focus%20variables%20entirely%0A-%20COAST%3A%20Ax%2FBoTorch%20is%20active%20but%20the%20causal%20prior%20does%20not%20shift%20the%20acquisition%20function%0A%0AThe%20Cross-Benchmark%20Comparison%20table%20and%20the%20Interpretation%20sections%20should%20explicitly%20note%20this%20configuration%20difference.%20The%20NORTH_C%20Action%20Item%201%20was%20%22Install%20Ax%2FBoTorch%20and%20re-run%22%20%E2%80%94%20it%20appears%20COAST%20was%20run%20after%20that%20install%20but%20NORTH_C%20was%20not%20re-run%2C%20making%20the%20comparison%20asymmetric.%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/ercot-coast-houston-2022-2024-benchmark-report.md
Line: 184-186

Comment:
**Ax/BoTorch availability differs between COAST and NORTH_C — cross-benchmark comparison is confounded**

Observation 1 here states "With Ax/BoTorch available, both strategies use Bayesian optimization but the causal graph prior does not alter the acquisition function enough to produce different suggestions." The NORTH_C report (Observation 1) says the opposite: "without Ax/BoTorch installed (RF surrogate fallback is active), the causal focus variables do not meaningfully alter the optimization path."

The runtime tables confirm this is a real environmental difference, not a phrasing inconsistency:

| Strategy | NORTH_C B20 | COAST B20 |
|----------|-------------|-----------|
| surrogate_only | 67.2 s | 141.7 s |
| causal | 66.9 s | 131.7 s |

Engine-based strategies are ~2× slower on COAST at B20 and 5× slower at B40/B80, consistent with Ax/BoTorch being active in one run but not the other.

This matters for the cross-benchmark conclusions. The report states the identical `causal == surrogate_only` outcome "confirms these are systemic properties of the optimizer," but the root causes are actually different:
- NORTH_C: RF surrogate fallback ignores causal focus variables entirely
- COAST: Ax/BoTorch is active but the causal prior does not shift the acquisition function

The Cross-Benchmark Comparison table and the Interpretation sections should explicitly note this configuration difference. The NORTH_C Action Item 1 was "Install Ax/BoTorch and re-run" — it appears COAST was run after that install but NORTH_C was not re-run, making the comparison asymmetric.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: update commit hash in benchmark re..."](https://github.com/datablogin/causal-optimizer/commit/3ed00eb76990a7c2b2c4331d7a7f3a3ff26058d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26492502)</sub>

<!-- /greptile_comment -->