### PR TITLE
Sprint 17 combined benchmark report with skip diagnostics and counterfactual results

### DIFF
--- a/thoughts/shared/docs/sprint-17-combined-report.md
+++ b/thoughts/shared/docs/sprint-17-combined-report.md
@@ -50,15 +50,19 @@
 ### Key Observations vs Sprint 16
 
 Sprint 16 showed `differentiated: PASS` because causal beat surrogate_only on ercot_north_c.
-Sprint 17 shows `differentiated: FAIL` -- causal and surrogate_only are identical at budget=20
-and budget=40 on both datasets. At budget=80, small differences emerge but the suite
-considers them identical because at smaller budgets the strategies produce byte-identical
-results (both converge to the same initial exploration then follow the same fallback path).
+Sprint 17 shows `differentiated: FAIL`. The suite evaluates differentiation at the
+**largest budget only** (budget=80) using `build_benchmark_summary()`, which selects the
+largest-budget `StrategyStats` per dataset. The `check_acceptance()` rule then requires
+causal and surrogate_only test MAE means to differ by more than 0.1%.
 
-The causal fallback differentiation from PR #70 (Sprint 16) is only active once the engine
-reaches the optimization phase (budget > 10 experiments), and the effect is small enough
-that at budget=20 and budget=40 the engine does not yet diverge. Only at budget=80 does
-the longer optimization run produce measurably different results.
+At budget=80, the actual differences are:
+
+- ercot_north_c: causal 132.83 vs surrogate_only 132.95 → 0.09% (below 0.1% threshold)
+- ercot_coast: causal 105.65 vs surrogate_only 105.58 → 0.07% (below 0.1% threshold)
+
+Both datasets fall just under the 0.1% differentiation threshold, so the suite correctly
+reports `differentiated: FAIL`. The strategies do produce numerically different results at
+budget=80, but the gap is too small to clear the acceptance bar.
 
 ### Full Results (All Budgets)
 


### PR DESCRIPTION
## Summary
- Re-ran full benchmark suite (ercot_north_c + ercot_coast) with `--audit-skip-rate 0.1` for skip calibration
- Ran new counterfactual demand-response benchmark across all strategies/budgets/seeds
- Combined report with findings, skip calibration analysis, and promotion assessment

Closes #78

## Key Findings

**Real benchmarks:** Random still wins on both datasets. Causal and surrogate_only are byte-identical at budget 20/40, only diverge at budget 80. Overall verdict: CONDITIONAL.

**Skip calibration:** Off-policy predictor skips 0–37% of candidates (seed-dependent). **33% false-skip rate** — too high for production. Skipping does not improve outcomes.

**Counterfactual benchmark:** Degenerate — treatment cost (50.0) exceeds all treatment benefits, so oracle is "never treat" and all strategies achieve zero regret. Needs re-parameterization.

**Promotion assessment: INVESTIGATE** — no regressions, but causal guidance doesn't improve any benchmark yet. Skip calibration infrastructure works but needs better calibration. Counterfactual benchmark needs non-trivial ground truth.

## Test plan
- [x] All 797 fast tests pass on main with both PRs merged
- [x] Suite ran successfully across 90 runs (2 datasets × 3 strategies × 3 budgets × 5 seeds)
- [x] Counterfactual benchmark ran successfully across 45 runs
- [x] Report accurately reflects artifact data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single new documentation file — `thoughts/shared/docs/sprint-17-combined-report.md` — that consolidates the Sprint 17 benchmark run results, skip-calibration analysis, and counterfactual demand-response benchmark findings into a unified report for the `causal-optimizer` project.

**Key points documented:**
- Full benchmark suite (`ercot_north_c` + `ercot_coast`) re-ran with `--audit-skip-rate 0.1`; overall verdict remains **CONDITIONAL** (random still wins, causal/surrogate_only are byte-identical at budgets ≤ 40)
- Skip calibration shows a **33% false-skip rate** (8/24 audited skips were incorrect), which the report correctly identifies as unacceptable for production
- Counterfactual benchmark is **degenerate** — treatment cost exceeds every treatment benefit so the oracle is trivially "never treat"; strategies converge to zero regret and the benchmark cannot differentiate them
- Promotion verdict set to **INVESTIGATE** with a clear four-priority action plan for Sprint 18
- One numeric inconsistency: the narrative claims a "100×" causal-vs-surrogate_only slowdown but the supporting figures (~32 s vs ~5 000 s) yield **~156×**
- Artifact paths are hard-coded to a local developer filesystem (`/Users/robertwelborn/...`) and will be inaccessible to other collaborators

<h3>Confidence Score: 5/5</h3>

Documentation-only PR with no code changes; safe to merge after minor fixes.

All findings are P2 (numeric wording inconsistency, non-portable local paths). Neither issue affects system behavior, data integrity, or correctness. The arithmetic in the audit tables is verified correct (8/24 = 33%). No code is touched.

thoughts/shared/docs/sprint-17-combined-report.md — minor wording and path issues only

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-17-combined-report.md | New sprint-17 combined benchmark report; contains one numeric inconsistency (100x vs actual ~156x runtime ratio) and hardcoded local artifact paths. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sprint 17 Benchmark Suite\n90 runs: 2 datasets × 3 strategies\n× 3 budgets × 5 seeds] --> B[Real Benchmark\nercot_north_c + ercot_coast]
    A --> C[Skip Calibration Analysis\naudit_skip_rate=0.1]
    A --> D[Counterfactual Benchmark\n45 runs: 3 strategies × 3 budgets × 5 seeds]

    B --> E{Verdict}
    E -->|random wins both datasets| F[CONDITIONAL]
    E -->|causal = surrogate_only\nat budget 20/40| F

    C --> G{False-Skip Rate}
    G -->|33% of audited\nskips incorrect| H[NOT PRODUCTION READY]

    D --> I{Oracle Policy}
    I -->|treatment_cost=50 exceeds\nall treatment benefits| J[DEGENERATE\nregret=0 everywhere]

    F --> K[Promotion Assessment:\nINVESTIGATE]
    H --> K
    J --> K

    K --> L[Sprint 18 Priorities]
    L --> L1[1. Fix counterfactual\nbenchmark parameterization]
    L --> L2[2. Improve skip\ncalibration]
    L --> L3[3. Causal differentiation\nat low budgets]
    L --> L4[4. Profile causal\nperformance ~156x slowdown]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Athoughts%2Fshared%2Fdocs%2Fsprint-17-combined-report.md%3A213-214%0A**Runtime%20multiplier%20inconsistency**%0A%0AThe%20narrative%20says%20%22100x%20slowdown%20for%20causal%20vs%20surrogate_only%22%20but%20the%20given%20timing%20figures%20%E2%80%94%20%60~32s%60%20for%20%60surrogate_only%60%20and%20%60~5000s%60%20for%20%60causal%60%20%E2%80%94%20yield%20a%20ratio%20of%20**~156%C3%97**%2C%20not%20100%C3%97.%20The%20text%20understates%20the%20severity%20of%20the%20performance%20gap.%0A%0A%60%60%60suggestion%0AThe%20156x%20slowdown%20for%20causal%20vs%20surrogate_only%20is%20caused%20by%20the%20screening%20designer%0Agenerating%20enormous%20numbers%20of%20formula%20permutations%20during%20the%20optimization%20phase.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Athoughts%2Fshared%2Fdocs%2Fsprint-17-combined-report.md%3A250-255%0A**Local%20machine%20paths%20in%20shared%20document**%0A%0AThe%20artifact%20paths%20are%20hard-coded%20to%20an%20individual%20developer's%20local%20filesystem%20%28%60%2FUsers%2Frobertwelborn%2FProjects%2F_local%2F...%60%29.%20These%20paths%20are%20inaccessible%20to%20any%20collaborator%20or%20CI%20runner%20and%20will%20silently%20break%20any%20automated%20process%20that%20tries%20to%20consume%20them.%20Consider%20replacing%20with%20repository-relative%20paths%2C%20S3%2FGCS%20URIs%2C%20or%20a%20clearly-marked%20placeholder%20so%20the%20intent%20is%20preserved%20without%20encoding%20a%20machine-specific%20location.%0A%0A%60%60%60suggestion%0A-%20Suite%20summary%3A%20%60artifacts%2Fsuite_sprint17%2Fsuite_summary.json%60%0A-%20Suite%20report%3A%20%60artifacts%2Fsuite_sprint17%2Fsuite_report.md%60%0A-%20ercot_north_c%20results%3A%20%60artifacts%2Fsuite_sprint17%2Fercot_north_c_results.json%60%0A-%20ercot_coast%20results%3A%20%60artifacts%2Fsuite_sprint17%2Fercot_coast_results.json%60%0A-%20Counterfactual%20results%3A%20%60artifacts%2Fcounterfactual_sprint17_results.json%60%0A%60%60%60%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Claude-black?logo=claude&logoColor=%23D97706"><img alt="Fix All in Claude Code" src="https://img.shields.io/badge/Fix_All_in_Claude-white?logo=claude&logoColor=%23D97706"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-17-combined-report.md
Line: 213-214

Comment:
**Runtime multiplier inconsistency**

The narrative says "100x slowdown for causal vs surrogate_only" but the given timing figures — `~32s` for `surrogate_only` and `~5000s` for `causal` — yield a ratio of **~156×**, not 100×. The text understates the severity of the performance gap.

```suggestion
The 156x slowdown for causal vs surrogate_only is caused by the screening designer
generating enormous numbers of formula permutations during the optimization phase.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-17-combined-report.md
Line: 250-255

Comment:
**Local machine paths in shared document**

The artifact paths are hard-coded to an individual developer's local filesystem (`/Users/robertwelborn/Projects/_local/...`). These paths are inaccessible to any collaborator or CI runner and will silently break any automated process that tries to consume them. Consider replacing with repository-relative paths, S3/GCS URIs, or a clearly-marked placeholder so the intent is preserved without encoding a machine-specific location.

```suggestion
- Suite summary: `artifacts/suite_sprint17/suite_summary.json`
- Suite report: `artifacts/suite_sprint17/suite_report.md`
- ercot_north_c results: `artifacts/suite_sprint17/ercot_north_c_results.json`
- ercot_coast results: `artifacts/suite_sprint17/ercot_coast_results.json`
- Counterfactual results: `artifacts/counterfactual_sprint17_results.json`
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: add Sprint 17 combined benchmark r..."](https://github.com/datablogin/causal-optimizer/commit/887f14fbc5daefd2b8a5589c7163385d69ace75d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26651169)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->