### PR TITLE
docs: Sprint 19 differentiation scorecard

### DIFF
--- a/thoughts/shared/docs/sprint-19-differentiation-scorecard.md
+++ b/thoughts/shared/docs/sprint-19-differentiation-scorecard.md
@@ -189,13 +189,12 @@ performance. The soft causal influence approach is directionally correct:
 earlier influence and softer weighting outperform the Sprint 18 approach
 of hard focus-variable restriction.
 
-**Limitation: `causal_softness` is not effective on the Ax/BoTorch path.**
-The soft ranking bonus only applies when the RF surrogate fallback is used.
-When Ax/BoTorch is available (the production path), the re-ranking uses
-pure causal alignment without a continuous softness trade-off. This means
-the documented `causal_softness` parameter does not have the expected
-effect on the primary optimization path. This should be addressed in
-Sprint 20.
+**Limitation: Ax/BoTorch path re-ranking is alignment-only.**
+`causal_softness` is now threaded into the Ax path (fixed during Sprint
+19 review), but the Ax re-ranking selects among Ax-suggested candidates
+using causal alignment alone — it does not blend GP-predicted objective
+values with alignment into a balanced score.  Sprint 20 should implement
+a weighted composite score on the Ax path for a true soft trade-off.
 
 ## 4. Skip Calibration
 
@@ -354,8 +353,8 @@ Specifically:
    and should be investigated.
 2. The confounded variant shows that bidirected edges alone do not help --
    actual deconfounding at the search level is needed.
-3. `causal_softness` does not affect the primary Ax/BoTorch path -- the
-   soft trade-off only works on the RF surrogate fallback.
+3. The Ax/BoTorch path now uses `causal_softness` for re-ranking, but
+   the re-ranking is alignment-only (no GP-predicted objective blend).
 
 ## 8. Sprint 20 Recommendation
 
@@ -387,12 +386,13 @@ If deconfounding at the search level is infeasible in one sprint, lower
 the confounded variant's priority and focus on hardening the high-noise
 advantage.
 
-### Direction C: Port soft ranking to the Ax/BoTorch path
+### Direction C: Balanced Ax re-ranking score
 
-The `causal_softness` parameter is currently inert on the primary Ax
-path. Sprint 20 should implement re-ranking of Ax candidates by a
-balanced score of predicted objective and causal alignment, so the
-documented parameter actually works on the production code path.
+`causal_softness` is now wired into the Ax path (Sprint 19 review fix),
+but the re-ranking selects among Ax candidates using causal alignment
+alone. Sprint 20 should implement a composite score that blends
+GP-predicted objective value with causal alignment, weighted by
+`causal_softness`, for a true soft trade-off on the production path.
 
 ### What not to do in Sprint 20
 


### PR DESCRIPTION
## Summary

Combined Sprint 19 report covering all three deliverables:

- **Harder Counterfactual Variants** (PR #98): high-noise (15D search space) and confounded (Simpson's paradox) variants with deconfounded evaluation
- **Softer Causal Influence** (PR #99): causal-weighted exploration, soft ranking bonus, adaptive targeted/LHS splitting, threaded into Ax path
- **Skip Calibration** (PR #101): SkipAuditEntry/SkipMetrics audit infrastructure, defensive parameter snapshots, measurement report

**Verdict: PROGRESS** — Causal beats surrogate_only on the base counterfactual benchmark at B40 and B80, and on the high-noise variant at B40/B80. Null control stays clean. Skip audit infrastructure in place. Confounded variant still needs work (bidirected edges alone insufficient for deconfounding).

**Sprint 20 Recommendation**: Continue optimizer-core work targeting the confounded variant (observational adjustment or IPW re-weighting) and run the full benchmark suite with the new variants.

Closes #102

## Test plan

- [x] All 894 fast tests pass
- [x] Report covers all three deliverables with evidence
- [x] Answers four key questions from sprint spec
- [x] Does not overclaim — notes confounded variant failure and surrogate_only regression
- [x] Makes specific Sprint 20 recommendation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `thoughts/shared/docs/sprint-19-differentiation-scorecard.md`, a 429-line combined sprint report covering three deliverables (harder counterfactual variants, softer causal influence, skip calibration). The document is well-structured, addresses all four sprint questions, and correctly distinguishes progress from caveats. Previously flagged issues (PR-description verdict mismatch, skip-calibration test count, identical null-control values explanation) have all been resolved in the companion commit `fbcef3c`.

Two minor documentation inconsistencies remain:

- **High-noise B20 finding understated** (§2a): The narrative says causal beats surrogate_only \"at B40 and B80,\" but the table shows causal also has the lower point-estimate regret at B20 (23.32 vs 23.99). The omission is plausible on statistical grounds (the gap is within overlapping stds), but the reasoning is never stated, leaving the text and table inconsistent for readers.
- **Unexplained zero std for `surrogate_only` at B80 on the confounded variant** (§2b table): `20.65 | 0.00` means all five seeds converged to the same value. The document explains similar behaviour in the null control (permuted targets → deterministic ridge), but does not give the same treatment here. Because this entry is used as a reference point for the causal underperformance claim, it warrants an explanatory note or a verification check.

<h3>Confidence Score: 4/5</h3>

Safe to merge; all prior blocking issues resolved, two minor documentation clarifications remain but do not affect correctness of the sprint verdict.

All three previously-flagged P1 issues (verdict mismatch, test count inconsistency, unexplained identical null-control values) were resolved in fbcef3c. The two remaining findings are P2 documentation clarifications — a narrative omission about B20 and an unexplained zero standard deviation in one table cell. Neither invalidates the PROGRESS verdict, but one (the zero-std entry) is load-bearing in the confounded-variant comparison and merits at least a note before merge.

thoughts/shared/docs/sprint-19-differentiation-scorecard.md — §2a finding text (B20 narrative) and §2b table (surrogate_only B80 std=0.00)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-19-differentiation-scorecard.md | New sprint scorecard documenting three deliverables; two minor documentation inconsistencies — the high-noise B20 narrative omits a causal win visible in the table, and a zero std for surrogate_only on the confounded variant at B80 is unexplained. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sprint 19 Scorecard] --> B[§2 Harder Variants]
    A --> C[§3 Softer Causal Influence]
    A --> D[§4 Skip Calibration]
    A --> E[§5 Null Control]

    B --> B1[High-Noise variant\n15D space, 3 causal parents\nCausal wins B40/B80 ✅]
    B --> B2[Confounded variant\nSimpson's paradox\nRandom wins – negative result ❌]

    C --> C1[S18 → S19 base benchmark\nCausal: 17.66 → 8.19 at B40\n-54% regret ✅]
    C --> C2[Surrogate_only regressed\nB20: 12.07 → 22.15\nAx/BoTorch stochasticity? ⚠️]

    D --> D1[SkipAuditEntry / SkipMetrics\ninfrastructure added]
    D --> D2[Real data: 0% false-skip\nSynthetic: 7% false-skip ✅]

    E --> E1[0.15% max strategy diff\nBelow 2% threshold ✅]

    B1 --> F[§7 Verdict: PROGRESS]
    C1 --> F
    D2 --> F
    E1 --> F
    F --> G[§8 Sprint 20 Recommendations\nA: Investigate surrogate_only regression\nB: Address confounding IPW/residualisation\nC: Balanced Ax re-ranking score]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Athoughts%2Fshared%2Fdocs%2Fsprint-19-differentiation-scorecard.md%3A60-62%0A**High-noise%20B20%20result%20understated**%0A%0AThe%20table%20at%20lines%2050%E2%80%9352%20shows%20causal%20regret%20of%2023.32%20vs%20surrogate_only%2023.99%20at%20B20%20%E2%80%94%20causal%20has%20the%20lower%20point%20estimate%20here%20too.%20Yet%20the%20narrative%20on%20lines%2060%E2%80%9362%20says%20**%22Causal%20beats%20surrogate_only%20at%20B40%20and%20B80%2C%22**%20silently%20omitting%20B20.%20A%20reader%20comparing%20text%20to%20table%20will%20notice%20the%20inconsistency.%0A%0AThe%20omission%20is%20arguably%20defensible%20because%20the%20margin%20at%20B20%20%280.67%29%20falls%20well%20within%20the%20overlapping%20standard%20deviations%20%285.20%20and%204.07%29%2C%20making%20it%20statistically%20indistinguishable%20from%20a%20tie.%20If%20that%20is%20the%20reasoning%2C%20the%20text%20should%20make%20it%20explicit%20%E2%80%94%20e.g.%3A%0A%0A%60%60%60suggestion%0A**Finding%3A%20Causal%20beats%20surrogate_only%20at%20B40%20and%20B80%3B%20the%20B20%20gap%20%2823.32%0Avs%2023.99%29%20is%20within%20noise%20given%20the%20overlapping%20standard%20deviations.**%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Athoughts%2Fshared%2Fdocs%2Fsprint-19-differentiation-scorecard.md%3A88-89%0A**Zero%20standard%20deviation%20for%20%60surrogate_only%60%20at%20B80%20unexplained**%0A%0AThe%20confounded-variant%20table%20shows%20%60surrogate_only%20%7C%2080%20%7C%2020.65%20%7C%200.00%60%20%E2%80%94%20zero%20variance%20across%20all%20seeds.%20The%20document%20already%20explains%20zero%20%60std%60%20for%20%60surrogate_only%60%20in%20the%20null%20control%20%28%C2%A75a%20note%3A%20convergence%20to%20the%20same%20ridge%20predictor%20on%20permuted%20data%20with%20no%20causal%20graph%29.%20That%20explanation%20is%20specific%20to%20permuted%20targets%3B%20here%20the%20data%20has%20real%20%28though%20biased%29%20signal.%0A%0AA%20%60std%60%20of%20exactly%200.00%20over%20five%20seeds%20on%20real%20confounded%20data%20is%20unusual%20and%20could%20indicate%20only%20one%20seed%20actually%20completed%2C%20an%20accidental%20duplicate%2C%20or%20a%20deterministic%20convergence%20artefact%20specific%20to%20this%20benchmark.%20The%20document%20should%20either%20explain%20why%20deterministic%20convergence%20is%20expected%20on%20the%20confounded%20variant%2C%20or%20flag%20it%20for%20verification.%0A%0AThis%20is%20especially%20load-bearing%20because%20%60surrogate_only%20%7C%2080%20%7C%2020.65%60%20is%20used%20as%20a%20reference%20point%20for%20causal's%20underperformance%20%2830.23%29%20%E2%80%94%20if%20the%2020.65%20is%20unreliable%2C%20the%20comparison%20is%20too.%0A%0A&repo=datablogin%2Fcausal-optimizer"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-19-differentiation-scorecard.md
Line: 60-62

Comment:
**High-noise B20 result understated**

The table at lines 50–52 shows causal regret of 23.32 vs surrogate_only 23.99 at B20 — causal has the lower point estimate here too. Yet the narrative on lines 60–62 says **"Causal beats surrogate_only at B40 and B80,"** silently omitting B20. A reader comparing text to table will notice the inconsistency.

The omission is arguably defensible because the margin at B20 (0.67) falls well within the overlapping standard deviations (5.20 and 4.07), making it statistically indistinguishable from a tie. If that is the reasoning, the text should make it explicit — e.g.:

```suggestion
**Finding: Causal beats surrogate_only at B40 and B80; the B20 gap (23.32
vs 23.99) is within noise given the overlapping standard deviations.**
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-19-differentiation-scorecard.md
Line: 88-89

Comment:
**Zero standard deviation for `surrogate_only` at B80 unexplained**

The confounded-variant table shows `surrogate_only | 80 | 20.65 | 0.00` — zero variance across all seeds. The document already explains zero `std` for `surrogate_only` in the null control (§5a note: convergence to the same ridge predictor on permuted data with no causal graph). That explanation is specific to permuted targets; here the data has real (though biased) signal.

A `std` of exactly 0.00 over five seeds on real confounded data is unusual and could indicate only one seed actually completed, an accidental duplicate, or a deterministic convergence artefact specific to this benchmark. The document should either explain why deterministic convergence is expected on the confounded variant, or flag it for verification.

This is especially load-bearing because `surrogate_only | 80 | 20.65` is used as a reference point for causal's underperformance (30.23) — if the 20.65 is unreliable, the comparison is too.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: update scorecard to reflect causal\_..."](https://github.com/datablogin/causal-optimizer/commit/9afc467f3bd23fc9915025343bd998056ad6a1f9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26942613)</sub>

<!-- /greptile_comment -->