### PR TITLE
docs: Sprint 20 stability audit for causal differentiation (#106)

### DIFF
--- a/thoughts/shared/docs/sprint-20-stability-audit-report.md
+++ b/thoughts/shared/docs/sprint-20-stability-audit-report.md
@@ -30,7 +30,7 @@ seed sweep, or is it fragile?**
 ### 2b. Benchmark Configuration
 
 - **Benchmark**: Counterfactual demand-response (base variant)
-- **Data**: `ercot_north_c_dfw_2022_2024.parquet` (ERCOT NORTH_C + DFW weather, 2022-2024; local path used: `/Users/robertwelborn/Projects/_local/causal-optimizer/data/ercot_north_c_dfw_2022_2024.parquet`)
+- **Data**: `ercot_north_c_dfw_2022_2024.parquet` (ERCOT NORTH_C + DFW weather, 2022-2024; local path used: `/Users/robertwelborn/Projects/_local/causal-optimizer/data/ercot_north_c_dfw_2022_2024.parquet`) — *Note: This is a developer-specific local path. Users reproducing this audit should substitute their own path to the ERCOT NORTH_C + DFW weather Parquet file via the `--data-path` argument.*
 - **Seeds**: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 (10 seeds)
 - **Budgets**: 20, 40, 80
 - **Strategies**: random, surrogate_only, causal
@@ -277,8 +277,12 @@ cannot be run on S18 (variant was added in Sprint 19).
 | B80 | 6/10 | 40 | 0.4723 (ns) |
 
 *Note: The B80 p-value (0.4723) coincidentally matches the S18 base B80
-p-value in Section 4d, but from different U statistics (U=40 here vs
-U=60 there). This is a numerical coincidence, not a copy-paste error.*
+p-value in Section 4d. This is not a copy-paste error: U=40 here and
+U=60 there are symmetric around the midpoint (n1 x n2 / 2 = 50) of the
+Mann-Whitney U distribution with n1=n2=10, so they produce identical
+two-sided p-values. Both values were computed from the same 10-seed
+sweep; the match is a mathematical consequence of the symmetric U
+statistics.*
 
 No comparison reaches statistical significance. Causal has a slight
 edge in win frequency (6/10 at every budget), but the variance is too
@@ -384,7 +388,11 @@ Recommendations for the Ax re-ranking workstream:
 
 Artifact files are stored locally at
 `/Users/robertwelborn/Projects/_local/causal-optimizer/artifacts/`
-(not committed to the repository) per project convention.
+and are not committed to the repository. This is standard practice for
+this project: benchmark artifacts contain large JSON output (full
+per-seed, per-budget, per-strategy result arrays) that would bloat the
+repo. They are retained locally for auditability and can be regenerated
+using the commands in Section 2c.
 
 ## 10. Summary
 


### PR DESCRIPTION
## Summary

- Ran widened 10-seed comparison of Sprint 18 baseline (`a0f8d5f`) vs current main (`52f7aef`) on the base counterfactual benchmark at budgets 20, 40, 80
- Also ran 10-seed sweep on the high-noise variant (main only, since S18 lacks the variant)
- Stability verdict: **FRAGILE** -- no causal vs surrogate_only comparison reaches p < 0.05, and causal has a bimodal failure mode at B80

### Key findings

1. **No comparison reaches statistical significance** (Mann-Whitney U, 10 seeds, all p > 0.05)
2. **Causal regressed at B80** compared to S18 (mean regret 11.10 vs 4.58) due to bimodal failures
3. **Surrogate_only is identical** between S18 and main (delta = 0.00 at all budgets)
4. **Sprint 19 scorecard numbers are not reproducible** from merged code -- scorecard was generated before the Ax path fix was applied during review
5. **High-noise variant**: causal wins 6/10 seeds at every budget but the advantage is not statistically significant
6. **B80 causal is bimodal**: 4/10 seeds achieve near-oracle performance, 6/10 have catastrophic regret (10-34)

### Recommendation

The Ax balanced re-ranking workstream should proceed. The alignment-only re-ranking is the proximate cause of the bimodal failures. A composite score (objective quality + alignment) should reduce variance.

## Test plan

- [x] All 894 fast tests pass (no source code changes)
- [x] Lint clean (ruff check)
- [x] Type check clean (mypy)
- [x] Report reviewed against raw JSON artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR adds a Sprint 20 stability audit report that runs a widened 10-seed comparison of Sprint 18 baseline vs. merged main on the base counterfactual benchmark (budgets 20/40/80) and a 10-seed sweep on the high-noise variant, ultimately issuing a **FRAGILE** verdict on the Sprint 19 causal win.

Key findings:
- Numerical data (means, medians, U statistics, p-values, rank-table calculations) all verify correctly against the raw per-seed table in Section 4f
- Previous review concerns (duplicate p-value, artifact non-commitment, absolute data path) have all been addressed in this commit with appropriate explanatory notes
- **One analytical gap remains**: Section 3 explicitly states that "seeds 0-4 also differ from the Sprint 19 scorecard values" for `surrogate_only`, yet Section 3 and Section 6 both explain the S18-vs-main surrogate_only identity as "expected, since `causal_graph=None` code path is unchanged." These two claims are in direct tension — if the `causal_graph=None` path were truly unaffected by the Ax path fix, pre-fix and post-fix surrogate_only values for seeds 0-4 would be the same, but they aren't. The Ax path fix (`126d0d8`) appears to have also touched the surrogate_only code path, and the report does not acknowledge or explain this, which could affect confidence in surrogate_only as a reliable baseline for future comparisons

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one analytical note to address; no source changes and all 894 tests pass.
- All prior P1 concerns from previous review rounds are resolved. One P2 analytical inconsistency remains: the report's explanation for surrogate_only being identical between S18 and merged main contradicts its own Section 3 observation about seeds 0-4 differing from the Sprint 19 scorecard. Numerical data is internally consistent and verifiable. Score is 4 rather than 5 because the unexplained surrogate_only behavior could mislead future sprint planning if left unaddressed, but it does not block merge.
- thoughts/shared/docs/sprint-20-stability-audit-report.md — specifically the surrogate_only explanation in Sections 3 and 6

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-20-stability-audit-report.md | New stability audit report documenting a widened 10-seed sweep of S18 vs merged main on the base counterfactual benchmark; verdict is FRAGILE with a bimodal causal failure at B80. Contains a logical inconsistency in the explanation for surrogate_only being identical between S18 and merged main. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Sprint 19 Scorecard\n(5 seeds, pre-Ax-fix code)"] -->|"Claims: causal B80 = 0.98\nvs surrogate_only = 2.16"| B["Sprint 20 Audit Question:\nDoes the win survive?"]
    B --> C["Run 10-seed sweep\nS18 baseline @ a0f8d5f"]
    B --> D["Run 10-seed sweep\nMerged main @ 52f7aef"]
    B --> E["Run 10-seed sweep\nHigh-noise variant (main only)"]

    C --> F["S18 causal B80\nmean=4.58, std=4.64"]
    D --> G["Main causal B80\nmean=11.10, std=10.19\n⚠️ BIMODAL: 4 good / 6 catastrophic"]
    E --> H["High-noise causal B80\nmean=10.49 vs surr=15.67\np=0.4723 (ns)"]

    F --> I{"Statistical tests\nMann-Whitney U, n=10"}
    G --> I
    H --> I

    I -->|"All p > 0.05"| J["VERDICT: FRAGILE\nNo comparison significant"]
    J --> K["Recommendation:\nAx balanced composite score\nobjective + alignment"]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Athoughts%2Fshared%2Fdocs%2Fsprint-20-stability-audit-report.md%3A115-122%0A**Explanation%20for%20surrogate_only%20identity%20contradicts%20Section%203's%20own%20observation**%0A%0ASection%203%20explicitly%20states%3A%20*%22For%20surrogate_only%2C%20seeds%200-4%20also%20differ%20from%20the%20Sprint%2019%20scorecard%20values.%22*%20This%20means%20that%20the%20merged%20main%20%28%6052f7aef%60%29%20produces%20different%20surrogate_only%20per-seed%20results%20than%20the%20pre-review-fix%20Sprint%2019%20code%20%E2%80%94%20which%20implies%20the%20Ax%20path%20fix%20%28%60126d0d8%60%29%20*did*%20change%20surrogate_only%20behavior%2C%20not%20just%20the%20causal%20path.%0A%0AYet%20the%20stated%20reason%20here%20%28%22expected%2C%20since%20surrogate_only%20passes%20%60causal_graph%3DNone%60%2C%20so%20the%20Sprint%2019%20causal%20changes%20have%20no%20effect%20on%20this%20code%20path%22%29%20implies%20surrogate_only%20is%20invariant%20to%20the%20Ax%20path%20fix.%20These%20two%20claims%20are%20in%20direct%20tension%3A%20if%20the%20causal%20changes%20truly%20left%20the%20%60causal_graph%3DNone%60%20path%20untouched%2C%20the%20pre-fix%20and%20post-fix%20surrogate_only%20values%20would%20be%20the%20same%20%E2%80%94%20but%20Section%203%20says%20they%20aren't.%0A%0AThe%20same%20tension%20propagates%20into%20Section%206%3A%20the%20conclusion%20that%20%22the%20surrogate_only%20'regression'%20reported%20in%20the%20Sprint%2019%20scorecard%20was%20an%20artifact%20of%20comparing%20against%20pre-review-fix%20code%22%20is%20correct%20in%20its%20empirical%20observation%2C%20but%20the%20accompanying%20explanation%20%28%22the%20Sprint%2019%20code%20changes%20do%20not%20affect%20surrogate_only%20behavior%22%29%20is%20not%20supported.%20A%20more%20accurate%20framing%20would%20be%3A%0A%0A%3E%20%22The%20Ax%20path%20fix%20appears%20to%20have%20touched%20shared%20Ax%20infrastructure%20that%20also%20affected%20the%20%60surrogate_only%60%20code%20path%2C%20restoring%20its%20behavior%20to%20match%20S18.%20Whether%20this%20was%20an%20intentional%20or%20incidental%20effect%20of%20the%20fix%20should%20be%20confirmed%20against%20%60126d0d8%60.%22%0A%0AThis%20matters%20for%20the%20confidence%20in%20surrogate_only%20as%20a%20stable%20baseline%3A%20if%20the%20fix%20inadvertently%20changed%20surrogate_only%2C%20future%20Ax%20changes%20could%20do%20the%20same%20without%20being%20noticed.%0A%0A&repo=datablogin%2Fcausal-optimizer"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-20-stability-audit-report.md
Line: 115-122

Comment:
**Explanation for surrogate_only identity contradicts Section 3's own observation**

Section 3 explicitly states: *"For surrogate_only, seeds 0-4 also differ from the Sprint 19 scorecard values."* This means that the merged main (`52f7aef`) produces different surrogate_only per-seed results than the pre-review-fix Sprint 19 code — which implies the Ax path fix (`126d0d8`) *did* change surrogate_only behavior, not just the causal path.

Yet the stated reason here ("expected, since surrogate_only passes `causal_graph=None`, so the Sprint 19 causal changes have no effect on this code path") implies surrogate_only is invariant to the Ax path fix. These two claims are in direct tension: if the causal changes truly left the `causal_graph=None` path untouched, the pre-fix and post-fix surrogate_only values would be the same — but Section 3 says they aren't.

The same tension propagates into Section 6: the conclusion that "the surrogate_only 'regression' reported in the Sprint 19 scorecard was an artifact of comparing against pre-review-fix code" is correct in its empirical observation, but the accompanying explanation ("the Sprint 19 code changes do not affect surrogate_only behavior") is not supported. A more accurate framing would be:

> "The Ax path fix appears to have touched shared Ax infrastructure that also affected the `surrogate_only` code path, restoring its behavior to match S18. Whether this was an intentional or incidental effect of the fix should be confirmed against `126d0d8`."

This matters for the confidence in surrogate_only as a stable baseline: if the fix inadvertently changed surrogate_only, future Ax changes could do the same without being noticed.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address Greptile review — p-value n..."](https://github.com/datablogin/causal-optimizer/commit/d7056cee87a4fed2b8e978bec9d0a91f7d29b731) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27075855)</sub>

<!-- /greptile_comment -->