### PR TITLE
docs: Sprint 20 differentiation scorecard (#104)

### DIFF
--- a/thoughts/shared/docs/sprint-20-differentiation-scorecard.md
+++ b/thoughts/shared/docs/sprint-20-differentiation-scorecard.md
@@ -65,6 +65,10 @@ Key observations from the stability audit:
 - **No comparison reaches statistical significance** (Mann-Whitney U,
   all p > 0.05, 10 seeds).
 - **Win rates**: causal wins 7/10 at B20 and B40, but only 3/10 at B80.
+  Note: 4 causal seeds have near-oracle regret (< 3) but one of those
+  (seed 5, regret 1.70) still loses to its matched surrogate_only seed
+  (seed 5, regret 0.35), so near-oracle performance does not guarantee a
+  head-to-head win.
 
 ### 2b. High-Noise Counterfactual (10-Seed, Main Only)
 
@@ -86,8 +90,10 @@ The Sprint 19 scorecard (5 seeds) reported causal B80 regret = 3.47 vs
 surrogate_only = 8.74, claiming a 60% gap. The 10-seed audit found
 causal B80 = 10.49 vs surrogate_only = 15.67, a 33% directional gap
 that is not statistically significant (p = 0.47 Mann-Whitney U). Causal
-wins 6/10 seeds at every budget but the variance is too high to be
-reliable.
+wins 6/10 seeds vs surrogate_only at every budget, but random is
+competitive at B40 (mean 18.14 vs causal 20.16) and B80 (mean 10.71 vs
+causal 10.49, effectively tied). The variance is too high for any
+pairwise advantage to be reliable.
 
 ### 2c. Confounded Counterfactual (5-Seed, Sprint 19)
 
@@ -110,6 +116,14 @@ learned strategies at B80. Causal is the worst performer at B80 (30.23).
 This variant remains an invalid positive control. No rerun was performed
 in Sprint 20 because the confounded variant was not a focus of the
 stability or Ax re-ranking workstreams.
+
+Note: surrogate_only shows std = 0.00 at B80 (and near-zero at B40).
+This is expected, not a data issue: with `causal_graph=None` and a
+fixed budget, the RF surrogate converges deterministically to the same
+optimum across seeds because the confounded variant's signal structure
+funnels all seeds to the same ridge configuration. The same deterministic
+convergence appears in the null control (Section 2d, surrogate_only B40
+std = 0.00).
 
 ### 2d. Null Control (3-Seed, Sprint 19)
 
@@ -176,9 +190,11 @@ a strong causal advantage at B80 did not survive. Causal at B80 regressed
 from S18 (mean regret 4.58 to 11.10) and is now worse than surrogate_only
 (mean 2.16) on average. No comparison reached statistical significance.
 
-The high-noise variant shows a directional causal advantage (lower mean
-regret at all budgets, 6/10 win rate) but the gap is not statistically
-significant.
+The high-noise variant shows a directional causal advantage vs
+surrogate_only (lower mean regret at all budgets, 6/10 win rate) but the
+gap is not statistically significant. Random is competitive with causal
+at B40 and B80 on this variant, so the causal advantage is specifically
+over surrogate_only, not over all baselines.
 
 ### Question 2: Did the balanced Ax re-ranking help, hurt, or leave results unchanged?
 
@@ -279,9 +295,14 @@ audit.
 Specific tasks:
 
 1. **Rerun base counterfactual with 10 seeds** on current main
-   (`f628e5a`+). Compare against the stability audit baselines. Success
-   criteria: B80 causal std < 5.0 (currently 10.19), B80 causal mean
-   regret < surrogate_only mean (currently 11.10 vs 2.16).
+   (`f628e5a`+). Compare against the stability audit baselines.
+   - Stretch goal: B80 causal mean regret < surrogate_only mean
+     (currently 11.10 vs 2.16). This is ambitious -- it requires
+     resolving the bimodal failure across most seeds.
+   - Intermediate goal: B80 causal std < 5.0 (currently 10.19) AND
+     causal win rate >= 6/10 vs surrogate_only at B80. This captures
+     meaningful progress even if causal does not yet beat surrogate_only
+     on mean regret.
 
 2. **Rerun high-noise counterfactual with 10 seeds.** Check whether the
    directional advantage (6/10 win rate) strengthens or weakens with the


### PR DESCRIPTION
## Summary

- Sprint 20 final decision document answering five key questions about causal differentiation after the stability audit and balanced Ax re-ranking
- **Verdict: MIXED** -- low-budget gains (B20, B40) are real across 10 seeds, but B80 causal is bimodal and fragile; balanced Ax re-ranking merged but not yet benchmarked
- Null control: PASS (0.18% max strategy difference)
- Skip calibration: acceptable (dormant on production benchmarks)
- Sprint 21 recommendation: benchmark the balanced Ax re-ranking before expanding research surface

### Key findings

1. Causal improved at B20/B40 (7/10 win rate vs surrogate_only) but regressed at B80 (bimodal failure, 6/10 seeds catastrophic)
2. No causal vs surrogate_only comparison reaches statistical significance (Mann-Whitney U, 10 seeds, all p > 0.05)
3. Sprint 19 scorecard numbers were not reproducible from merged code (generated on pre-review-fix code)
4. Balanced Ax re-ranking (PR #108) is the designed fix for B80 bimodal failure but has not been benchmarked end-to-end
5. Confounded variant remains unsolved (random beats both learned strategies)

Closes #104

## Test plan

- [x] All 891 fast tests pass (no source code changes)
- [x] Lint clean (ruff check)
- [x] Format clean (ruff format)
- [x] Type check clean (mypy)
- [x] All claims traced to artifacts listed in Section 6
- [x] Null-control verdict explicit (Section 3, Question 3)
- [x] Skip-calibration summary included (Section 2e)
- [x] Stability vs mean performance distinguished throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the Sprint 20 differentiation scorecard (`thoughts/shared/docs/sprint-20-differentiation-scorecard.md`), a decision document that assesses causal-guidance performance after a 10-seed stability audit (PR #107) and balanced Ax re-ranking (PR #108). It carries a MIXED verdict: low-budget (B20/B40) gains are real and reproducible across 10 seeds, while B80 causal performance regressed and exhibits a bimodal failure mode; the designed fix (balanced Ax re-ranking) is merged but not yet benchmarked.

Key points from the review:

- All prior review-thread concerns (near-oracle vs win-rate discrepancy, random competitiveness, surrogate_only determinism, and B80 success-criterion ambition) are explicitly addressed and closed in this revision — good convergence.
- Numerical spot-checks pass throughout: table deltas, per-seed mean, and percentage gap calculations are all internally consistent.
- One data concern: the null-control table (Section 2d) shows `causal | 20` and `causal | 40` with identical mean (3259.11) and std (2.16) to two decimal places, while `random` shows clearly different values across the two budget levels. This is likely a copy-paste from the B20 row rather than genuine B40 data; if the true B40 value differed materially, the null-control pass verdict could be affected.
- The document is otherwise thorough, with an explicit evidence inventory, missing-artifact table, and tiered Sprint 21 success criteria.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after verifying the null-control causal B40 row against the source JSON artifact.
- All prior review concerns are resolved; the single remaining finding is a potential copy-paste in a data table that, if incorrect, could silently misrepresent the null-control result. This warrants a quick artifact check before merge, keeping the score at 4 rather than 5.
- thoughts/shared/docs/sprint-20-differentiation-scorecard.md — null-control table rows for causal B20 and B40 need verification against null_sprint19_final.json.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-20-differentiation-scorecard.md | New sprint decision document with well-structured analysis; one potential copy-paste data error in the null-control table (causal B20 and B40 rows are byte-for-byte identical) that warrants verification against source artifacts before merge. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    S18["Sprint 18 baseline\n(a0f8d5f, 5 seeds)"] --> AUDIT["Stability Audit — PR #107\n10-seed sweep on base + high-noise"]
    S19["Sprint 19 main\n(52f7aef, 5 seeds)"] --> AUDIT

    AUDIT --> B20B40["B20 / B40: causal improved\n7/10 win rate vs surrogate_only"]
    AUDIT --> B80["B80: causal REGRESSED\nBimodal — 4/10 near-oracle,\n6/10 catastrophic"]
    AUDIT --> STAT["No comparison statistically\nsignificant (Mann-Whitney U,\nall p > 0.05)"]

    B80 --> FIX["Balanced Ax Re-Ranking — PR #108\nComposite score: RF-quality +\ncausal alignment × softness"]
    FIX --> MERGED["Merged to main (f628e5a)\nUnit-tested ✓  End-to-end: NOT YET"]

    AUDIT --> NULL["Null Control (3 seeds)\nMax strategy diff: 0.18%\nVERDICT: PASS ⚠ on pre-#108 code"]
    AUDIT --> SKIP["Skip Calibration\nDormant on all prod benchmarks\nVERDICT: ACCEPTABLE"]

    B20B40 --> VERDICT["Sprint 20 Verdict: MIXED"]
    B80 --> VERDICT
    MERGED --> VERDICT
    NULL --> VERDICT
    SKIP --> VERDICT

    VERDICT --> S21["Sprint 21 Priority\n1. Benchmark balanced Ax re-ranking\n2. Rerun null control post-#108\n3. Rerun high-noise (10 seeds)\n4. Skip audit post-change"]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Athoughts%2Fshared%2Fdocs%2Fsprint-20-differentiation-scorecard.md%3A136-139%0A**Causal%20B20%20and%20B40%20null-control%20rows%20are%20identical%20%E2%80%94%20possible%20copy-paste**%0A%0ABoth%20the%20%60causal%20%7C%2020%60%20and%20%60causal%20%7C%2040%60%20rows%20report%20the%20same%20mean%20%283259.11%29%20and%20the%20same%20std%20%282.16%29%20to%20two%20decimal%20places%3A%0A%0A%60%60%60%0A%7C%20causal%20%7C%2020%20%7C%203259.11%20%7C%202.16%20%7C%0A%7C%20causal%20%7C%2040%20%7C%203259.11%20%7C%202.16%20%7C%0A%60%60%60%0A%0AIn%20contrast%2C%20%60random%60%20shows%20clearly%20different%20values%20at%20B20%20and%20B40%20%28mean%203260.48%20vs%203261.58%2C%20std%201.75%20vs%200.28%29%2C%20which%20is%20the%20expected%20behaviour%20when%20budget%20changes%20the%20number%20of%20optimizer%20evaluations.%20For%20causal%20to%20produce%20bit-for-bit%20identical%20mean%20**and**%20std%20across%20two%20different%20budgets%20%28even%20in%20a%20null-signal%20setting%29%20with%20only%203%20seeds%20would%20be%20a%20remarkable%20coincidence.%0A%0AIf%20this%20is%20a%20copy-paste%20of%20the%20B20%20row%20rather%20than%20genuine%20B40%20data%2C%20the%20actual%20causal%20B40%20mean%20could%20differ%20%E2%80%94%20and%20if%20it%20exceeded%20~3270%20the%20null-control%20pass%20verdict%20%28max%20strategy%20difference%20%3C%202%25%2C%20currently%20anchored%20on%20random%20B40%20vs%20surrogate_only%20B20%29%20could%20change.%0A%0APlease%20verify%20the%20values%20against%20%60null_sprint19_final.json%60.%20If%20the%20data%20are%20genuinely%20identical%2C%20a%20one-line%20note%20explaining%20why%20budget%20has%20no%20effect%20on%20causal%20MAE%20in%20the%20null-signal%20regime%20would%20prevent%20future%20confusion.%0A%0A&repo=datablogin%2Fcausal-optimizer"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-20-differentiation-scorecard.md
Line: 136-139

Comment:
**Causal B20 and B40 null-control rows are identical — possible copy-paste**

Both the `causal | 20` and `causal | 40` rows report the same mean (3259.11) and the same std (2.16) to two decimal places:

```
| causal | 20 | 3259.11 | 2.16 |
| causal | 40 | 3259.11 | 2.16 |
```

In contrast, `random` shows clearly different values at B20 and B40 (mean 3260.48 vs 3261.58, std 1.75 vs 0.28), which is the expected behaviour when budget changes the number of optimizer evaluations. For causal to produce bit-for-bit identical mean **and** std across two different budgets (even in a null-signal setting) with only 3 seeds would be a remarkable coincidence.

If this is a copy-paste of the B20 row rather than genuine B40 data, the actual causal B40 mean could differ — and if it exceeded ~3270 the null-control pass verdict (max strategy difference < 2%, currently anchored on random B40 vs surrogate_only B20) could change.

Please verify the values against `null_sprint19_final.json`. If the data are genuinely identical, a one-line note explaining why budget has no effect on causal MAE in the null-signal regime would prevent future confusion.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile review — clarify w..."](https://github.com/datablogin/causal-optimizer/commit/28670ac6ed1168f7d8d5cc189d4a7290504391e4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27100252)</sub>

<!-- /greptile_comment -->