### PR TITLE
docs: Sprint 20 post-Ax controlled rerun report

### DIFF
--- a/thoughts/shared/docs/sprint-20-post-ax-rerun-report.md
+++ b/thoughts/shared/docs/sprint-20-post-ax-rerun-report.md
@@ -17,8 +17,8 @@ audit (PR #107) found that pre-#108 code exhibited a bimodal failure
 mode at B80: 4/10 seeds achieved near-oracle performance while 6/10
 had catastrophic regret (10--34).
 
-This rerun answers: **did the balanced Ax re-ranking fix the bimodal
-B80 failure mode and improve the benchmark picture?**
+This rerun answers: **does the post-#108 merged main resolve the
+bimodal B80 failure mode and improve the benchmark picture?**
 
 ## 2. Methodology
 
@@ -117,8 +117,8 @@ Causal mean regret improved at all three budget levels:
 ### 3c. Bimodal Failure Mode: Resolved
 
 The stability audit's primary finding was a bimodal failure at B80
-where 6/10 seeds had catastrophic regret. The balanced Ax re-ranking
-substantially resolves this:
+where 6/10 seeds had catastrophic regret. The post-#108 merged main
+substantially improves this picture:
 
 | Metric | Pre-Ax | Post-Ax |
 |--------|--------|---------|
@@ -170,8 +170,11 @@ different Ax environment). The comparison is still valid for answering
 "does causal beat surrogate_only on this code?" but the surrogate_only
 baseline is not directly comparable to the stability audit baseline.
 
-To isolate the re-ranking effect on causal alone (holding surrogate_only
-constant), we compare causal across runs:
+To assess whether the causal strategy itself improved (independent of
+the surrogate_only shift), we compare causal across pre- and post-merge
+runs.  Note: this comparison is **consistent with** the re-ranking fix
+being beneficial, but does not cleanly isolate it from environment drift
+(the same resolved Ax/BoTorch/PyTorch versions affect all strategies):
 
 | Budget | Pre-Ax Causal | Post-Ax Causal | Improvement? |
 |--------|---------------|----------------|-------------|
@@ -179,8 +182,9 @@ constant), we compare causal across runs:
 | B40 | 15.51 | 7.44 | Yes (-52%) |
 | B80 | 11.10 | 3.85 | Yes (-65%) |
 
-Causal improved substantially at all budgets, independent of the
-surrogate_only shift.
+Causal improved at all budgets in the post-merge run.  The improvement
+is consistent with the balanced re-ranking fix but cannot be fully
+separated from environment drift.
 
 ### 3g. Per-Seed B80 Comparison
 
@@ -346,8 +350,10 @@ Verdict: PASS.
 
 **BETTER.**
 
-The balanced Ax re-ranking (PR #108) materially improved the causal
-strategy across both benchmark families:
+The post-#108 merged main produced materially better causal benchmark
+results across both families.  The improvement is consistent with the
+balanced Ax re-ranking fix, though it cannot be fully isolated from
+Ax/BoTorch environment drift (see Section 3e):
 
 1. **The bimodal B80 failure mode is substantially resolved.** On base,
    catastrophic seeds (regret > 10) dropped from 6/10 to 2/10. On
@@ -405,4 +411,4 @@ Other contributors should substitute their own local artifacts path.
 | 18 | PASS (infrastructure) | Null control clean, causal does not beat surrogate_only |
 | 19 | PROGRESS | Soft causal influence improves low-budget performance |
 | 20 (stability) | FRAGILE | Bimodal B80 failure, no stat sig, 5-seed scorecard misleading |
-| 20 (post-Ax) | BETTER | Balanced re-ranking fixes bimodal B80, stat sig at B40/B80 on high-noise |
+| 20 (post-Ax) | BETTER | Post-merge main resolves bimodal B80, stat sig at B40/B80 on high-noise |


### PR DESCRIPTION
## Summary

Controlled benchmark rerun on merged main (commit `3ad4d24`, includes #107 stability audit, #108 balanced Ax re-ranking, #109 scorecard) to measure whether balanced Ax re-ranking resolved the bimodal B80 failure mode identified in the stability audit.

**Benchmarks run:**
- Base counterfactual: 10 seeds x 3 budgets x 3 strategies = 90 runs
- High-noise counterfactual: 10 seeds x 3 budgets x 3 strategies = 90 runs
- Null control: 3 seeds x 2 budgets x 3 strategies = 18 runs
- Skip calibration check

**Key question:** Did B80 causal mean regret improve, variance decrease, and win rate increase after balanced Ax re-ranking?

Closes #104 (partial — evidence component)

## Test plan

- [x] All 891 fast tests pass
- [x] Report traces all claims to artifacts
- [x] Null-control verdict explicit
- [x] Pre/post comparison tables included
- [x] B80 stability evaluated by mean, std, and win rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new benchmark report documenting the Sprint 20 post-Ax controlled rerun, confirming that balanced Ax re-ranking (#108) substantially resolved the bimodal B80 failure mode identified in the stability audit. Three prior review concerns (contradictory std-target language, absolute path leakage, base B80 delta rounding) were addressed in commit `1ee92e4`; two small residual issues remain: the high-noise B80 delta is recorded as `-7.84` instead of the arithmetic result of `-7.85` (same pattern as the fixed base delta), and the Section 9 environment-drift caveat cross-references Section 3e (Statistical Significance) instead of the correct Section 3f / 2e.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 documentation-accuracy nits that do not affect code or conclusions.

All three P1-level concerns from the previous review cycle are resolved. The two remaining findings are 0.01 rounding artefacts and a wrong section cross-reference — neither affects the validity of the benchmark conclusions or any code path.

No files require special attention beyond the two inline nits flagged.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-20-post-ax-rerun-report.md | New benchmark report documenting post-Ax controlled rerun results; two minor rounding/cross-reference inconsistencies remain after prior fixes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Merged main @ 3ad4d24
#107 stability audit
#108 balanced Ax re-ranking
#109 scorecard] --> B[Run benchmarks]
    B --> C[Base counterfactual
10 seeds x 3 budgets x 3 strategies
90 runs]
    B --> D[High-noise counterfactual
10 seeds x 3 budgets x 3 strategies
90 runs]
    B --> E[Null control
3 seeds x 2 budgets x 3 strategies
18 runs]
    C --> F{B80 bimodal resolved?}
    D --> F
    F -->|Base: 6 to 2 catastrophic
High-noise: 5 to 1 catastrophic| G[YES - BETTER verdict]
    E --> H{Null signal < 2% threshold?}
    H -->|Max diff 0.20%| I[PASS]
    G --> J[Report: sprint-20-post-ax-rerun-report.md]
    I --> J
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Athoughts%2Fshared%2Fdocs%2Fsprint-20-post-ax-rerun-report.md%3A216%0A**High-noise%20B80%20delta%20rounding%20artefact**%0A%0A10.49%20%E2%88%92%202.64%20%3D%20**7.85**%2C%20not%207.84.%20The%20same%200.01%20rounding%20discrepancy%20was%20fixed%20for%20the%20base%20B80%20delta%20%28%60-7.26%60%20%E2%86%92%20%60-7.25%60%29%20in%20a%20prior%20review%20cycle%3B%20this%20occurrence%20on%20the%20high-noise%20row%20was%20missed.%20The%20value%20%60-7.84%60%20also%20appears%20on%20line%20300%20%28Q1%20answer%29.%0A%0A%60%60%60suggestion%0A%7C%20causal%20%7C%2080%20%7C%2010.49%20%7C%206.34%20%7C%202.64%20%7C%204.29%20%7C%20-7.85%20%7C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Athoughts%2Fshared%2Fdocs%2Fsprint-20-post-ax-rerun-report.md%3A300%0A**Q1%20answer%20repeats%20the%20high-noise%20delta%20rounding%20error**%0A%0ACompanion%20fix%20to%20line%20216%3A%20the%20repeated%20delta%20value%20should%20be%20%60-7.85%60%20%2810.49%20%E2%88%92%202.64%20%3D%207.85%29.%0A%0A%60%60%60suggestion%0A**Yes%2C%20substantially.**%20Base%3A%2011.10%20to%203.85%20%28delta%20-7.25%2C%20-65%25%29.%0AHigh-noise%3A%2010.49%20to%202.64%20%28delta%20-7.85%2C%20-75%25%29.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Athoughts%2Fshared%2Fdocs%2Fsprint-20-post-ax-rerun-report.md%3A356%0A**Wrong%20section%20cross-reference**%0A%0A%22see%20Section%203e%22%20points%20to%20the%20*Statistical%20Significance*%20section%2C%20not%20to%20the%20Ax%2FBoTorch%20environment%20drift%20discussion.%20The%20drift%20caveat%20is%20explained%20in%20Section%203f%20%28Surrogate_Only%20Shift%29%20and%20Section%202e%20%28Reproducibility%20Note%29.%20A%20reader%20following%20this%20link%20lands%20in%20the%20wrong%20place.%0A%0A%60%60%60suggestion%0Aresults%20across%20both%20families.%20%20The%20improvement%20is%20consistent%20with%20the%0Abalanced%20Ax%20re-ranking%20fix%2C%20though%20it%20cannot%20be%20fully%20isolated%20from%0AAx%2FBoTorch%20environment%20drift%20%28see%20Sections%202e%20and%203f%29%3A%0A%60%60%60%0A%0A&repo=datablogin%2Fcausal-optimizer"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-20-post-ax-rerun-report.md
Line: 216

Comment:
**High-noise B80 delta rounding artefact**

10.49 − 2.64 = **7.85**, not 7.84. The same 0.01 rounding discrepancy was fixed for the base B80 delta (`-7.26` → `-7.25`) in a prior review cycle; this occurrence on the high-noise row was missed. The value `-7.84` also appears on line 300 (Q1 answer).

```suggestion
| causal | 80 | 10.49 | 6.34 | 2.64 | 4.29 | -7.85 |
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-20-post-ax-rerun-report.md
Line: 300

Comment:
**Q1 answer repeats the high-noise delta rounding error**

Companion fix to line 216: the repeated delta value should be `-7.85` (10.49 − 2.64 = 7.85).

```suggestion
**Yes, substantially.** Base: 11.10 to 3.85 (delta -7.25, -65%).
High-noise: 10.49 to 2.64 (delta -7.85, -75%).
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-20-post-ax-rerun-report.md
Line: 356

Comment:
**Wrong section cross-reference**

"see Section 3e" points to the *Statistical Significance* section, not to the Ax/BoTorch environment drift discussion. The drift caveat is explained in Section 3f (Surrogate_Only Shift) and Section 2e (Reproducibility Note). A reader following this link lands in the wrong place.

```suggestion
results across both families.  The improvement is consistent with the
balanced Ax re-ranking fix, though it cannot be fully isolated from
Ax/BoTorch environment drift (see Sections 2e and 3f):
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: soften attribution language per rev..."](https://github.com/datablogin/causal-optimizer/commit/98f10b7e4c9c91730d3838f12654c8cbd5772d08) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27197689)</sub>

<!-- /greptile_comment -->