### PR TITLE
feat: optimizer-path provenance in benchmark artifacts (Sprint 28)

### DIFF
--- a/causal_optimizer/benchmarks/provenance.py
+++ b/causal_optimizer/benchmarks/provenance.py
@@ -101,7 +101,8 @@ def detect_optimizer_path() -> dict[str, object]:
         - ``ax_available``: bool
         - ``botorch_available``: bool
         - ``fallback_reason``: ``None`` if Ax/BoTorch available, or a
-          string describing why fallback occurred (e.g., missing package)
+          string describing why fallback occurred (e.g., missing or broken
+          package install)
     """
     ax_ok = False
     botorch_ok = False
@@ -111,15 +112,17 @@ def detect_optimizer_path() -> dict[str, object]:
         import ax  # noqa: F401
 
         ax_ok = True
-    except ImportError:
-        reasons.append("ax-platform not installed")
+    except Exception as exc:
+        reasons.append(f"ax-platform not installed or failed to import ({type(exc).__name__})")
 
     try:
         import botorch  # noqa: F401
 
         botorch_ok = True
-    except ImportError:
-        reasons.append("botorch not installed")
+    except Exception as exc:
+        reasons.append(
+            f"botorch not installed or failed to import ({type(exc).__name__})"
+        )
 
     if ax_ok and botorch_ok:
         return {

--- a/causal_optimizer/benchmarks/provenance.py
+++ b/causal_optimizer/benchmarks/provenance.py
@@ -120,9 +120,7 @@ def detect_optimizer_path() -> dict[str, object]:
 
         botorch_ok = True
     except Exception as exc:
-        reasons.append(
-            f"botorch not installed or failed to import ({type(exc).__name__})"
-        )
+        reasons.append(f"botorch not installed or failed to import ({type(exc).__name__})")
 
     if ax_ok and botorch_ok:
         return {

--- a/causal_optimizer/benchmarks/provenance.py
+++ b/causal_optimizer/benchmarks/provenance.py
@@ -87,6 +87,56 @@ def dataset_hash(path: str) -> str | None:
         return None
 
 
+def detect_optimizer_path() -> dict[str, object]:
+    """Detect which optimizer path is available in the current environment.
+
+    Checks whether Ax and BoTorch are importable.  When both are available,
+    the optimizer uses Bayesian optimization (``ax_botorch``).  When either
+    is missing, the engine falls back to the RF surrogate path
+    (``rf_fallback``).
+
+    Returns:
+        A JSON-serializable dict with:
+        - ``optimizer_path``: ``"ax_botorch"`` or ``"rf_fallback"``
+        - ``ax_available``: bool
+        - ``botorch_available``: bool
+        - ``fallback_reason``: ``None`` if Ax/BoTorch available, or a
+          string describing why fallback occurred (e.g., missing package)
+    """
+    ax_ok = False
+    botorch_ok = False
+    reasons: list[str] = []
+
+    try:
+        import ax  # noqa: F401
+
+        ax_ok = True
+    except ImportError:
+        reasons.append("ax-platform not installed")
+
+    try:
+        import botorch  # noqa: F401
+
+        botorch_ok = True
+    except ImportError:
+        reasons.append("botorch not installed")
+
+    if ax_ok and botorch_ok:
+        return {
+            "optimizer_path": "ax_botorch",
+            "ax_available": True,
+            "botorch_available": True,
+            "fallback_reason": None,
+        }
+
+    return {
+        "optimizer_path": "rf_fallback",
+        "ax_available": ax_ok,
+        "botorch_available": botorch_ok,
+        "fallback_reason": "; ".join(reasons),
+    }
+
+
 def collect_provenance(
     *,
     seeds: list[int],
@@ -111,7 +161,8 @@ def collect_provenance(
         A JSON-serializable dict with provenance metadata including
         ``git_sha``, ``python_version``, ``package_versions``,
         ``command_line``, ``timestamp``, ``seeds``, ``budgets``,
-        ``strategies``, and optionally ``dataset_path`` / ``dataset_hash``.
+        ``strategies``, ``optimizer_path``, and optionally
+        ``dataset_path`` / ``dataset_hash``.
     """
     vi = sys.version_info
     python_version = f"{vi.major}.{vi.minor}.{vi.micro}"
@@ -132,5 +183,8 @@ def collect_provenance(
     if dataset_path is not None:
         prov["dataset_path"] = dataset_path
         prov["dataset_hash"] = dataset_hash(dataset_path)
+
+    # Sprint 28: optimizer-path provenance
+    prov["optimizer_path"] = detect_optimizer_path()
 
     return prov

--- a/tests/unit/test_optimizer_path_provenance.py
+++ b/tests/unit/test_optimizer_path_provenance.py
@@ -92,7 +92,7 @@ class TestDetectOptimizerPathFallback:
 
         assert result["optimizer_path"] == "rf_fallback"
         assert result["ax_available"] is False
-        assert "ax-platform not installed" in result["fallback_reason"]
+        assert "ax-platform not installed or failed to import" in result["fallback_reason"]
 
     def test_rf_fallback_when_both_missing(self):
         """When both ax and botorch imports fail, should detect rf_fallback."""
@@ -114,8 +114,30 @@ class TestDetectOptimizerPathFallback:
         assert result["optimizer_path"] == "rf_fallback"
         assert result["ax_available"] is False
         assert result["botorch_available"] is False
-        assert "ax-platform not installed" in result["fallback_reason"]
-        assert "botorch not installed" in result["fallback_reason"]
+        assert "ax-platform" in result["fallback_reason"]
+        assert "botorch" in result["fallback_reason"]
+
+    def test_rf_fallback_on_non_import_error(self):
+        """A broken install that raises OSError should still degrade to
+        rf_fallback, not crash provenance capture."""
+        import builtins
+        from unittest.mock import patch
+
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "ax":
+                raise OSError("broken ax install")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            result = detect_optimizer_path()
+
+        assert result["optimizer_path"] == "rf_fallback"
+        assert result["ax_available"] is False
+        assert "OSError" in result["fallback_reason"]
 
 
 class TestCollectProvenanceIncludesOptimizerPath:

--- a/tests/unit/test_optimizer_path_provenance.py
+++ b/tests/unit/test_optimizer_path_provenance.py
@@ -1,0 +1,89 @@
+"""Tests for optimizer-path provenance (Sprint 28).
+
+Verifies that benchmark provenance captures which optimizer path ran
+(Ax/BoTorch vs RF fallback) and the reason for fallback when applicable.
+"""
+
+from __future__ import annotations
+
+
+class TestDetectOptimizerPath:
+    """Tests for the optimizer path detection function."""
+
+    def test_detect_returns_dict(self):
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        result = detect_optimizer_path()
+        assert isinstance(result, dict)
+
+    def test_detect_has_required_keys(self):
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        result = detect_optimizer_path()
+        assert "optimizer_path" in result
+        assert "ax_available" in result
+        assert "botorch_available" in result
+        assert "fallback_reason" in result
+
+    def test_optimizer_path_is_valid_value(self):
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        result = detect_optimizer_path()
+        assert result["optimizer_path"] in ("ax_botorch", "rf_fallback")
+
+    def test_ax_available_is_bool(self):
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        result = detect_optimizer_path()
+        assert isinstance(result["ax_available"], bool)
+
+    def test_botorch_available_is_bool(self):
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        result = detect_optimizer_path()
+        assert isinstance(result["botorch_available"], bool)
+
+    def test_fallback_reason_is_none_or_string(self):
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        result = detect_optimizer_path()
+        assert result["fallback_reason"] is None or isinstance(result["fallback_reason"], str)
+
+    def test_path_consistent_with_availability(self):
+        """If both ax and botorch are available, path should be ax_botorch.
+        If either is missing, path should be rf_fallback."""
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        result = detect_optimizer_path()
+        if result["ax_available"] and result["botorch_available"]:
+            assert result["optimizer_path"] == "ax_botorch"
+            assert result["fallback_reason"] is None
+        else:
+            assert result["optimizer_path"] == "rf_fallback"
+            assert result["fallback_reason"] is not None
+
+
+class TestCollectProvenanceIncludesOptimizerPath:
+    """Tests that collect_provenance includes optimizer path fields."""
+
+    def test_provenance_has_optimizer_path_key(self):
+        from causal_optimizer.benchmarks.provenance import collect_provenance
+
+        prov = collect_provenance(seeds=[0], budgets=[20], strategies=["random"])
+        assert "optimizer_path" in prov
+
+    def test_provenance_optimizer_path_is_dict(self):
+        from causal_optimizer.benchmarks.provenance import collect_provenance
+
+        prov = collect_provenance(seeds=[0], budgets=[20], strategies=["random"])
+        assert isinstance(prov["optimizer_path"], dict)
+
+    def test_provenance_optimizer_path_has_required_keys(self):
+        from causal_optimizer.benchmarks.provenance import collect_provenance
+
+        prov = collect_provenance(seeds=[0], budgets=[20], strategies=["random"])
+        op = prov["optimizer_path"]
+        assert "optimizer_path" in op
+        assert "ax_available" in op
+        assert "botorch_available" in op
+        assert "fallback_reason" in op

--- a/tests/unit/test_optimizer_path_provenance.py
+++ b/tests/unit/test_optimizer_path_provenance.py
@@ -63,6 +63,61 @@ class TestDetectOptimizerPath:
             assert result["fallback_reason"] is not None
 
 
+class TestDetectOptimizerPathFallback:
+    """Tests for the fallback detection path using mocks."""
+
+    def test_rf_fallback_when_ax_missing(self):
+        """When ax import fails, should detect rf_fallback."""
+        from unittest.mock import patch
+
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        with patch.dict("sys.modules", {"ax": None}):
+            # Force reimport detection by calling the function
+            # Note: detect_optimizer_path tries import ax directly
+            pass
+
+        # Use a more direct approach: mock the import itself
+        import builtins
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "ax":
+                raise ImportError("mocked: ax not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            result = detect_optimizer_path()
+
+        assert result["optimizer_path"] == "rf_fallback"
+        assert result["ax_available"] is False
+        assert "ax-platform not installed" in result["fallback_reason"]
+
+    def test_rf_fallback_when_both_missing(self):
+        """When both ax and botorch imports fail, should detect rf_fallback."""
+        import builtins
+        from unittest.mock import patch
+
+        from causal_optimizer.benchmarks.provenance import detect_optimizer_path
+
+        real_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name in ("ax", "botorch"):
+                raise ImportError(f"mocked: {name} not installed")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=mock_import):
+            result = detect_optimizer_path()
+
+        assert result["optimizer_path"] == "rf_fallback"
+        assert result["ax_available"] is False
+        assert result["botorch_available"] is False
+        assert "ax-platform not installed" in result["fallback_reason"]
+        assert "botorch not installed" in result["fallback_reason"]
+
+
 class TestCollectProvenanceIncludesOptimizerPath:
     """Tests that collect_provenance includes optimizer path fields."""
 

--- a/thoughts/shared/docs/sprint-28-optimizer-path-provenance-report.md
+++ b/thoughts/shared/docs/sprint-28-optimizer-path-provenance-report.md
@@ -1,0 +1,118 @@
+# Sprint 28 Optimizer-Path Provenance Report
+
+## Metadata
+
+- **Date**: 2026-04-09
+- **Sprint**: 28 (Optimizer-Path Provenance)
+- **Issue**: #146
+- **Branch**: `sprint-28/optimizer-path-provenance`
+- **Base commit**: `8a48966` (Sprint 27 crossover scorecard merged to main)
+
+## 1. What Was Added
+
+### 1a. New Function: `detect_optimizer_path()`
+
+Added to `causal_optimizer/benchmarks/provenance.py`.  Probes the runtime
+environment to determine which optimizer backend is available.
+
+Returns a JSON-serializable dict with four fields:
+
+| Field | Type | Values |
+|-------|------|--------|
+| `optimizer_path` | str | `"ax_botorch"` or `"rf_fallback"` |
+| `ax_available` | bool | Whether `ax` is importable |
+| `botorch_available` | bool | Whether `botorch` is importable |
+| `fallback_reason` | str or null | `null` when Ax/BoTorch available; describes missing packages otherwise |
+
+### 1b. Integration Into `collect_provenance()`
+
+The existing `collect_provenance()` function now includes an
+`optimizer_path` key in its output.  Since all benchmark CLI scripts
+(counterfactual, null, dose-response) already call `collect_provenance()`,
+the new field appears automatically in every benchmark JSON artifact
+without any script changes.
+
+### 1c. Example Output
+
+When Ax/BoTorch are installed:
+```json
+"optimizer_path": {
+    "optimizer_path": "ax_botorch",
+    "ax_available": true,
+    "botorch_available": true,
+    "fallback_reason": null
+}
+```
+
+When Ax/BoTorch are not installed:
+```json
+"optimizer_path": {
+    "optimizer_path": "rf_fallback",
+    "ax_available": false,
+    "botorch_available": false,
+    "fallback_reason": "ax-platform not installed; botorch not installed"
+}
+```
+
+## 2. How a Run Distinguishes Ax/BoTorch From RF Fallback
+
+The detection logic is simple and mechanical:
+
+1. Try `import ax` — if it fails, record `ax_available: false`
+2. Try `import botorch` — if it fails, record `botorch_available: false`
+3. If both succeed: `optimizer_path: "ax_botorch"`, `fallback_reason: null`
+4. If either fails: `optimizer_path: "rf_fallback"`, `fallback_reason` lists the missing packages
+
+This matches the runtime behavior in `suggest.py`:
+`_suggest_optimization()` tries `_suggest_bayesian()` first, catches
+`ImportError`, and falls back to `_suggest_surrogate()`.
+
+## 3. How Fallback Reason Is Represented
+
+The `fallback_reason` field is:
+- `null` when no fallback occurred (both packages available)
+- A semicolon-separated string listing each missing package when fallback
+  occurred (e.g., `"ax-platform not installed; botorch not installed"`)
+
+This captures the most common fallback scenarios:
+- Only `ax-platform` missing
+- Only `botorch` missing
+- Both missing (typical in lightweight CI or worktree environments)
+
+## 4. What Ambiguity This Removes
+
+### Removed
+
+- **Backend inference from narrative**: Prior scorecards had to state
+  "this run used RF fallback" as a caveat.  Now every JSON artifact
+  self-documents its optimizer path.
+- **Cross-run comparison ambiguity**: When comparing Sprint 25 (Ax/BoTorch)
+  to Sprint 27 regression gate (RF fallback), readers had to check the
+  report text.  Now they can programmatically filter artifacts by
+  `optimizer_path.optimizer_path == "ax_botorch"`.
+- **Scorecard hygiene**: Future scorecards can auto-verify that compared
+  runs used the same backend, or flag when they didn't.
+
+### Remaining
+
+- **Within-run path switches**: The provenance captures what was available
+  at the start of the run, not per-step.  If a package becomes unavailable
+  mid-run (unlikely but possible in edge cases), the artifact would not
+  reflect that.
+- **GP fallback within Ax**: When Ax/BoTorch are available, the engine
+  may still fall back from causal GP to standard Bayesian optimization
+  within `_suggest_optimization()`.  This internal fallback is not captured
+  in the provenance (it is logged at runtime, not persisted in artifacts).
+- **Version-specific behavior**: Two runs with `optimizer_path: "ax_botorch"`
+  but different Ax/BoTorch versions may produce different results.  The
+  `package_versions` field (already present) covers this, but the
+  `optimizer_path` field alone does not.
+
+## 5. Scope of Change
+
+- **1 function added**: `detect_optimizer_path()` in `provenance.py`
+- **1 function modified**: `collect_provenance()` — added `optimizer_path` key
+- **10 tests added**: `tests/unit/test_optimizer_path_provenance.py`
+- **0 script changes**: all benchmark CLIs inherit the new field automatically
+- **Backward compatible**: existing JSON readers that don't expect
+  `optimizer_path` will silently ignore it


### PR DESCRIPTION
## Summary

Every benchmark JSON artifact now self-documents whether the run used Ax/BoTorch Bayesian optimization or the RF surrogate fallback path.

**New function:** `detect_optimizer_path()` probes the runtime environment and returns:
- `optimizer_path`: `"ax_botorch"` or `"rf_fallback"`
- `ax_available` / `botorch_available`: booleans
- `fallback_reason`: `null` or string describing missing packages

Integrated into `collect_provenance()` which is already called by all benchmark CLIs — no script changes needed.

**What this removes:** backend inference from narrative caveats. Future scorecards can programmatically verify compared runs used the same backend.

Closes #146

## Test plan

- [x] 10 focused tests for detect_optimizer_path and provenance integration
- [x] All fast tests pass
- [x] Backward compatible (new key, existing readers ignore it)
- [x] Report documents exact fields and remaining ambiguity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `detect_optimizer_path()` to `provenance.py`, which probes whether Ax/BoTorch are importable and records the result (`"ax_botorch"` or `"rf_fallback"`) in every benchmark artifact via `collect_provenance()`. The change is backward-compatible and the previous concern about non-`ImportError` exceptions is fully addressed with broad `except Exception` handling.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only finding is a dead code block in one test method, which does not affect correctness or coverage.

All remaining findings are P2 (style). The implementation logic is correct, the previous non-`ImportError` concern from the prior review is addressed, and 10 focused tests cover both happy-path and fallback scenarios including broad exception types.

tests/unit/test_optimizer_path_provenance.py — minor dead code cleanup in `test_rf_fallback_when_ax_missing`.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| causal_optimizer/benchmarks/provenance.py | Adds `detect_optimizer_path()` with broad `Exception` catching for defensive probing, integrated cleanly into `collect_provenance()`; logic is correct and backward-compatible. |
| tests/unit/test_optimizer_path_provenance.py | Good coverage including mock-based fallback tests; one test method contains a dead `with patch.dict(...): pass` block that is an abandoned draft approach and should be removed. |
| thoughts/shared/docs/sprint-28-optimizer-path-provenance-report.md | Documentation-only sprint report; honestly describes remaining ambiguities (within-run path switches, GP fallback within Ax, version-specific behavior). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as Benchmark CLI
    participant CP as collect_provenance()
    participant DOP as detect_optimizer_path()
    participant Env as Runtime Environment

    CLI->>CP: collect_provenance(seeds, budgets, strategies)
    CP->>DOP: detect_optimizer_path()
    DOP->>Env: import ax
    alt ax importable
        Env-->>DOP: success
    else ax missing or broken
        Env-->>DOP: Exception → ax_ok=False, append reason
    end
    DOP->>Env: import botorch
    alt botorch importable
        Env-->>DOP: success
    else botorch missing or broken
        Env-->>DOP: Exception → botorch_ok=False, append reason
    end
    alt ax_ok and botorch_ok
        DOP-->>CP: {optimizer_path: "ax_botorch", fallback_reason: null}
    else either missing
        DOP-->>CP: {optimizer_path: "rf_fallback", fallback_reason: "..."}
    end
    CP-->>CLI: provenance dict with optimizer_path key
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Funit%2Ftest_optimizer_path_provenance.py%3A69-80%0A**Dead%20code%20from%20abandoned%20approach**%0A%0AThe%20first%20%60with%20patch.dict%28%22sys.modules%22%2C%20%7B%22ax%22%3A%20None%7D%29%3A%20pass%60%20block%20does%20nothing%20%E2%80%94%20only%20%60pass%60%20lives%20inside%20it.%20It%20reads%20like%20an%20abandoned%20first%20draft%20of%20the%20mock%20approach%2C%20left%20in%20before%20switching%20to%20the%20%60builtins.__import__%60%20strategy.%20It%20should%20be%20removed%20to%20avoid%20confusing%20future%20readers.%0A%0A%60%60%60suggestion%0A%20%20%20%20def%20test_rf_fallback_when_ax_missing%28self%29%3A%0A%20%20%20%20%20%20%20%20%22%22%22When%20ax%20import%20fails%2C%20should%20detect%20rf_fallback.%22%22%22%0A%20%20%20%20%20%20%20%20import%20builtins%0A%20%20%20%20%20%20%20%20from%20unittest.mock%20import%20patch%0A%0A%20%20%20%20%20%20%20%20from%20causal_optimizer.benchmarks.provenance%20import%20detect_optimizer_path%0A%0A%20%20%20%20%20%20%20%20real_import%20%3D%20builtins.__import__%0A%60%60%60%0A%0A&repo=datablogin%2Fcausal-optimizer"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tests/unit/test_optimizer_path_provenance.py
Line: 69-80

Comment:
**Dead code from abandoned approach**

The first `with patch.dict("sys.modules", {"ax": None}): pass` block does nothing — only `pass` lives inside it. It reads like an abandoned first draft of the mock approach, left in before switching to the `builtins.__import__` strategy. It should be removed to avoid confusing future readers.

```suggestion
    def test_rf_fallback_when_ax_missing(self):
        """When ax import fails, should detect rf_fallback."""
        import builtins
        from unittest.mock import patch

        from causal_optimizer.benchmarks.provenance import detect_optimizer_path

        real_import = builtins.__import__
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: catch all exceptions in detect\_opti..."](https://github.com/datablogin/causal-optimizer/commit/78dfcf9eddf263ce9a6764e4aab6d35746d42e17) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27814215)</sub>

<!-- /greptile_comment -->