### PR TITLE
docs: Sprint 29 dose-response 10-seed Ax certification (CAUSAL WIN p=0.002)

### DIFF
--- a/thoughts/shared/docs/sprint-29-dose-response-10seed-report.md
+++ b/thoughts/shared/docs/sprint-29-dose-response-10seed-report.md
@@ -1,0 +1,178 @@
+# Sprint 29 Dose-Response 10-Seed Certification Report
+
+**Date**: 2026-04-10
+**Sprint**: 29 (Adaptive Causal Guidance)
+**Issue**: #152
+**Branch**: `sprint-29/dose-response-10seed`
+**Base commit**: `ff4af00` (Sprint 29 trajectory diagnosis merged to main)
+**Optimizer path**: ax_botorch (ax-platform 1.2.4, botorch 0.17.2, torch 2.10.0)
+
+## Verdict
+
+**CAUSAL WIN CERTIFIED** -- the Sprint 28 dose-response causal trend is
+confirmed as a statistically significant win at 10 seeds.  Causal beats
+surrogate-only at B80 with two-sided MWU p=0.002, 9/10 seed wins,
+sample-pooled Cohen's d=1.46.
+
+## 1. Executive Summary
+
+The Sprint 29 trajectory diagnosis identified dose-response as a real
+but underpowered causal trend at n=5 (p=0.142, d~1.5).  This report
+reruns the dose-response benchmark with 10 seeds under the Ax/BoTorch
+primary path to certify or refute that trend.
+
+**Result:** the trend is strongly confirmed.  At B80, causal converges
+to near-zero regret (0.19, std 0.03) across all 10 seeds, while
+surrogate-only is higher and more variable (0.92, std 0.66).  The
+two-sided MWU p-value drops from 0.142 (5 seeds) to 0.002 (10 seeds),
+crossing the significance threshold by a wide margin.  Causal also wins
+at B40 (p=0.004).
+
+This converts dose-response from an "Ax-primary mean-regret direction"
+row to a **certified Ax-primary causal win**, narrowing the
+backend-sensitive gap identified in the Sprint 28 scorecard.
+
+## 2. B80 Results (10 Seeds)
+
+| Strategy | Mean Regret | Std | Per-Seed |
+|----------|------------|-----|----------|
+| random | 9.08 | 0.71 | 8.79, 9.10, 8.58, 9.40, 10.20, 7.90, 8.38, 10.12, 8.73, 9.58 |
+| surrogate_only | 0.92 | 0.66 | 1.49, 1.89, 0.30, 0.15, 2.11, 0.71, 0.45, 0.45, 0.45, 1.15 |
+| causal | 0.19 | 0.03 | 0.22, 0.17, 0.23, 0.20, 0.20, 0.20, 0.21, 0.17, 0.15, 0.15 |
+
+MWU causal vs s.o.: U=9.0, one-sided p=0.001, two-sided p=0.002
+Causal wins: 9/10 seeds
+Cohen's d (sample-pooled): 1.46
+
+## 3. Full Budget Trajectory
+
+| Budget | Causal Mean (Std) | S.O. Mean (Std) | MWU Two-Sided p | Causal Wins |
+|--------|-------------------|------------------|-----------------|-------------|
+| B20 | 6.20 (3.89) | 7.59 (2.80) | 0.909 | 6/10 |
+| B40 | 0.73 (1.50) | 6.37 (3.22) | **0.004** | 8/10 |
+| B80 | 0.19 (0.03) | 0.92 (0.66) | **0.002** | 9/10 |
+
+At B20, both strategies are noisy and not significantly different.
+At B40, causal already wins decisively (p=0.004, 8/10 seeds) -- only
+one laggard seed (seed 2, regret 5.23) has not yet converged.
+At B80, all 10 causal seeds converge to the 0.15-0.23 range with
+near-zero variance.
+
+## 4. Comparison to Sprint 28 (5-Seed Baseline)
+
+| Metric | Sprint 28 (5 seeds) | Sprint 29 (10 seeds) | Change |
+|--------|--------------------|--------------------|--------|
+| Causal B80 mean | 0.20 | 0.19 | -0.01 (stable) |
+| Causal B80 std | 0.02 | 0.03 | +0.01 (stable) |
+| S.O. B80 mean | 1.19 | 0.92 | -0.27 (new seeds slightly better) |
+| S.O. B80 std | 0.81 | 0.66 | -0.15 |
+| Two-sided MWU p | 0.142 | **0.002** | Significant |
+| Causal wins | 3/5 pairwise | 9/10 | Decisive |
+| Cohen's d | ~1.5 | 1.46 | Stable |
+
+**Seeds 0-4 reproduced exactly** for causal (0.22, 0.17, 0.23, 0.20,
+0.20 -- identical to Sprint 28).  Seeds 5-9 are new and all converge to
+the same narrow band (0.15-0.21).  The causal result is deterministic
+and reproducible.
+
+Surrogate-only seeds 0-4 also reproduced exactly (1.49, 1.89, 0.30,
+0.15, 2.11).  The new seeds 5-9 are generally better (0.71, 0.45, 0.45,
+0.45, 1.15), which slightly reduces the s.o. mean from 1.19 to 0.92.
+The causal advantage persists regardless.
+
+## 5. Per-Seed B80 Comparison
+
+| Seed | Causal | S.O. | Causal Wins? |
+|------|--------|------|-------------|
+| 0 | 0.22 | 1.49 | Yes |
+| 1 | 0.17 | 1.89 | Yes |
+| 2 | 0.23 | 0.30 | Yes |
+| 3 | 0.20 | 0.15 | No |
+| 4 | 0.20 | 2.11 | Yes |
+| 5 | 0.20 | 0.71 | Yes |
+| 6 | 0.21 | 0.45 | Yes |
+| 7 | 0.17 | 0.45 | Yes |
+| 8 | 0.15 | 0.45 | Yes |
+| 9 | 0.15 | 1.15 | Yes |
+
+Seed 3 is the only seed where surrogate-only beats causal (0.15 vs 0.20),
+and by a margin of only 0.05.  In all other 9 seeds, causal wins by
+0.07-1.91 regret points.
+
+## 6. Mechanism Confirmation
+
+The trajectory diagnosis (PR #155) attributed the dose-response causal
+advantage to dimensionality reduction: the causal graph correctly prunes
+3 noise dimensions (bmi_threshold, age_threshold, comorbidity_threshold),
+letting the GP model the smooth 3D Emax surface with higher sample
+efficiency.
+
+The 10-seed data confirms this mechanism:
+1. Causal variance is near-zero at B80 (std 0.03) -- the 3D GP reliably
+   finds the optimum
+2. S.O. variance remains 20x higher (std 0.66) -- the 6D GP sometimes
+   wastes budget on noise dimensions
+3. The advantage is visible at B40 (p=0.004), confirming faster
+   convergence, not just a final-value difference
+4. All 10 causal seeds land in a 0.08-point band (0.15-0.23), while
+   s.o. spans a 1.96-point band (0.15-2.11)
+
+## 7. Updated Backend Classification
+
+The Sprint 28 scorecard classified dose-response as "Ax-primary,
+mean-regret direction reverses."  With 10-seed certification, the
+updated classification is:
+
+| Benchmark | Old Classification | New Classification |
+|-----------|-------------------|-------------------|
+| Dose-response | Ax-primary (mean-regret direction) | **Ax-primary (certified causal win, p=0.002)** |
+
+The project now has **4 certified causal wins** under Ax/BoTorch (base
+energy p=0.045, medium-noise p=0.007, high-noise p=0.014, dose-response
+p=0.002) and 4 backend-invariant rows.  Only the interaction row remains
+as a surrogate-only advantage.
+
+## 8. Provenance
+
+### Environment
+
+- Python 3.13.12
+- numpy 2.4.2, scipy 1.17.1, scikit-learn 1.8.0
+- **ax-platform: 1.2.4**, **botorch: 0.17.2**, **torch: 2.10.0**
+- git SHA: ff4af00
+
+### Optimizer Path
+
+All runs confirmed `optimizer_path: "ax_botorch"` in provenance metadata.
+
+### Artifacts
+
+Local (not committed):
+```
+artifacts/sprint-29-dose-10seed/dose_response_10seed_results.json
+```
+
+Regeneration command:
+```bash
+uv sync --extra bayesian
+uv run python3 scripts/dose_response_benchmark.py \
+  --seeds 0,1,2,3,4,5,6,7,8,9 \
+  --budgets 20,40,80 \
+  --output dose_response_10seed_results.json
+```
+
+Runtime: 823 seconds (~14 minutes).
+
+## 9. Sprint 29 Recommendation
+
+With dose-response now certified, the remaining optimizer-frontier row is
+interaction only.  Issue #153 (adaptive causal guidance) should focus
+exclusively on:
+
+1. **Interaction ablation**: test whether reducing
+   `causal_exploration_weight` and/or delaying alignment bonus improves
+   the interaction B20/B80 gap
+2. **Regression gate**: confirm demand-response and dose-response wins
+   are preserved after any interaction-targeted change
+3. **Do not pursue dose-response improvements** -- the row is solved
+   (regret 0.19, p=0.002)

--- a/thoughts/shared/docs/sprint-29-dose-response-10seed-report.md
+++ b/thoughts/shared/docs/sprint-29-dose-response-10seed-report.md
@@ -67,7 +67,7 @@ near-zero variance.
 | S.O. B80 mean | 1.19 | 0.92 | -0.27 (new seeds slightly better) |
 | S.O. B80 std | 0.81 | 0.66 | -0.15 |
 | Two-sided MWU p | 0.142 | **0.002** | Significant |
-| Causal wins | 3/5 pairwise | 9/10 | Decisive |
+| Causal wins | 4/5 pairwise | 9/10 | Decisive |
 | Cohen's d | ~1.5 | 1.46 | Stable |
 
 **Seeds 0-4 reproduced exactly** for causal (0.22, 0.17, 0.23, 0.20,


### PR DESCRIPTION
## Summary

- Reruns dose-response benchmark with 10 seeds under Ax/BoTorch primary path
- **Verdict: CAUSAL WIN CERTIFIED** -- two-sided MWU p=0.002, 9/10 seed wins, Cohen's d=1.46
- B80: causal 0.19 (std 0.03) vs surrogate-only 0.92 (std 0.66)
- B40: causal also wins (p=0.004, 8/10 seeds)
- Seeds 0-4 reproduce Sprint 28 exactly; seeds 5-9 confirm the same pattern
- Dose-response moves from "Ax-primary mean-regret direction" to "Ax-primary certified causal win"
- Recommends #153 focus exclusively on interaction adaptive guidance

Addresses #152

## Test plan

- [ ] Lint passes (`ruff check .`)
- [ ] Format passes (`ruff format --check .`)
- [ ] All 1001 unit tests pass
- [ ] Seeds 0-4 match Sprint 28 baseline exactly
- [ ] Provenance confirms optimizer_path: ax_botorch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a certification report for the Sprint 29 dose-response 10-seed benchmark run under Ax/BoTorch, confirming a statistically significant causal win (MWU p=0.002, 9/10 seeds, Cohen's d=1.46) that elevates dose-response from an underpowered trend to a certified result. The report's internal arithmetic — means, stds, MWU U=9.0, and Cohen's d=1.46 — is self-consistent with the per-seed data.

<h3>Confidence Score: 5/5</h3>

Docs-only PR; all key statistics are internally consistent with the per-seed data — safe to merge.

All findings are P2 (style/terminology). No code changes, no logic errors, and the report's arithmetic (means, stds, MWU U=9.0, Cohen's d=1.46, 4/5 Sprint 28 pairwise win count) checks out against the per-seed values provided.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-29-dose-response-10seed-report.md | New certification report; all key statistics (means, stds, U=9.0, d=1.46, 4/5 Sprint 28 win count) are internally consistent with the per-seed data, with one minor terminology imprecision in Section 6. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sprint 28: 5-seed dose-response\nn=5, p=0.142, d~1.5\nUnderpowered trend] --> B[Sprint 29 certification run\n10 seeds x 3 budgets B20/B40/B80\nAx/BoTorch primary path]
    B --> C{B20: p=0.909\nNot significant}
    B --> D{B40: p=0.004\n8/10 causal wins}
    B --> E{B80: p=0.002\nU=9.0, d=1.46\n9/10 causal wins}
    C --> F[Both strategies noisy\nCausal: 6.20 +/- 3.89\nS.O.: 7.59 +/- 2.80]
    D --> G[Causal converging\nOnly seed-2 lagging\nRegret 5.23]
    E --> H[Causal certified\n0.19 +/- 0.03\nS.O.: 0.92 +/- 0.66]
    H --> I[CAUSAL WIN CERTIFIED\nDose-response: Ax-primary certified\n4 total Ax-primary wins]
    I --> J[Recommendation: Issue 153\nFocus on interaction row only\nRegression-gate demand- and dose-response]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Athoughts%2Fshared%2Fdocs%2Fsprint-29-dose-response-10seed-report.md%3A113%0A**%22Variance%22%20and%20%2220x%22%20are%20both%20slightly%20imprecise**%0A%0AThe%20sentence%20says%20%22S.O.%20variance%20remains%2020x%20higher%20%28std%200.66%29%22%20but%20the%20parenthetical%20references%20the%20std%2C%20not%20the%20variance.%20From%20the%20reported%20per-seed%20values%2C%20the%20std%20ratio%20is%200.66%20%2F%200.03%20%E2%89%88%2022%C3%97%20%28or%20~23%C3%97%20from%20unrounded%20data%29%3B%20the%20variance%20ratio%20would%20be%20~484%C3%97.%20Saying%20%2220x%22%20for%20the%20std%20is%20a%20reasonable%20approximation%2C%20but%20mixing%20%22variance%22%20and%20%22std%22%20in%20the%20same%20clause%20may%20confuse%20a%20reader.%0A%0A%60%60%60suggestion%0A2.%20S.O.%20spread%20remains%20~22x%20higher%20%28std%200.66%20vs%200.03%29%20--%20the%206D%20GP%20sometimes%0A%60%60%60%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-29-dose-response-10seed-report.md
Line: 113

Comment:
**"Variance" and "20x" are both slightly imprecise**

The sentence says "S.O. variance remains 20x higher (std 0.66)" but the parenthetical references the std, not the variance. From the reported per-seed values, the std ratio is 0.66 / 0.03 ≈ 22× (or ~23× from unrounded data); the variance ratio would be ~484×. Saying "20x" for the std is a reasonable approximation, but mixing "variance" and "std" in the same clause may confuse a reader.

```suggestion
2. S.O. spread remains ~22x higher (std 0.66 vs 0.03) -- the 6D GP sometimes
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: correct Sprint 28 pairwise win coun..."](https://github.com/datablogin/causal-optimizer/commit/0b7a32f92b13ac264578303a83ea80a0ba50e352) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27996060)</sub>

<!-- /greptile_comment -->