### PR TITLE
feat: set causal_exploration_weight default to 0.0 (Sprint 29)

### DIFF
--- a/causal_optimizer/engine/loop.py
+++ b/causal_optimizer/engine/loop.py
@@ -120,7 +120,7 @@ class ExperimentEngine:
         experiment_id: str | None = None,
         strategy: str = "bayesian",
         audit_skip_rate: float = 0.0,
-        causal_exploration_weight: float = 0.3,
+        causal_exploration_weight: float = 0.0,
         causal_softness: float = 0.5,
     ) -> None:
         """Initialize the experiment engine.
@@ -165,7 +165,9 @@ class ExperimentEngine:
                 Must be in ``[0.0, 1.0]``.
             causal_exploration_weight: Strength of causal bias during
                 exploration (0.0 = pure LHS, higher = more ancestor emphasis).
-                Default 0.3.  Set to 0.0 to recover Sprint 18 behavior.
+                Default 0.0 (changed from 0.3 in Sprint 29 after ablation
+                showed exploration weighting causes B20 penalty on interaction
+                surfaces).
             causal_softness: Strength of causal alignment bonus during
                 optimization (0.0 = no bonus, large = approximates hard focus).
                 Default 0.5.  ``causal_exploration_weight=0.0`` +

--- a/causal_optimizer/optimizer/suggest.py
+++ b/causal_optimizer/optimizer/suggest.py
@@ -115,7 +115,7 @@ def suggest_parameters(
     objectives: list[ObjectiveSpec] | None = None,
     strategy: str = "bayesian",
     seed: int | None = None,
-    causal_exploration_weight: float = 0.3,
+    causal_exploration_weight: float = 0.0,
     causal_softness: float = 0.5,
 ) -> dict[str, Any]:
     """Suggest next experiment parameters based on current phase and history.

--- a/causal_optimizer/optimizer/suggest.py
+++ b/causal_optimizer/optimizer/suggest.py
@@ -134,7 +134,8 @@ def suggest_parameters(
         seed: Random seed forwarded to strategy-specific optimizers for
             reproducibility.
         causal_exploration_weight: Strength of causal bias during exploration
-            (0.0 = pure LHS, higher = more ancestor emphasis). Default 0.3.
+            (0.0 = pure LHS, higher = more ancestor emphasis). Default 0.0
+            (changed from 0.3 in Sprint 29 after ablation evidence).
         causal_softness: Strength of causal alignment bonus during optimization
             (0.0 = no bonus, large = approximates hard focus). Default 0.5.
     """

--- a/tests/unit/test_soft_causal.py
+++ b/tests/unit/test_soft_causal.py
@@ -408,7 +408,12 @@ def test_engine_accepts_causal_config_params() -> None:
 
 
 def test_engine_default_causal_config() -> None:
-    """Default causal config should be weight=0.3, softness=0.5."""
+    """Default causal config should be weight=0.0, softness=0.5.
+
+    Sprint 29 changed weight from 0.3 to 0.0 based on ablation evidence
+    showing exploration weighting is the primary cause of the interaction
+    benchmark B20 catastrophe (PR #159).
+    """
     ss = SearchSpace(
         variables=[
             Variable(name="x", variable_type=VariableType.CONTINUOUS, lower=0.0, upper=10.0),
@@ -418,7 +423,7 @@ def test_engine_default_causal_config() -> None:
         search_space=ss,
         runner=_DummyRunner(),
     )
-    assert engine.causal_exploration_weight == 0.3
+    assert engine.causal_exploration_weight == 0.0
     assert engine.causal_softness == 0.5
 
 

--- a/thoughts/shared/docs/sprint-29-adaptive-causal-guidance-report.md
+++ b/thoughts/shared/docs/sprint-29-adaptive-causal-guidance-report.md
@@ -1,0 +1,122 @@
+# Sprint 29 Adaptive Causal Guidance Report
+
+**Date**: 2026-04-11
+**Sprint**: 29 (Adaptive Causal Guidance)
+**Issue**: #153
+**Branch**: `sprint-29/adaptive-causal-guidance`
+**Base commit**: `76aeb8f` (Sprint 29 interaction ablation merged to main)
+
+## Verdict
+
+**DEFAULT CHANGED** -- `causal_exploration_weight` default changed from
+`0.3` to `0.0`.  This is the narrowest evidence-supported intervention
+from the Sprint 29 ablation (PR #159).
+
+## 1. What Exact Default Changed?
+
+| Parameter | Old Default | New Default | Location |
+|-----------|------------|------------|----------|
+| `causal_exploration_weight` | 0.3 | **0.0** | `engine/loop.py:123`, `optimizer/suggest.py:118` |
+
+The parameter controls the strength of causal bias during exploration
+(experiments 1-10).  At 0.0, exploration uses pure LHS with no ancestor
+weighting.  The causal graph is still passed to the engine and used
+during the optimization phase (alignment bonus, targeted perturbation).
+
+## 2. Where Is the Default Defined in Code?
+
+Two source-of-truth locations:
+
+1. **`causal_optimizer/engine/loop.py`** line 123:
+   `ExperimentEngine.__init__()` constructor parameter default
+2. **`causal_optimizer/optimizer/suggest.py`** line 118:
+   `suggest_parameters()` function parameter default
+
+Both were changed from `0.3` to `0.0`.
+
+Additionally updated:
+- **`engine/loop.py`** docstring (line 166-170): updated default
+  documentation from "Default 0.3" to "Default 0.0" with Sprint 29
+  rationale
+- **`tests/unit/test_soft_causal.py`** line 421: test assertion updated
+  from `== 0.3` to `== 0.0` with Sprint 29 rationale in docstring
+
+## 3. Why Is This the Narrowest Evidence-Supported Intervention?
+
+The Sprint 29 ablation (PR #159) showed:
+
+| Arm | Weight | Softness | B20 Mean | B80 Mean |
+|-----|--------|----------|----------|----------|
+| surrogate_only | — | — | 5.44 | 2.18 |
+| causal_default | 0.3 | 0.5 | **13.83** | 3.17 |
+| no_exploration | 0.0 | 0.5 | 4.76 | 1.90 |
+| no_alignment | 0.3 | 0.0 | 7.77 | 2.79 |
+| graph_only | 0.0 | 0.0 | 4.13 | **1.80** |
+
+Removing exploration weighting is sufficient to eliminate the B20
+catastrophe (13.83 → 4.76).  While graph_only (also removing alignment
+bonus) is empirically the best arm, the ablation did not isolate the
+exact Ax-path mechanism for the alignment-bonus contribution.  Changing
+one parameter at a time is the safer approach:
+
+1. This PR changes `causal_exploration_weight` only
+2. Issue #154 runs the full regression gate to verify no regressions
+3. If the regression gate passes and interaction improves, the project
+   can consider whether to also change `causal_softness` in a separate
+   evidence-supported step
+
+## 4. What Did We Intentionally Leave Unchanged?
+
+| Item | Status | Reason |
+|------|--------|--------|
+| `causal_softness` default (0.5) | **Unchanged** | Alignment bonus effect is not independently harmful enough to justify a second default change in the same PR |
+| README public claims | **Unchanged** | Claims should only update after #154 regression gate confirms results |
+| Benchmark harness | **Unchanged** | No benchmark code changes needed |
+| Ablation script | **Unchanged** | Already uses explicit parameter values, not defaults |
+| Other optimizer behavior | **Unchanged** | No heuristic gates, no adaptive logic |
+
+## 5. What Must #154 Verify in the Full Ax-Primary Regression Gate?
+
+Issue #154 must run the Ax-primary regression gate and confirm:
+
+1. **Demand-response family preserved:**
+   - Base B80: 0/10 catastrophic, mean < 2.0, causal wins (p <= 0.05)
+   - Medium-noise B80: causal wins (p <= 0.01)
+   - High-noise B80: causal wins (p <= 0.02)
+2. **Dose-response preserved:** causal wins at B80 (p <= 0.05 at 10 seeds)
+3. **Interaction improved:** B80 mean regret < 2.0 (currently 3.17 with
+   old default; expected ~1.90 based on ablation no_exploration arm)
+4. **Null control clean:** max delta < 2%
+5. **Confounded unchanged:** all strategies converge to same wrong optimum
+
+**Risks:**
+- The demand-response family has always been tested with the old default
+  (weight=0.3).  While the ablation suggests exploration weighting is
+  harmful on interaction, it was not tested on demand-response.  This
+  is the primary risk: if demand-response relied on causal-weighted
+  exploration for its wins, the change could regress those rows.
+- If demand-response regresses, the fix is to revert this PR and
+  instead gate exploration weight behind a landscape-type heuristic
+  (e.g., enable only when categoricals are present).
+
+## 6. Test Results
+
+```
+$ uv run pytest tests/unit/ -x -q --tb=short
+1001 passed, 12 skipped in 255.31s
+```
+
+Key tests:
+- `test_engine_default_causal_config`: asserts `weight == 0.0`, `softness == 0.5`
+- `test_engine_accepts_causal_config_params`: asserts explicit override
+  still works (`weight=0.5`, `softness=1.0`)
+- All 1001 tests pass with no regressions
+
+## 7. Change Summary
+
+| File | Change |
+|------|--------|
+| `causal_optimizer/engine/loop.py:123` | Default `0.3` → `0.0` |
+| `causal_optimizer/engine/loop.py:166-170` | Docstring updated |
+| `causal_optimizer/optimizer/suggest.py:118` | Default `0.3` → `0.0` |
+| `tests/unit/test_soft_causal.py:411-422` | Test + docstring updated |


### PR DESCRIPTION
## Summary

- Changes `causal_exploration_weight` default from `0.3` to `0.0` in two source-of-truth locations
- Based on Sprint 29 ablation evidence (PR #159): exploration weighting is the primary cause of the interaction B20 catastrophe
- `causal_softness` left unchanged (0.5) — one parameter at a time
- Test updated to assert new default; all 1001 tests pass
- Report documents the change, rationale, and what #154 must verify

Closes #153

## Changed files

| File | Change |
|------|--------|
| `causal_optimizer/engine/loop.py` | Default `0.3` → `0.0`, docstring updated |
| `causal_optimizer/optimizer/suggest.py` | Default `0.3` → `0.0` |
| `tests/unit/test_soft_causal.py` | Test assertion `0.3` → `0.0`, docstring updated |
| `thoughts/shared/docs/sprint-29-adaptive-causal-guidance-report.md` | New report |

## Risks for #154 to verify

- Demand-response family was always tested with weight=0.3 — must confirm wins are preserved
- If demand-response regresses, revert and gate behind a landscape-type heuristic instead

## Test plan

- [x] `test_engine_default_causal_config` fails with old default, passes with new
- [x] `test_engine_accepts_causal_config_params` confirms explicit override still works
- [x] All 1001 unit tests pass
- [ ] CI green (lint, format, typecheck, test matrix)
- [ ] #154 Ax-primary regression gate (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the `causal_exploration_weight` default from `0.3` to `0.0` in both source-of-truth locations (`engine/loop.py` and `optimizer/suggest.py`), updates the corresponding test assertion, and adds a Sprint 29 ablation report. The change is backed by ablation data from PR #159 showing that exploration weighting (weight=0.3) is the primary driver of the B20 benchmark catastrophe on interaction surfaces, while removing it drops the mean regret from 13.83 to 4.76.

All changes are minimal, consistent across both API surfaces, and no benchmark or CLI code sets this parameter explicitly — they will all inherit the new default. The acknowledged risk (demand-response regression) is correctly deferred to PR #154.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-scoped default change backed by ablation data with no logic modifications.

All changes are a single numeric default updated consistently across two API surfaces, with matching test and documentation updates. No benchmark or CLI code hardcodes the old default, so the rollout is uniform. The demand-response regression risk is correctly acknowledged and deferred to PR #154. No P0 or P1 findings.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| causal_optimizer/engine/loop.py | Default changed from 0.3 to 0.0 at constructor parameter; docstring updated with Sprint 29 rationale. Clean, minimal change. |
| causal_optimizer/optimizer/suggest.py | Default changed from 0.3 to 0.0 at suggest_parameters signature; docstring updated. Consistent with engine/loop.py change. |
| tests/unit/test_soft_causal.py | Test assertion updated from 0.3 to 0.0 with Sprint 29 rationale in docstring; explicit-override tests at lines 132 and 371 correctly retain 0.3 as passed values. |
| thoughts/shared/docs/sprint-29-adaptive-causal-guidance-report.md | New ablation report documenting the default change rationale, referenced line numbers, risk analysis, and regression gate requirements for PR #154. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ExperimentEngine.step] --> B{Phase?}
    B -- "exploration (1-10)" --> C[suggest_parameters\ncausal_exploration_weight=0.0]
    B -- "optimization (11-50)" --> D[suggest_parameters\ncausal_softness=0.5]
    B -- "exploitation (50+)" --> E[suggest_parameters\nlocal perturbation]

    C --> F{causal_graph AND\nweight > 0?}
    F -- "No (weight=0.0 default)" --> G[Pure LHS\nno ancestor bias]
    F -- "Yes (explicit override)" --> H[Causal-weighted LHS\nancestor emphasis]

    D --> I[Bayesian optimization\n+ alignment bonus]

    G --> J[ExperimentResult]
    H --> J
    I --> J
    E --> J
```

<sub>Reviews (1): Last reviewed commit: ["fix: update stale suggest.py docstring d..."](https://github.com/datablogin/causal-optimizer/commit/9db5de117ef8a845e5f4da498dca79dc555035b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28098926)</sub>

<!-- /greptile_comment -->