### PR TITLE
docs: Sprint 30 general-causal portability brief

### DIFF
--- a/thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
+++ b/thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
@@ -73,8 +73,8 @@ These are the components tied to energy data or ERCOT-specific logic:
 | DemandResponseScenario | `benchmarks/counterfactual_energy.py` | ERCOT energy covariates |
 | CounterfactualVariants | `benchmarks/counterfactual_variants.py` | ERCOT energy covariates |
 | InteractionPolicyScenario | `benchmarks/interaction_policy.py` | ERCOT energy covariates |
-| NullPredictiveEnergyBenchmark | `benchmarks/null_predictive_energy.py` | ERCOT energy data |
-| PredictiveEnergyBenchmark | `benchmarks/predictive_energy.py` | ERCOT energy data |
+| NullSignalResult (module) | `benchmarks/null_predictive_energy.py` | ERCOT energy data |
+| ValidationEnergyRunner / PredictiveBenchmarkResult | `benchmarks/predictive_energy.py` | ERCOT energy data |
 | counterfactual_benchmark.py | `scripts/counterfactual_benchmark.py` | Energy CLI |
 | null_energy_benchmark.py | `scripts/null_energy_benchmark.py` | Energy CLI |
 
@@ -85,8 +85,8 @@ These are the components tied to energy data or ERCOT-specific logic:
 | DoseResponseScenario | `benchmarks/dose_response.py` | Yes — synthetic clinical |
 | CompleteGraphBenchmark | `benchmarks/complete_graph.py` | Yes — synthetic |
 | ToyGraphBenchmark | `benchmarks/toy_graph.py` | Yes — synthetic |
-| HighDimensionalBenchmark | `benchmarks/high_dimensional.py` | Yes — synthetic |
-| InteractionSCMBenchmark | `benchmarks/interaction_scm.py` | Yes — synthetic |
+| HighDimensionalSparseBenchmark | `benchmarks/high_dimensional.py` | Yes — synthetic |
+| InteractionSCM | `benchmarks/interaction_scm.py` | Yes — synthetic |
 | InteractionBenchmark | `benchmarks/interaction.py` | Yes — synthetic |
 
 ### 2e. Summary
@@ -230,7 +230,7 @@ synthetic manufacturing yield optimization.
 |------|---------|--------|
 | Predictive real-data | 1 domain (energy) | 2+ domains |
 | Intervention / offline-policy | 0 active | 1+ active |
-| Controlled positive/negative | 7 rows (5 energy-tied) | 7+ rows (3+ non-energy) |
+| Controlled positive/negative | 7 rows (6 energy-tied) | 7+ rows (3+ non-energy) |
 
 ## 5. Sprint 31 Recommendation
 
@@ -254,7 +254,7 @@ whether the engine's causal advantage is domain-portable.
 
 If the marketing benchmark passes, the project will have demonstrated
 causal advantage on three domain families (energy demand-response,
-clinical dose-response, marketing policy) instead of one.
+clinical dose-response, marketing policy) instead of the current two.
 
 If it fails, the failure will be specific and diagnosable — and the
 project will have honestly tested its generality claim instead of

--- a/thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
+++ b/thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
@@ -1,0 +1,242 @@
+# Sprint 30 General-Causal Portability Brief
+
+**Date**: 2026-04-12
+**Sprint**: 30 (General Causal Autoresearch: Reality Check And Portability)
+**Issue**: #163
+**Branch**: `sprint-30/general-causal-portability-brief`
+**Base commit**: `4294a9e` (Sprint 29 optimizer-core regression gate merged)
+
+## 1. Project Thesis
+
+The causal-optimizer is not an energy forecasting tool.  It is a
+**domain-agnostic automated research organization** that combines causal
+reasoning, experiment design, benchmark discipline, and institutional
+memory to decide what experiment to run next and whether the result is
+real.
+
+The origin document (00-origin.md) states the gap clearly: no existing
+system combines causal discovery, experimental design, doubly-robust
+estimation, causal Bayesian optimization, evolutionary diversity,
+off-policy evaluation, and sensitivity analysis into one production
+system.  The adapters listed — marketing, ML training, manufacturing,
+drug discovery — are validation surfaces, not the product identity.
+
+ERCOT energy is the first and most exercised validation surface.  It is
+not the project.
+
+## 2. Energy-Specific vs Domain-Portable Components
+
+### 2a. Domain-Portable (Core Engine)
+
+These components work on any domain that provides a search space, a
+runner, and optionally a causal graph:
+
+| Component | Path | Portability |
+|-----------|------|-------------|
+| ExperimentEngine | `engine/loop.py` | Fully generic |
+| suggest_parameters | `optimizer/suggest.py` | Fully generic |
+| CausalGraph / SearchSpace / types | `types.py` | Fully generic |
+| EffectEstimator | `estimator/effects.py` | Fully generic |
+| OffPolicyPredictor | `predictor/off_policy.py` | Fully generic |
+| ScreeningDesigner | `designer/screening.py` | Fully generic |
+| MAPElites | `evolution/map_elites.py` | Fully generic |
+| GraphLearner | `discovery/graph_learner.py` | Fully generic |
+| DomainAdapter base | `domain_adapters/base.py` | Fully generic |
+| BenchmarkRunner | `benchmarks/runner.py` | Fully generic |
+| Provenance | `benchmarks/provenance.py` | Fully generic |
+| Bayesian optimizer | `optimizer/bayesian.py` | Fully generic |
+
+### 2b. Domain Adapters (Reusable Contracts, Domain-Specific Data)
+
+| Adapter | Path | Status | Domain |
+|---------|------|--------|--------|
+| EnergyLoadAdapter | `domain_adapters/energy_load.py` | Shipped, tested | Energy forecasting |
+| MarketingLogAdapter | `domain_adapters/marketing_logs.py` | Shipped, tested | Marketing policy |
+| MLTrainingAdapter | `domain_adapters/ml_training.py` | Shipped | ML hyperparameter |
+| MarketingAdapter | `domain_adapters/marketing.py` | Shipped | Marketing (older) |
+
+Each adapter implements the same `DomainAdapter` contract:
+`get_search_space()`, `run_experiment()`, `get_prior_graph()`,
+`get_objective_name()`, `get_minimize()`.
+
+### 2c. Energy-Specific Benchmarks
+
+These are the components tied to energy data or ERCOT-specific logic:
+
+| Component | Path | Tied To |
+|-----------|------|---------|
+| DemandResponseScenario | `benchmarks/counterfactual_energy.py` | ERCOT energy covariates |
+| InteractionPolicyScenario | `benchmarks/interaction_policy.py` | ERCOT energy covariates |
+| NullPredictiveEnergyBenchmark | `benchmarks/null_predictive_energy.py` | ERCOT energy data |
+| PredictiveEnergyBenchmark | `benchmarks/predictive_energy.py` | ERCOT energy data |
+| counterfactual_benchmark.py | `scripts/counterfactual_benchmark.py` | Energy CLI |
+| null_energy_benchmark.py | `scripts/null_energy_benchmark.py` | Energy CLI |
+
+### 2d. Domain-Portable Benchmarks
+
+| Component | Path | Domain-Free? |
+|-----------|------|-------------|
+| DoseResponseScenario | `benchmarks/dose_response.py` | Yes — synthetic clinical |
+| ToyGraphBenchmark | `benchmarks/toy_graph.py` | Yes — synthetic |
+| HighDimensionalBenchmark | `benchmarks/high_dimensional.py` | Yes — synthetic |
+| InteractionSCMBenchmark | `benchmarks/interaction_scm.py` | Yes — synthetic |
+
+### 2e. Summary
+
+The core engine is **fully domain-portable**.  The benchmark portfolio
+is **heavily energy-weighted** (4 of 7 active benchmark rows use ERCOT
+covariates).  The dose-response benchmark is the only non-energy active
+row.  The MarketingLogAdapter exists and is tested but has no benchmark
+contract or Sprint evidence attached to it.
+
+## 3. Recommended Next Non-Energy Benchmark Contract
+
+### 3a. Candidate: Marketing Offline Policy Benchmark
+
+**Why marketing:**
+
+1. The `MarketingLogAdapter` already exists, is tested (36 unit + 5
+   integration tests), and satisfies the full adapter contract
+2. Marketing policy evaluation is intervention-oriented: the engine
+   searches over treatment policies, not passive predictions
+3. The logged-action / IPS evaluation paradigm is a natural fit for the
+   engine's causal framework — propensity scores, treatment effects, and
+   policy value are first-class concepts
+4. The adapter already has a causal graph (14 edges), search space
+   (6 variables), and a fixture dataset (300 rows)
+5. This is the next non-energy domain recommended in the real-data
+   adapter requirements doc (04-real-data-adapter-requirements.md)
+
+**What the benchmark would test:**
+
+1. Can the engine find better marketing policies than random search
+   under a fixed experiment budget?
+2. Does causal guidance (graph-based focus on policy levers) improve
+   sample efficiency compared to surrogate-only search?
+3. Does the null-control discipline transfer — i.e., does the optimizer
+   avoid manufacturing false signal on a permuted-outcome marketing
+   dataset?
+
+### 3b. Benchmark Contract Shape
+
+| Element | Specification |
+|---------|--------------|
+| Data | `tests/fixtures/marketing_log_fixture.csv` (300 rows) for CI; real marketing log for extended evaluation |
+| Search space | 6 continuous variables (eligibility threshold, channel allocation, propensity clip, regularization, treatment budget) |
+| Objective | `policy_value`, maximize |
+| Strategies | random, surrogate_only, causal |
+| Seeds | 10 |
+| Budgets | 20, 40, 80 |
+| Causal graph | 14-edge prior from adapter |
+| Null control | Permuted outcome column, same search space |
+| Success criterion | Causal >= surrogate_only on policy_value at B80 |
+| Failure criterion | Causal <= random at B80, or null control fails |
+
+### 3c. Acceptance Rules
+
+1. The benchmark must run on the committed fixture data without network
+   access
+2. Results must be deterministic under fixed seed
+3. The null control must use outcome permutation, not label shuffling
+4. The report must separate observed policy improvement from causal
+   attribution
+5. Provenance must record optimizer path and adapter version
+
+### 3d. What This Would Prove
+
+A passing marketing benchmark would show that the engine's causal
+advantage is not specific to energy demand-response surfaces.  It would
+demonstrate that:
+
+1. the intervention-oriented framing works on logged-action data
+2. the causal graph provides useful variable pruning on a non-energy
+   search space
+3. the Sprint 29 default (causal_exploration_weight=0.0) is
+   domain-portable, not energy-tuned
+
+A failing benchmark would be equally informative: it would identify
+whether the engine needs adaptation for IPS-weighted objectives,
+non-Gaussian metrics, or policy-evaluation-specific challenges.
+
+## 4. Recommended Benchmark Portfolio Shape
+
+For a general causal research assistant, the benchmark portfolio should
+contain three research modes:
+
+### Mode 1: Predictive Real-Data Benchmarks
+
+**Purpose:** ground truth on real forecasting tasks.
+
+**Current coverage:** ERCOT NORTH_C and COAST (energy).
+
+**Gap:** no non-energy real-data predictive benchmark.
+
+**Future candidates:** retail demand forecasting, web traffic
+prediction, or any domain with a clear time-series prediction task and
+available covariates.
+
+### Mode 2: Intervention / Offline-Policy Benchmarks
+
+**Purpose:** test whether the engine can find better intervention
+policies from logged or experimental data.
+
+**Current coverage:** none active (MarketingLogAdapter exists but has
+no benchmark evidence).
+
+**Next step:** the marketing offline policy benchmark described above.
+
+**Future candidates:** clinical trial dose optimization (real logged
+data), A/B test configuration optimization, ad bidding policy
+evaluation.
+
+### Mode 3: Controlled Positive / Negative Controls
+
+**Purpose:** mechanism testing with known ground truth.
+
+**Current coverage:**
+- Demand-response family (3 noise levels + confounded): energy-specific
+  covariates
+- Dose-response (synthetic clinical): domain-free
+- Interaction policy: energy-specific covariates
+- Null control: energy-specific data
+
+**Gap:** no non-energy controlled positive control.
+
+**Future candidates:** synthetic marketing uplift with known CATE,
+synthetic manufacturing yield optimization.
+
+### Portfolio Balance Target
+
+| Mode | Current | Target |
+|------|---------|--------|
+| Predictive real-data | 1 domain (energy) | 2+ domains |
+| Intervention / offline-policy | 0 active | 1+ active |
+| Controlled positive/negative | 7 rows (5 energy-tied) | 7+ rows (3+ non-energy) |
+
+## 5. Sprint 31 Recommendation
+
+**Start the marketing offline policy benchmark as a concrete non-energy
+validation surface.**
+
+Sprint 31 should:
+
+1. Write a marketing offline policy benchmark scenario class modeled on
+   `DoseResponseScenario` (which is already non-energy and works well)
+2. Run it on the fixture data with 10 seeds, B20/B40/B80
+3. Add a marketing null control (permuted outcomes)
+4. Compare causal vs surrogate_only vs random
+5. Publish a benchmark report with the same evidence standards used for
+   energy (provenance, MWU tests, per-seed detail)
+
+This should happen alongside or after the ERCOT rerun (Issue #162),
+not instead of it.  The ERCOT rerun tests whether the Sprint 29
+optimizer change matters on real data.  The marketing benchmark tests
+whether the engine's causal advantage is domain-portable.
+
+If the marketing benchmark passes, the project will have demonstrated
+causal advantage on three domain families (energy demand-response,
+clinical dose-response, marketing policy) instead of one.
+
+If it fails, the failure will be specific and diagnosable — and the
+project will have honestly tested its generality claim instead of
+assuming it from adapter existence alone.

--- a/thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
+++ b/thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
@@ -53,7 +53,12 @@ runner, and optionally a causal graph:
 | EnergyLoadAdapter | `domain_adapters/energy_load.py` | Shipped, tested | Energy forecasting |
 | MarketingLogAdapter | `domain_adapters/marketing_logs.py` | Shipped, tested | Marketing policy |
 | MLTrainingAdapter | `domain_adapters/ml_training.py` | Shipped | ML hyperparameter |
-| MarketingAdapter | `domain_adapters/marketing.py` | Shipped | Marketing (older) |
+| MarketingAdapter | `domain_adapters/marketing.py` | Shipped | Marketing (older, simulated) |
+
+Note: `MarketingAdapter` is an older simulated marketing adapter.
+`MarketingLogAdapter` is the newer logged-data / IPS-weighted adapter
+recommended for the next benchmark.  Both implement the `DomainAdapter`
+contract but serve different use cases (simulated vs logged data).
 
 Each adapter implements the same `DomainAdapter` contract:
 `get_search_space()`, `run_experiment()`, `get_prior_graph()`,
@@ -66,6 +71,7 @@ These are the components tied to energy data or ERCOT-specific logic:
 | Component | Path | Tied To |
 |-----------|------|---------|
 | DemandResponseScenario | `benchmarks/counterfactual_energy.py` | ERCOT energy covariates |
+| CounterfactualVariants | `benchmarks/counterfactual_variants.py` | ERCOT energy covariates |
 | InteractionPolicyScenario | `benchmarks/interaction_policy.py` | ERCOT energy covariates |
 | NullPredictiveEnergyBenchmark | `benchmarks/null_predictive_energy.py` | ERCOT energy data |
 | PredictiveEnergyBenchmark | `benchmarks/predictive_energy.py` | ERCOT energy data |
@@ -77,16 +83,25 @@ These are the components tied to energy data or ERCOT-specific logic:
 | Component | Path | Domain-Free? |
 |-----------|------|-------------|
 | DoseResponseScenario | `benchmarks/dose_response.py` | Yes — synthetic clinical |
+| CompleteGraphBenchmark | `benchmarks/complete_graph.py` | Yes — synthetic |
 | ToyGraphBenchmark | `benchmarks/toy_graph.py` | Yes — synthetic |
 | HighDimensionalBenchmark | `benchmarks/high_dimensional.py` | Yes — synthetic |
 | InteractionSCMBenchmark | `benchmarks/interaction_scm.py` | Yes — synthetic |
+| InteractionBenchmark | `benchmarks/interaction.py` | Yes — synthetic |
 
 ### 2e. Summary
 
 The core engine is **fully domain-portable**.  The benchmark portfolio
-is **heavily energy-weighted** (4 of 7 active benchmark rows use ERCOT
-covariates).  The dose-response benchmark is the only non-energy active
-row.  The MarketingLogAdapter exists and is tested but has no benchmark
+is **heavily energy-weighted**: of the 7 active rows in the Ax-primary
+regression gate, **6 use ERCOT energy data** (base, medium-noise,
+high-noise, confounded, null control, interaction — all built on ERCOT
+covariates).  Dose-response is the only non-energy active row.
+
+Several additional domain-portable benchmarks exist in the codebase
+(complete_graph, toy_graph, high_dimensional, interaction_scm,
+interaction) but are not part of the active regression gate.
+
+The MarketingLogAdapter exists and is extensively tested but has no benchmark
 contract or Sprint evidence attached to it.
 
 ## 3. Recommended Next Non-Energy Benchmark Contract
@@ -95,15 +110,16 @@ contract or Sprint evidence attached to it.
 
 **Why marketing:**
 
-1. The `MarketingLogAdapter` already exists, is tested (36 unit + 5
-   integration tests), and satisfies the full adapter contract
+1. The `MarketingLogAdapter` already exists, is extensively tested
+   (66 unit + 5 integration tests), and satisfies the full adapter
+   contract
 2. Marketing policy evaluation is intervention-oriented: the engine
    searches over treatment policies, not passive predictions
 3. The logged-action / IPS evaluation paradigm is a natural fit for the
    engine's causal framework — propensity scores, treatment effects, and
    policy value are first-class concepts
 4. The adapter already has a causal graph (14 edges), search space
-   (6 variables), and a fixture dataset (300 rows)
+   (6 continuous variables), and a fixture dataset (300 rows)
 5. This is the next non-energy domain recommended in the real-data
    adapter requirements doc (04-real-data-adapter-requirements.md)
 
@@ -121,8 +137,8 @@ contract or Sprint evidence attached to it.
 
 | Element | Specification |
 |---------|--------------|
-| Data | `tests/fixtures/marketing_log_fixture.csv` (300 rows) for CI; real marketing log for extended evaluation |
-| Search space | 6 continuous variables (eligibility threshold, channel allocation, propensity clip, regularization, treatment budget) |
+| Data | `tests/fixtures/marketing_log_fixture.csv` (300 rows) for CI; real marketing log for extended evaluation. **Known limitation:** 300 rows may be marginal for stable IPS-weighted policy evaluation across 10 seeds. The benchmark should report ESS (effective sample size) per seed and note variance if ESS is consistently low. |
+| Search space | 6 continuous variables: `eligibility_threshold`, `email_share`, `social_share_of_remainder`, `min_propensity_clip`, `regularization`, `treatment_budget_pct` |
 | Objective | `policy_value`, maximize |
 | Strategies | random, surrogate_only, causal |
 | Seeds | 10 |
@@ -136,7 +152,9 @@ contract or Sprint evidence attached to it.
 
 1. The benchmark must run on the committed fixture data without network
    access
-2. Results must be deterministic under fixed seed
+2. Results must be reproducible within tolerance under fixed seed (Ax/BoTorch
+   has known cross-platform non-determinism; strict determinism applies
+   only to the RF surrogate path)
 3. The null control must use outcome permutation, not label shuffling
 4. The report must separate observed policy improvement from causal
    attribution
@@ -151,8 +169,9 @@ demonstrate that:
 1. the intervention-oriented framing works on logged-action data
 2. the causal graph provides useful variable pruning on a non-energy
    search space
-3. the Sprint 29 default (causal_exploration_weight=0.0) is
-   domain-portable, not energy-tuned
+3. the Sprint 29 default (causal_exploration_weight=0.0) is not
+   harmful on non-energy surfaces and transfers without
+   domain-specific tuning
 
 A failing benchmark would be equally informative: it would identify
 whether the engine needs adaptation for IPS-weighted objectives,


### PR DESCRIPTION
## Summary

- Identifies domain-portable vs energy-specific components in the codebase
- Core engine is fully generic; 4 of 7 active benchmark rows use ERCOT energy data
- Recommends **marketing offline policy benchmark** as the next non-energy validation surface
- Defines a 3-mode benchmark portfolio target (predictive, intervention, controlled)
- Sprint 31: start marketing benchmark alongside ERCOT rerun

Addresses #163

## Key findings

| Layer | Portable | Energy-Specific |
|-------|----------|-----------------|
| Core engine | 12 modules | 0 |
| Domain adapters | 4 (energy, marketing x2, ML) | 0 (all use generic contract) |
| Active benchmarks | 2 (dose-response, null control framework) | 5 (demand-response x3, interaction, predictive) |

The MarketingLogAdapter exists with 36 unit + 5 integration tests but has **zero benchmark evidence** — no Sprint has tested whether causal guidance helps on marketing policy data.

## Test plan

- [x] All 1001 unit tests pass
- [x] Lint and format clean
- [ ] claude-review.sh
- [ ] Greptile clean
- [ ] Human review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Sprint 30 portability brief documenting the causal-optimizer's domain-agnostic core, identifying energy-specific vs portable components, and proposing a marketing offline-policy benchmark as the next non-energy validation surface. The document is well-structured, but several factual claims do not match the actual codebase inventory.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the self-contradictory §2e benchmark count and filling in the missing benchmark entries — all findings are documentation accuracy issues with no code impact.

One P1 (self-contradictory 'only non-energy active row' claim) and two P2 inventory gaps (missing counterfactual_variants.py from energy list; missing complete_graph.py and interaction.py from portable list) should be corrected before this becomes the authoritative reference doc for Sprint 31 planning.

thoughts/shared/docs/sprint-30-general-causal-portability-brief.md — §2c, §2d, and §2e need reconciliation with actual benchmark files.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-30-general-causal-portability-brief.md | Documentation brief with several factual inaccuracies: self-contradictory benchmark count in §2e, omitted benchmarks from both the energy-specific (counterfactual_variants.py) and domain-portable (complete_graph.py, interaction.py) inventories, and a 5-item parenthetical for a 6-variable search space. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Core["Core Engine (12 modules — fully portable)"]
        EE["ExperimentEngine\nengine/loop.py"]
        SP["suggest_parameters\noptimizer/suggest.py"]
        EE --> SP
    end

    subgraph Adapters["Domain Adapters (4 — all use generic contract)"]
        EA["EnergyLoadAdapter"]
        MLA["MarketingLogAdapter\n36 unit + 5 integration tests"]
        MKT["MarketingAdapter"]
        ML["MLTrainingAdapter"]
    end

    subgraph Benchmarks["Benchmark Portfolio"]
        subgraph Energy["Energy-Specific (ERCOT)"]
            CE["counterfactual_energy.py\nDemandResponseScenario"]
            CV["counterfactual_variants.py\n3 variants ⚠️ missing from doc"]
            IP["interaction_policy.py"]
            NPE["null_predictive_energy.py"]
            PE["predictive_energy.py"]
        end
        subgraph Portable["Domain-Portable (synthetic)"]
            DR["dose_response.py ✓"]
            TG["toy_graph.py ✓"]
            HD["high_dimensional.py ✓"]
            IS["interaction_scm.py ✓"]
            IB["interaction.py ⚠️ missing from doc"]
            CG["complete_graph.py ⚠️ missing from doc"]
        end
        subgraph Proposed["Proposed — Sprint 31"]
            MB["Marketing Offline\nPolicy Benchmark"]
        end
    end

    Core --> Adapters
    Adapters --> Benchmarks
    MLA -.->|"no benchmark\nevidence yet"| MB
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Athoughts%2Fshared%2Fdocs%2Fsprint-30-general-causal-portability-brief.md%3A116-120%0A**Self-contradictory%20benchmark%20count%20in%20%C2%A72e**%0A%0AThe%20paragraph%20states%20%224%20of%207%20active%20benchmark%20rows%20use%20ERCOT%20covariates%22%20and%20then%20immediately%20says%20%22The%20dose-response%20benchmark%20is%20the%20**only**%20non-energy%20active%20row.%22%20Those%20two%20claims%20are%20incompatible%3A%20if%204%20of%207%20use%20ERCOT%20then%203%20are%20non-energy%2C%20not%201.%20The%20table%20in%20%C2%A72d%20directly%20above%20this%20paragraph%20already%20lists%20four%20domain-portable%20benchmarks%20%28DoseResponse%2C%20ToyGraph%2C%20HighDimensional%2C%20InteractionSCM%29%2C%20making%20%22the%20only%20non-energy%20active%20row%22%20obviously%20wrong.%20Please%20reconcile%20the%20count%20and%20the%20%22only%22%20claim%20%E2%80%94%20the%20table%20is%20the%20accurate%20part.%0A%0A%23%23%23%20Issue%202%20of%204%0Athoughts%2Fshared%2Fdocs%2Fsprint-30-general-causal-portability-brief.md%3A74-83%0A**Energy-specific%20benchmark%20inventory%20incomplete**%0A%0A%60causal_optimizer%2Fbenchmarks%2Fcounterfactual_variants.py%60%20is%20absent%20from%20this%20table.%20It%20contains%20three%20energy-specific%20variants%20%E2%80%94%20%60MediumNoiseDemandResponse%60%2C%20%60HighNoiseDemandResponse%60%2C%20and%20%60ConfoundedDemandResponse%60%20%E2%80%94%20all%20built%20on%20ERCOT%20covariates%20and%20contributing%20to%20the%20%22demand-response%20x3%22%20rows%20cited%20in%20the%20PR%20description's%20key-findings%20table.%20Omitting%20it%20from%20the%20inventory%20understates%20the%20energy%20concentration%20of%20the%20benchmark%20suite.%0A%0A%23%23%23%20Issue%203%20of%204%0Athoughts%2Fshared%2Fdocs%2Fsprint-30-general-causal-portability-brief.md%3A87-96%0A**Domain-portable%20benchmark%20inventory%20incomplete**%0A%0ATwo%20synthetic%20benchmarks%20are%20missing%20from%20this%20table%3A%0A%0A-%20%60benchmarks%2Fcomplete_graph.py%60%20%E2%86%92%20%60CompleteGraphBenchmark%60%20%287-variable%20DAG%20with%202%20unobserved%20confounders%2C%20purely%20mathematical%20SCM%29%0A-%20%60benchmarks%2Finteraction.py%60%20%E2%86%92%20%60InteractionBenchmark%60%20%28two-boolean%20interaction%20benchmark%2C%20fully%20synthetic%29%0A%0ABoth%20are%20domain-free.%20Their%20absence%20makes%20the%20portable%20inventory%20look%20smaller%20than%20it%20is%20and%20affects%20the%20%224%20of%207%22%20ratio%20cited%20in%20%C2%A72e.%0A%0A%23%23%23%20Issue%204%20of%204%0Athoughts%2Fshared%2Fdocs%2Fsprint-30-general-causal-portability-brief.md%3A133-140%0A**Parenthetical%20variable%20list%20is%20missing%20one%20variable**%0A%0AThe%20description%20says%20%226%20continuous%20variables%20%28eligibility%20threshold%2C%20channel%20allocation%2C%20propensity%20clip%2C%20regularization%2C%20treatment%20budget%29%22%20%E2%80%94%20but%20that%20parenthetical%20lists%20only%205%20conceptual%20entries.%20The%20actual%20%60MarketingLogAdapter.get_search_space%28%29%60%20defines%20**two**%20channel%20variables%20%28%60email_share%60%20and%20%60social_share_of_remainder%60%29%2C%20which%20are%20collapsed%20here%20into%20the%20single%20label%20%22channel%20allocation.%22%20The%20count%20is%20correct%20but%20the%20list%20silently%20drops%20%60social_share_of_remainder%60.%0A%0A%60%60%60suggestion%0A%7C%20Search%20space%20%7C%206%20continuous%20variables%20%28eligibility%20threshold%2C%20email%20share%2C%20social%20share%20of%20remainder%2C%20propensity%20clip%2C%20regularization%2C%20treatment%20budget%29%20%7C%0A%60%60%60%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
Line: 116-120

Comment:
**Self-contradictory benchmark count in §2e**

The paragraph states "4 of 7 active benchmark rows use ERCOT covariates" and then immediately says "The dose-response benchmark is the **only** non-energy active row." Those two claims are incompatible: if 4 of 7 use ERCOT then 3 are non-energy, not 1. The table in §2d directly above this paragraph already lists four domain-portable benchmarks (DoseResponse, ToyGraph, HighDimensional, InteractionSCM), making "the only non-energy active row" obviously wrong. Please reconcile the count and the "only" claim — the table is the accurate part.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
Line: 74-83

Comment:
**Energy-specific benchmark inventory incomplete**

`causal_optimizer/benchmarks/counterfactual_variants.py` is absent from this table. It contains three energy-specific variants — `MediumNoiseDemandResponse`, `HighNoiseDemandResponse`, and `ConfoundedDemandResponse` — all built on ERCOT covariates and contributing to the "demand-response x3" rows cited in the PR description's key-findings table. Omitting it from the inventory understates the energy concentration of the benchmark suite.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
Line: 87-96

Comment:
**Domain-portable benchmark inventory incomplete**

Two synthetic benchmarks are missing from this table:

- `benchmarks/complete_graph.py` → `CompleteGraphBenchmark` (7-variable DAG with 2 unobserved confounders, purely mathematical SCM)
- `benchmarks/interaction.py` → `InteractionBenchmark` (two-boolean interaction benchmark, fully synthetic)

Both are domain-free. Their absence makes the portable inventory look smaller than it is and affects the "4 of 7" ratio cited in §2e.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-30-general-causal-portability-brief.md
Line: 133-140

Comment:
**Parenthetical variable list is missing one variable**

The description says "6 continuous variables (eligibility threshold, channel allocation, propensity clip, regularization, treatment budget)" — but that parenthetical lists only 5 conceptual entries. The actual `MarketingLogAdapter.get_search_space()` defines **two** channel variables (`email_share` and `social_share_of_remainder`), which are collapsed here into the single label "channel allocation." The count is correct but the list silently drops `social_share_of_remainder`.

```suggestion
| Search space | 6 continuous variables (eligibility threshold, email share, social share of remainder, propensity clip, regularization, treatment budget) |
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: Sprint 30 general-causal portabili..."](https://github.com/datablogin/causal-optimizer/commit/962bea6a923ea6c0793ab7609c1390560d43b4b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28138241)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->