### PR TITLE
feat: Sprint 31 Hillstrom benchmark harness

### DIFF
--- a/causal_optimizer/benchmarks/__init__.py
+++ b/causal_optimizer/benchmarks/__init__.py
@@ -27,6 +27,23 @@ from causal_optimizer.benchmarks.dose_response import (
     evaluate_protocol,
 )
 from causal_optimizer.benchmarks.high_dimensional import HighDimensionalSparseBenchmark
+from causal_optimizer.benchmarks.hillstrom import (
+    HILLSTROM_FROZEN_PARAMS,
+    HILLSTROM_POOLED_PROPENSITY,
+    HILLSTROM_PRIMARY_PROPENSITY,
+    HillstromBenchmarkResult,
+    HillstromPolicyRunner,
+    HillstromScenario,
+    HillstromSliceType,
+    hillstrom_active_search_space,
+    hillstrom_null_baseline,
+    hillstrom_projected_prior_graph,
+    load_hillstrom_slice,
+    permute_hillstrom_spend,
+)
+from causal_optimizer.benchmarks.hillstrom import (
+    VALID_STRATEGIES as HILLSTROM_VALID_STRATEGIES,
+)
 from causal_optimizer.benchmarks.interaction import InteractionBenchmark
 from causal_optimizer.benchmarks.interaction_policy import (
     InteractionPolicyScenario,
@@ -81,6 +98,10 @@ class BenchmarkSCM(Protocol):
 
 
 __all__ = [
+    "HILLSTROM_FROZEN_PARAMS",
+    "HILLSTROM_POOLED_PROPENSITY",
+    "HILLSTROM_PRIMARY_PROPENSITY",
+    "HILLSTROM_VALID_STRATEGIES",
     "BenchmarkResult",
     "BenchmarkRunner",
     "BenchmarkSCM",
@@ -92,10 +113,14 @@ __all__ = [
     "DoseResponseScenario",
     "HighDimensionalSparseBenchmark",
     "HighNoiseDemandResponse",
+    "HillstromBenchmarkResult",
+    "HillstromPolicyRunner",
+    "HillstromScenario",
+    "HillstromSliceType",
     "InteractionBenchmark",
     "InteractionPolicyScenario",
-    "MediumNoiseDemandResponse",
     "InteractionSCM",
+    "MediumNoiseDemandResponse",
     "NullSignalResult",
     "PolicyRunner",
     "PredictiveBenchmarkResult",
@@ -108,10 +133,15 @@ __all__ = [
     "evaluate_on_test",
     "evaluate_policy",
     "evaluate_protocol",
+    "hillstrom_active_search_space",
+    "hillstrom_null_baseline",
+    "hillstrom_projected_prior_graph",
     "interaction_propensity",
     "interaction_treatment_effect",
     "load_energy_frame",
+    "load_hillstrom_slice",
     "net_benefit",
+    "permute_hillstrom_spend",
     "permute_target",
     "propensity",
     "run_null_strategy",

--- a/causal_optimizer/benchmarks/hillstrom.py
+++ b/causal_optimizer/benchmarks/hillstrom.py
@@ -1,0 +1,587 @@
+"""Sprint 31 Hillstrom benchmark harness.
+
+Implements the launch contract locked in the Sprint 31 Hillstrom
+benchmark contract doc. Reuses ``MarketingLogAdapter`` unchanged via a
+narrow loader + wrapped runner pattern; no changes to
+``causal_optimizer/domain_adapters/marketing_logs.py`` are required.
+
+Contract anchors
+----------------
+
+- Primary slice: ``Womens E-Mail`` vs ``No E-Mail`` (binary).
+- Pooled secondary slice: ``Any E-Mail`` (``Mens E-Mail`` +
+  ``Womens E-Mail``) vs ``No E-Mail`` (binary).
+- Per-slice propensity pinned as an exact constant:
+  ``0.5`` for the primary slice (computed as ``(1/3) / (2/3)``) and
+  ``2.0 / 3.0`` for the pooled slice (computed as ``2.0 / 3.0`` in
+  code, not a rounded constant).
+- Frozen parameter dimensions (pre-baked in every forwarded call):
+  ``email_share = 1.0``, ``social_share_of_remainder = 0.0``,
+  ``min_propensity_clip = 0.01``. Active tuned search space is therefore
+  3 variables: ``eligibility_threshold``, ``regularization``,
+  ``treatment_budget_pct``.
+- Prior graph: projected to the 7-edge sub-DAG over the active nodes.
+  The three frozen variables and the 7 edges incident to them are
+  dropped.
+- Null control: permuted-outcome null baseline is the raw scalar
+  ``μ = mean(spend)`` computed on the unshuffled reshaped frame; this
+  avoids the misleading "``policy_value`` under a uniform-treatment
+  policy" framing, which on randomized data only recovers the
+  treated-arm mean (see ``marketing_logs.py:322``).
+
+Public API
+----------
+- :class:`HillstromSliceType`
+- :func:`load_hillstrom_slice`
+- :func:`hillstrom_active_search_space`
+- :func:`hillstrom_projected_prior_graph`
+- :class:`HillstromPolicyRunner`
+- :func:`permute_hillstrom_spend`
+- :func:`hillstrom_null_baseline`
+- :class:`HillstromBenchmarkResult`
+- :class:`HillstromScenario`
+- :data:`HILLSTROM_FROZEN_PARAMS`
+- :data:`HILLSTROM_PRIMARY_PROPENSITY`
+- :data:`HILLSTROM_POOLED_PROPENSITY`
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from causal_optimizer.benchmarks.runner import sample_random_params
+from causal_optimizer.domain_adapters.marketing_logs import MarketingLogAdapter
+from causal_optimizer.engine.loop import ExperimentEngine
+from causal_optimizer.types import (
+    CausalGraph,
+    SearchSpace,
+    Variable,
+    VariableType,
+)
+
+# ── Contract constants ──────────────────────────────────────────────
+
+HILLSTROM_PRIMARY_PROPENSITY: float = 0.5
+"""Primary slice propensity: ``(1/3) / (2/3) = 0.5`` exactly."""
+
+HILLSTROM_POOLED_PROPENSITY: float = 2.0 / 3.0
+"""Pooled slice propensity: ``(1/3 + 1/3) / 1 = 2/3`` exactly.
+
+Computed as ``2.0 / 3.0`` rather than a rounded constant like ``0.667``
+so the Sprint 31 smoke-test invariant ``propensity == 2.0 / 3.0`` is
+bitwise-true on every pooled-slice row.
+"""
+
+HILLSTROM_FROZEN_PARAMS: dict[str, float] = {
+    "email_share": 1.0,
+    "social_share_of_remainder": 0.0,
+    "min_propensity_clip": 0.01,
+}
+"""Frozen ``MarketingLogAdapter`` dimensions for Hillstrom.
+
+All three are degenerate on Hillstrom:
+
+- ``email_share`` and ``social_share_of_remainder``: Hillstrom treatment
+  is single-channel e-mail, so there is no cross-channel allocation
+  problem to solve.
+- ``min_propensity_clip``: propensity is a per-slice constant
+  (``0.5`` or ``2/3``) and both are ``>= 0.5`` (the upper bound of
+  ``min_propensity_clip``'s range), so the clip never activates and
+  the optimizer sees a flat response surface along this dimension.
+"""
+
+HILLSTROM_TREATED_ARMS: frozenset[str] = frozenset({"Mens E-Mail", "Womens E-Mail"})
+HILLSTROM_CONTROL_ARM: str = "No E-Mail"
+HILLSTROM_TREATED_COST: float = 0.10
+HILLSTROM_CONTROL_COST: float = 0.0
+
+# history_segment bucket map — matches the raw Hillstrom CSV strings,
+# numeric prefix included, per Sprint 31 contract Section 3c.
+_HISTORY_SEGMENT_TO_SEGMENT: dict[str, str] = {
+    "1) $0 - $100": "low",
+    "2) $100 - $200": "low",
+    "3) $200 - $350": "medium",
+    "4) $350 - $500": "medium",
+    "5) $500 - $750": "high_value",
+    "6) $750 - $1,000": "high_value",
+    "7) $1,000 +": "high_value",
+}
+
+
+# ── Slice type ───────────────────────────────────────────────────────
+
+
+class HillstromSliceType(str, Enum):
+    """Which Hillstrom binary slice to load.
+
+    ``PRIMARY``
+        ``Womens E-Mail`` (``treatment=1``) vs ``No E-Mail``
+        (``treatment=0``). Drops ``Mens E-Mail`` rows. Propensity is
+        exactly ``0.5``.
+    ``POOLED``
+        ``Any E-Mail`` (``Mens`` or ``Womens``, ``treatment=1``) vs
+        ``No E-Mail`` (``treatment=0``). Keeps every raw row.
+        Propensity is exactly ``2/3``.
+    """
+
+    PRIMARY = "primary"
+    POOLED = "pooled"
+
+
+# ── Loader ───────────────────────────────────────────────────────────
+
+
+def _treatment_from_segment(segment: pd.Series, slice_type: HillstromSliceType) -> pd.Series:
+    """Map the raw ``segment`` column to binary ``treatment``."""
+    if slice_type is HillstromSliceType.PRIMARY:
+        return (segment == "Womens E-Mail").astype(int)
+    return segment.isin(HILLSTROM_TREATED_ARMS).astype(int)
+
+
+def _propensity_for_slice(slice_type: HillstromSliceType) -> float:
+    if slice_type is HillstromSliceType.PRIMARY:
+        return HILLSTROM_PRIMARY_PROPENSITY
+    return HILLSTROM_POOLED_PROPENSITY
+
+
+def load_hillstrom_slice(
+    raw: pd.DataFrame,
+    *,
+    slice_type: HillstromSliceType,
+    treated_cost: float = HILLSTROM_TREATED_COST,
+    control_cost: float = HILLSTROM_CONTROL_COST,
+) -> pd.DataFrame:
+    """Reshape a raw Hillstrom frame into the ``MarketingLogAdapter`` schema.
+
+    Filters to the requested slice, maps ``segment`` → ``treatment``,
+    passes through ``spend`` → ``outcome``, assigns a constant per-slice
+    propensity, a fixed per-send cost, the constant ``channel = "email"``,
+    and a bucketed ``segment`` column derived from ``history_segment``.
+    The ``visit`` and ``conversion`` columns are retained on the output
+    frame as secondary reported outcomes (not as adapter descriptors),
+    matching Sprint 31 contract Section 4c.
+
+    Args:
+        raw: DataFrame with the canonical Hillstrom column schema.
+        slice_type: Which binary slice to produce.
+        treated_cost: Per-treated-row fixed cost. Defaults to
+            ``HILLSTROM_TREATED_COST``.
+        control_cost: Per-control-row fixed cost. Defaults to
+            ``HILLSTROM_CONTROL_COST``.
+
+    Returns:
+        A new DataFrame with the ``MarketingLogAdapter`` required
+        columns (``treatment``, ``outcome``, ``cost``) plus the optional
+        columns (``propensity``, ``channel``, ``segment``) and the
+        retained Hillstrom ``visit`` and ``conversion`` columns.
+
+    Raises:
+        ValueError: If ``raw`` is missing any required Hillstrom
+            column.
+    """
+    required = {"segment", "spend", "visit", "conversion", "history_segment"}
+    missing = required - set(raw.columns)
+    if missing:
+        msg = f"Hillstrom frame is missing required columns: {sorted(missing)}"
+        raise ValueError(msg)
+
+    frame = raw.copy()
+
+    # Slice filter
+    if slice_type is HillstromSliceType.PRIMARY:
+        keep = frame["segment"].isin({"Womens E-Mail", HILLSTROM_CONTROL_ARM})
+        frame = frame.loc[keep].reset_index(drop=True)
+    # Pooled slice keeps every row.
+
+    treatment = _treatment_from_segment(frame["segment"], slice_type)
+    propensity = _propensity_for_slice(slice_type)
+    cost = np.where(treatment == 1, treated_cost, control_cost)
+
+    # Bucket history_segment → {"low", "medium", "high_value"}. Any
+    # unknown bucket is mapped to "low" to avoid silent NaNs; this
+    # should not occur on canonical Hillstrom data but is defensive.
+    segment_bucket = frame["history_segment"].map(_HISTORY_SEGMENT_TO_SEGMENT).fillna("low")
+
+    reshaped = pd.DataFrame(
+        {
+            "treatment": treatment.astype(int),
+            "outcome": frame["spend"].astype(float),
+            "cost": cost.astype(float),
+            "propensity": np.full(len(frame), propensity, dtype=float),
+            "channel": "email",
+            "segment": segment_bucket.astype(str),
+            # Retained Hillstrom outcomes as secondary reported outcomes.
+            "visit": frame["visit"].astype(int),
+            "conversion": frame["conversion"].astype(int),
+        }
+    )
+
+    return reshaped
+
+
+# ── Active search space ──────────────────────────────────────────────
+
+
+_ACTIVE_VAR_NAMES: tuple[str, ...] = (
+    "eligibility_threshold",
+    "regularization",
+    "treatment_budget_pct",
+)
+
+
+def hillstrom_active_search_space() -> SearchSpace:
+    """Return the 3-variable active search space for Hillstrom.
+
+    Bounds are inherited from ``MarketingLogAdapter.get_search_space()``
+    so the active subspace is numerically identical to the adapter's
+    native ranges for the three tuned dimensions. The three frozen
+    dimensions (``email_share``, ``social_share_of_remainder``,
+    ``min_propensity_clip``) are pre-baked by
+    :class:`HillstromPolicyRunner` and do not appear in this space.
+    """
+    # Build a throwaway adapter against a minimal placeholder frame to
+    # extract the canonical bounds. Note: the adapter's __init__ requires
+    # non-empty data with treatment/outcome/cost columns, so we use a
+    # 2-row stub. This is not a data dependency — it only reads the
+    # adapter's static variable bounds.
+    stub = pd.DataFrame(
+        {
+            "treatment": [0, 1],
+            "outcome": [0.0, 1.0],
+            "cost": [0.0, 0.0],
+        }
+    )
+    full = MarketingLogAdapter(data=stub).get_search_space()
+    by_name = {v.name: v for v in full.variables}
+    variables = [
+        Variable(
+            name=name,
+            variable_type=VariableType.CONTINUOUS,
+            lower=by_name[name].lower,
+            upper=by_name[name].upper,
+        )
+        for name in _ACTIVE_VAR_NAMES
+    ]
+    return SearchSpace(variables=variables)
+
+
+# ── Projected prior graph ────────────────────────────────────────────
+
+
+def hillstrom_projected_prior_graph() -> CausalGraph:
+    """Return the 7-edge projected prior graph for Hillstrom.
+
+    The projection drops the 3 frozen variables and the 7 edges
+    incident to them from ``MarketingLogAdapter.get_prior_graph()``,
+    leaving a sub-DAG over the active nodes. See Sprint 31 contract
+    Section 4a.i for the enumeration and rationale.
+    """
+    return CausalGraph(
+        edges=[
+            ("eligibility_threshold", "treated_fraction"),
+            ("treatment_budget_pct", "treated_fraction"),
+            ("regularization", "treated_fraction"),
+            ("regularization", "policy_value"),
+            ("treated_fraction", "total_cost"),
+            ("treated_fraction", "policy_value"),
+            ("treated_fraction", "effective_sample_size"),
+        ],
+    )
+
+
+# ── Wrapped runner ───────────────────────────────────────────────────
+
+
+class HillstromPolicyRunner:
+    """ExperimentRunner that pre-bakes frozen params before adapter call.
+
+    Accepts an active-only parameter dict (with the three tuned
+    variables) and forwards to ``MarketingLogAdapter.run_experiment``
+    after injecting the three frozen constants in
+    :data:`HILLSTROM_FROZEN_PARAMS`. Does not mutate the caller's dict
+    and does not modify the adapter.
+
+    The returned metrics include ``MarketingLogAdapter``'s full
+    per-run dict (``policy_value``, ``total_cost``, ``treated_fraction``,
+    ``effective_sample_size``, ``propensity_clip_fraction``,
+    ``max_ips_weight``, ``weight_cv``, ``zero_support``) plus an
+    ``objective`` alias equal to the negated ``policy_value`` — because
+    ``policy_value`` is maximized but the engine minimizes ``objective``.
+    """
+
+    def __init__(self, adapter: MarketingLogAdapter) -> None:
+        self._adapter = adapter
+
+    def _forward_params(self, active_params: dict[str, Any]) -> dict[str, Any]:
+        """Return a new dict with frozen params injected.
+
+        Does not mutate the caller's ``active_params`` dict.
+        """
+        forwarded: dict[str, Any] = dict(active_params)
+        for key, value in HILLSTROM_FROZEN_PARAMS.items():
+            forwarded[key] = value
+        return forwarded
+
+    def run(self, parameters: dict[str, Any]) -> dict[str, float]:
+        """Evaluate one active-only parameter dict on the wrapped adapter."""
+        forwarded = self._forward_params(parameters)
+        metrics = self._adapter.run_experiment(forwarded)
+        # Engine minimizes "objective"; Hillstrom maximizes policy_value.
+        metrics["objective"] = -metrics["policy_value"]
+        return metrics
+
+
+# ── Null control helpers ─────────────────────────────────────────────
+
+
+def permute_hillstrom_spend(
+    reshaped: pd.DataFrame, *, seed: int, outcome_col: str = "outcome"
+) -> pd.DataFrame:
+    """Return a copy of ``reshaped`` with the ``outcome`` column permuted.
+
+    The permutation is deterministic in ``seed`` and preserves:
+
+    - the multiset of ``outcome`` values (permutation of the same column
+      — so ``μ = mean(outcome)`` is identical on the original and the
+      shuffled frame)
+    - every other column, including ``treatment``, ``propensity``,
+      ``cost``, ``channel``, ``segment``, ``visit``, and ``conversion``.
+
+    Args:
+        reshaped: A frame already reshaped by :func:`load_hillstrom_slice`.
+        seed: RNG seed. Use one seed per null-control replicate.
+        outcome_col: Name of the column to permute. Defaults to
+            ``"outcome"``.
+
+    Returns:
+        A new frame with the outcome column shuffled; the original
+        frame is not modified.
+
+    Raises:
+        ValueError: If ``outcome_col`` is not in the frame.
+    """
+    if outcome_col not in reshaped.columns:
+        raise ValueError(f"column {outcome_col!r} not in reshaped frame")
+    out = reshaped.copy()
+    rng = np.random.default_rng(seed)
+    values = out[outcome_col].to_numpy().copy()
+    rng.shuffle(values)
+    out[outcome_col] = values
+    return out
+
+
+def hillstrom_null_baseline(reshaped: pd.DataFrame, *, outcome_col: str = "outcome") -> float:
+    """Return the Sprint 31 null-control baseline ``μ = mean(outcome)``.
+
+    Called once on the original (unshuffled) reshaped frame; shuffling
+    is a permutation and does not change the column mean, so the same
+    scalar is used for every null-control seed.
+    """
+    return float(reshaped[outcome_col].astype(float).mean())
+
+
+# ── Benchmark scenario ───────────────────────────────────────────────
+
+
+_VALID_STRATEGIES: frozenset[str] = frozenset({"random", "surrogate_only", "causal"})
+
+
+@dataclass
+class HillstromBenchmarkResult:
+    """Result of running one strategy on one Hillstrom slice.
+
+    Attributes:
+        strategy: ``"random"`` / ``"surrogate_only"`` / ``"causal"``.
+        budget: Experiments run by the strategy.
+        seed: RNG seed for the optimizer.
+        slice_type: ``"primary"`` or ``"pooled"``.
+        is_null_control: ``True`` when evaluated on a permuted-outcome
+            frame (Sprint 31 null-control path).
+        policy_value: Best ``policy_value`` found by the strategy on the
+            given slice (higher is better).
+        selected_parameters: Best active-only parameter dict, or
+            ``None`` if no valid result was produced.
+        runtime_seconds: Wall-clock time for the full strategy run.
+    """
+
+    strategy: str
+    budget: int
+    seed: int
+    slice_type: str
+    is_null_control: bool
+    policy_value: float
+    selected_parameters: dict[str, Any] | None = None
+    runtime_seconds: float = 0.0
+    null_baseline: float | None = None
+    # Secondary reported outcomes — IPS-unweighted per-strategy aggregates
+    # taken over the logged observations matched by the best policy.
+    secondary_outcomes: dict[str, float] = field(default_factory=dict)
+
+
+class HillstromScenario:
+    """Top-level Hillstrom benchmark scenario.
+
+    Wraps a reshaped Hillstrom frame in a :class:`MarketingLogAdapter`
+    and a :class:`HillstromPolicyRunner`, then runs one strategy at a
+    given ``(budget, seed)`` pair. Supports both the real slice and
+    the permuted-outcome null-control path.
+
+    Note: the scenario is intended as the unit of work for the Sprint 31
+    benchmark runner; a separate CLI script composes scenarios over a
+    grid of (strategy, budget, seed) combinations.
+    """
+
+    def __init__(
+        self,
+        raw: pd.DataFrame,
+        *,
+        slice_type: HillstromSliceType,
+    ) -> None:
+        self._raw = raw
+        self._slice_type = slice_type
+        self._real_slice = load_hillstrom_slice(raw, slice_type=slice_type)
+        # The null-baseline μ is a scalar computed once from the real
+        # (unshuffled) frame; shuffling preserves the column mean.
+        self._null_baseline = hillstrom_null_baseline(self._real_slice)
+
+    @property
+    def slice_type(self) -> HillstromSliceType:
+        return self._slice_type
+
+    @property
+    def null_baseline(self) -> float:
+        return self._null_baseline
+
+    @property
+    def real_slice(self) -> pd.DataFrame:
+        return self._real_slice
+
+    def run_strategy(
+        self,
+        strategy: str,
+        *,
+        budget: int,
+        seed: int,
+        null_control: bool = False,
+    ) -> HillstromBenchmarkResult:
+        """Run one strategy on this scenario and return the result.
+
+        Args:
+            strategy: One of ``"random"``, ``"surrogate_only"``,
+                ``"causal"``.
+            budget: Number of experiments (adapter evaluations).
+            seed: Optimizer RNG seed.
+            null_control: When ``True``, the strategy runs against a
+                permuted-outcome copy of the reshaped frame. Permutation
+                seed is the same ``seed`` argument so null-control seeds
+                are reproducible.
+
+        Returns:
+            A :class:`HillstromBenchmarkResult`.
+
+        Raises:
+            ValueError: If ``strategy`` is not in ``_VALID_STRATEGIES``.
+        """
+        if strategy not in _VALID_STRATEGIES:
+            msg = f"Unknown strategy {strategy!r}. Must be one of {sorted(_VALID_STRATEGIES)}."
+            raise ValueError(msg)
+
+        t_start = time.perf_counter()
+
+        frame = (
+            permute_hillstrom_spend(self._real_slice, seed=seed)
+            if null_control
+            else self._real_slice
+        )
+        adapter = MarketingLogAdapter(data=frame, seed=seed)
+        runner = HillstromPolicyRunner(adapter=adapter)
+        space = hillstrom_active_search_space()
+
+        best_policy_value = float("-inf")
+        best_params: dict[str, Any] | None = None
+
+        if strategy == "random":
+            rng = np.random.default_rng(seed)
+            for _ in range(budget):
+                params = sample_random_params(space, rng)
+                metrics = runner.run(params)
+                pv = metrics["policy_value"]
+                if pv > best_policy_value:
+                    best_policy_value = pv
+                    best_params = params
+        else:
+            graph = hillstrom_projected_prior_graph() if strategy == "causal" else None
+            engine = ExperimentEngine(
+                search_space=space,
+                runner=runner,
+                causal_graph=graph,
+                objective_name="objective",
+                minimize=True,
+                seed=seed,
+            )
+            engine.run_loop(budget)
+            best_result = engine.log.best_result("objective", minimize=True)
+            if best_result is not None:
+                best_params = best_result.parameters
+                best_policy_value = best_result.metrics.get("policy_value", float("-inf"))
+
+        runtime = time.perf_counter() - t_start
+
+        secondary: dict[str, float] = {}
+        if best_params is not None and not null_control:
+            # Secondary outcomes: IPS-unweighted treated-arm means of the
+            # retained Hillstrom columns, taken over the rows actually
+            # selected by the best policy. This is a report-time
+            # diagnostic, not an optimization target.
+            secondary = _secondary_outcomes_under_policy(frame, best_params)
+
+        return HillstromBenchmarkResult(
+            strategy=strategy,
+            budget=budget,
+            seed=seed,
+            slice_type=self._slice_type.value,
+            is_null_control=null_control,
+            policy_value=(
+                best_policy_value if best_policy_value != float("-inf") else float("nan")
+            ),
+            selected_parameters=best_params,
+            runtime_seconds=runtime,
+            null_baseline=self._null_baseline,
+            secondary_outcomes=secondary,
+        )
+
+
+def _secondary_outcomes_under_policy(
+    frame: pd.DataFrame, params: dict[str, Any]
+) -> dict[str, float]:
+    """Compute IPS-unweighted per-strategy aggregates for secondary outcomes.
+
+    The contract (Section 4c) says ``visit`` and ``conversion`` should
+    be tracked as secondary reported outcomes on the observations matched
+    by each seed's best policy. We approximate "matched by the policy" at
+    report time as "treatment == 1 AND selected by the adapter's
+    threshold+budget rule for the given params," which is the same
+    match-treat set the adapter uses internally. For the Sprint 31 smoke
+    harness we report the simple in-sample treated-arm means as a
+    diagnostic.
+    """
+    if "visit" not in frame.columns or "conversion" not in frame.columns:
+        return {}
+    # Treated-arm aggregates are adapter-independent diagnostics; they
+    # do not re-run the adapter and do not enter the optimizer objective.
+    treated_mask = frame["treatment"] == 1
+    control_mask = frame["treatment"] == 0
+    aggregates: dict[str, float] = {}
+    if int(treated_mask.sum()) > 0:
+        aggregates["treated_visit_rate"] = float(frame.loc[treated_mask, "visit"].mean())
+        aggregates["treated_conversion_rate"] = float(frame.loc[treated_mask, "conversion"].mean())
+    if int(control_mask.sum()) > 0:
+        aggregates["control_visit_rate"] = float(frame.loc[control_mask, "visit"].mean())
+        aggregates["control_conversion_rate"] = float(frame.loc[control_mask, "conversion"].mean())
+    return aggregates

--- a/causal_optimizer/benchmarks/hillstrom.py
+++ b/causal_optimizer/benchmarks/hillstrom.py
@@ -389,7 +389,13 @@ def hillstrom_null_baseline(reshaped: pd.DataFrame, *, outcome_col: str = "outco
 # ── Benchmark scenario ───────────────────────────────────────────────
 
 
-_VALID_STRATEGIES: frozenset[str] = frozenset({"random", "surrogate_only", "causal"})
+VALID_STRATEGIES: frozenset[str] = frozenset({"random", "surrogate_only", "causal"})
+"""Public set of strategy names accepted by :class:`HillstromScenario`.
+
+Exported so that CLI wrappers and downstream callers import the same
+source of truth rather than redefining their own frozenset — a local
+copy would drift silently if a new strategy were added here.
+"""
 
 
 @dataclass
@@ -486,10 +492,10 @@ class HillstromScenario:
             A :class:`HillstromBenchmarkResult`.
 
         Raises:
-            ValueError: If ``strategy`` is not in ``_VALID_STRATEGIES``.
+            ValueError: If ``strategy`` is not in ``VALID_STRATEGIES``.
         """
-        if strategy not in _VALID_STRATEGIES:
-            msg = f"Unknown strategy {strategy!r}. Must be one of {sorted(_VALID_STRATEGIES)}."
+        if strategy not in VALID_STRATEGIES:
+            msg = f"Unknown strategy {strategy!r}. Must be one of {sorted(VALID_STRATEGIES)}."
             raise ValueError(msg)
 
         t_start = time.perf_counter()
@@ -535,11 +541,12 @@ class HillstromScenario:
 
         secondary: dict[str, float] = {}
         if best_params is not None and not null_control:
-            # Secondary outcomes: IPS-unweighted treated-arm means of the
-            # retained Hillstrom columns, taken over the rows actually
-            # selected by the best policy. This is a report-time
-            # diagnostic, not an optimization target.
-            secondary = _secondary_outcomes_under_policy(frame, best_params)
+            # Secondary outcomes: IPS-unweighted in-sample treated/control-arm
+            # means of the retained Hillstrom columns on the reshaped frame.
+            # These are report-time diagnostics, not policy-filtered —
+            # policy-conditioned secondary outcomes are deferred to a later
+            # sprint (Sprint 32+) when uplift/CATE scoring is in scope.
+            secondary = _secondary_outcomes_under_policy(frame)
 
         return HillstromBenchmarkResult(
             strategy=strategy,
@@ -557,19 +564,20 @@ class HillstromScenario:
         )
 
 
-def _secondary_outcomes_under_policy(
-    frame: pd.DataFrame, params: dict[str, Any]
-) -> dict[str, float]:
-    """Compute IPS-unweighted per-strategy aggregates for secondary outcomes.
+def _secondary_outcomes_under_policy(frame: pd.DataFrame) -> dict[str, float]:
+    """Compute in-sample treated/control-arm aggregates for secondary outcomes.
 
-    The contract (Section 4c) says ``visit`` and ``conversion`` should
-    be tracked as secondary reported outcomes on the observations matched
-    by each seed's best policy. We approximate "matched by the policy" at
-    report time as "treatment == 1 AND selected by the adapter's
-    threshold+budget rule for the given params," which is the same
-    match-treat set the adapter uses internally. For the Sprint 31 smoke
-    harness we report the simple in-sample treated-arm means as a
-    diagnostic.
+    The Sprint 31 contract (Section 4c) says ``visit`` and ``conversion``
+    should be tracked as secondary reported outcomes. The Sprint 31
+    harness reports simple in-sample treated-arm and control-arm means
+    on the reshaped frame as a diagnostic — it does **not** filter to
+    the policy's selected observations. Policy-conditioned secondary
+    outcomes (uplift- or CATE-filtered subpopulations) are deferred to a
+    later sprint when learned uplift scoring is in scope.
+
+    These aggregates are adapter-independent and do not re-run the
+    adapter; they are derived purely from the reshaped frame's
+    ``treatment``, ``visit``, and ``conversion`` columns.
     """
     if "visit" not in frame.columns or "conversion" not in frame.columns:
         return {}

--- a/causal_optimizer/benchmarks/hillstrom.py
+++ b/causal_optimizer/benchmarks/hillstrom.py
@@ -47,6 +47,7 @@ Public API
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass, field
 from enum import Enum
@@ -473,7 +474,10 @@ class HillstromScenario:
         *,
         slice_type: HillstromSliceType,
     ) -> None:
-        self._raw = raw
+        # The raw frame is only used here to produce the reshaped slice;
+        # it is not stored because it can be substantially larger than
+        # the slice (especially for the primary slice, which drops the
+        # Mens arm) and the scenario never needs to re-read it.
         self._slice_type = slice_type
         self._real_slice = load_hillstrom_slice(raw, slice_type=slice_type)
         # The null-baseline μ is a scalar computed once from the real
@@ -588,9 +592,7 @@ class HillstromScenario:
             seed=seed,
             slice_type=self._slice_type.value,
             is_null_control=null_control,
-            policy_value=(
-                best_policy_value if best_policy_value != float("-inf") else float("nan")
-            ),
+            policy_value=(best_policy_value if math.isfinite(best_policy_value) else float("nan")),
             selected_parameters=best_params,
             runtime_seconds=runtime,
             null_baseline=self._null_baseline,

--- a/causal_optimizer/benchmarks/hillstrom.py
+++ b/causal_optimizer/benchmarks/hillstrom.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass, field
 from enum import Enum
+from functools import lru_cache
 from typing import Any
 
 import numpy as np
@@ -68,10 +69,18 @@ from causal_optimizer.types import (
 # ── Contract constants ──────────────────────────────────────────────
 
 HILLSTROM_PRIMARY_PROPENSITY: float = 0.5
-"""Primary slice propensity: ``(1/3) / (2/3) = 0.5`` exactly."""
+"""Primary slice propensity: ``P(treated | row in primary slice) = 0.5``.
+
+Derivation: each of Hillstrom's three arms (``Mens E-Mail``,
+``Womens E-Mail``, ``No E-Mail``) is randomized at ``P = 1/3``. After
+dropping the ``Mens E-Mail`` arm, the primary slice contains the
+``Womens E-Mail`` and ``No E-Mail`` arms. Conditional on a row being in
+the slice, ``P(treated) = P(Womens) / (P(Womens) + P(None)) =
+(1/3) / (1/3 + 1/3) = 0.5``.
+"""
 
 HILLSTROM_POOLED_PROPENSITY: float = 2.0 / 3.0
-"""Pooled slice propensity: ``(1/3 + 1/3) / 1 = 2/3`` exactly.
+"""Pooled slice propensity: ``P(treated | row in pooled slice) = 2/3`` exactly.
 
 Computed as ``2.0 / 3.0`` rather than a rounded constant like ``0.667``
 so the Sprint 31 smoke-test invariant ``propensity == 2.0 / 3.0`` is
@@ -235,6 +244,7 @@ _ACTIVE_VAR_NAMES: tuple[str, ...] = (
 )
 
 
+@lru_cache(maxsize=1)
 def hillstrom_active_search_space() -> SearchSpace:
     """Return the 3-variable active search space for Hillstrom.
 
@@ -244,9 +254,16 @@ def hillstrom_active_search_space() -> SearchSpace:
     dimensions (``email_share``, ``social_share_of_remainder``,
     ``min_propensity_clip``) are pre-baked by
     :class:`HillstromPolicyRunner` and do not appear in this space.
+
+    The result is cached at module level (``lru_cache(maxsize=1)``)
+    because the adapter's native bounds are constants — there is no
+    per-call state to recompute. ``HillstromScenario.run_strategy``
+    calls this on every ``(strategy, budget, seed)`` combination, so
+    caching avoids rebuilding a throwaway adapter each time.
     """
     # Build a throwaway adapter against a minimal placeholder frame to
-    # extract the canonical bounds. Note: the adapter's __init__ requires
+    # extract the canonical bounds. Runs exactly once per process thanks
+    # to the lru_cache decorator. The adapter's __init__ requires
     # non-empty data with treatment/outcome/cost columns, so we use a
     # 2-row stub. This is not a data dependency — it only reads the
     # adapter's static variable bounds.
@@ -537,6 +554,22 @@ class HillstromScenario:
                 best_params = best_result.parameters
                 best_policy_value = best_result.metrics.get("policy_value", float("-inf"))
 
+        # Invariant: the engine-logged best parameters must contain only the
+        # 3 active-only dimensions. Frozen dimensions are injected by
+        # HillstromPolicyRunner before the adapter call and must never leak
+        # back into the experiment log — if they did, downstream readers
+        # would mis-identify the Hillstrom search scope. This assertion
+        # guards the "loader + wrapped runner" contract boundary against a
+        # future engine change that could start forwarding runner-side
+        # metadata back into the logged parameters.
+        if best_params is not None:
+            assert set(best_params) == set(_ACTIVE_VAR_NAMES), (
+                f"HillstromScenario: best_params has unexpected keys "
+                f"{sorted(best_params)!r}; expected exactly "
+                f"{sorted(_ACTIVE_VAR_NAMES)!r}. Frozen Hillstrom dimensions "
+                f"must not appear in the experiment log."
+            )
+
         runtime = time.perf_counter() - t_start
 
         secondary: dict[str, float] = {}
@@ -546,7 +579,7 @@ class HillstromScenario:
             # These are report-time diagnostics, not policy-filtered —
             # policy-conditioned secondary outcomes are deferred to a later
             # sprint (Sprint 32+) when uplift/CATE scoring is in scope.
-            secondary = _secondary_outcomes_under_policy(frame)
+            secondary = _secondary_arm_aggregates(frame)
 
         return HillstromBenchmarkResult(
             strategy=strategy,
@@ -564,7 +597,7 @@ class HillstromScenario:
         )
 
 
-def _secondary_outcomes_under_policy(frame: pd.DataFrame) -> dict[str, float]:
+def _secondary_arm_aggregates(frame: pd.DataFrame) -> dict[str, float]:
     """Compute in-sample treated/control-arm aggregates for secondary outcomes.
 
     The Sprint 31 contract (Section 4c) says ``visit`` and ``conversion``

--- a/causal_optimizer/benchmarks/hillstrom.py
+++ b/causal_optimizer/benchmarks/hillstrom.py
@@ -244,6 +244,25 @@ _ACTIVE_VAR_NAMES: tuple[str, ...] = (
     "treatment_budget_pct",
 )
 
+_HILLSTROM_ENGINE_OBJECTIVE: str = "policy_value"
+"""The string passed to ``ExperimentEngine`` as ``objective_name``.
+
+This constant is the single source of truth that couples:
+
+1. the engine's ``objective_name`` argument in
+   :meth:`HillstromScenario.run_strategy`,
+2. the sink node of :func:`hillstrom_projected_prior_graph`,
+3. the metric key :class:`HillstromPolicyRunner` returns unmodified
+   from :class:`MarketingLogAdapter`.
+
+If the projected graph's sink node and the engine's objective_name
+ever drift, the causal optimizer's ancestor/parent lookups in
+``optimizer/suggest.py`` and ``predictor/off_policy.py`` return empty
+sets and the causal path silently degrades to surrogate-only
+behavior without any test failure. Pinning this as a shared constant
+makes the coupling explicit and testable.
+"""
+
 
 @lru_cache(maxsize=1)
 def hillstrom_active_search_space() -> SearchSpace:
@@ -343,12 +362,17 @@ class HillstromPolicyRunner:
     :data:`HILLSTROM_FROZEN_PARAMS`. Does not mutate the caller's dict
     and does not modify the adapter.
 
-    The returned metrics include ``MarketingLogAdapter``'s full
-    per-run dict (``policy_value``, ``total_cost``, ``treated_fraction``,
+    The returned metrics are ``MarketingLogAdapter``'s full per-run
+    dict (``policy_value``, ``total_cost``, ``treated_fraction``,
     ``effective_sample_size``, ``propensity_clip_fraction``,
-    ``max_ips_weight``, ``weight_cv``, ``zero_support``) plus an
-    ``objective`` alias equal to the negated ``policy_value`` — because
-    ``policy_value`` is maximized but the engine minimizes ``objective``.
+    ``max_ips_weight``, ``weight_cv``, ``zero_support``). The
+    :class:`HillstromScenario` runs the engine with
+    ``objective_name="policy_value"`` and ``minimize=False``, matching
+    the adapter's native ``get_minimize()`` semantics. No sign flip —
+    the engine maximizes ``policy_value`` directly, and the projected
+    prior graph's ``policy_value`` sink node is therefore the engine's
+    ``objective_name``, so the causal optimizer's ancestor/parent/focus
+    lookups receive the intended graph signal.
     """
 
     def __init__(self, adapter: MarketingLogAdapter) -> None:
@@ -367,10 +391,7 @@ class HillstromPolicyRunner:
     def run(self, parameters: dict[str, Any]) -> dict[str, float]:
         """Evaluate one active-only parameter dict on the wrapped adapter."""
         forwarded = self._forward_params(parameters)
-        metrics = self._adapter.run_experiment(forwarded)
-        # Engine minimizes "objective"; Hillstrom maximizes policy_value.
-        metrics["objective"] = -metrics["policy_value"]
-        return metrics
+        return self._adapter.run_experiment(forwarded)
 
 
 # ── Null control helpers ─────────────────────────────────────────────
@@ -461,8 +482,15 @@ class HillstromBenchmarkResult:
     selected_parameters: dict[str, Any] | None = None
     runtime_seconds: float = 0.0
     null_baseline: float | None = None
-    # Secondary reported outcomes — IPS-unweighted per-strategy aggregates
-    # taken over the logged observations matched by the best policy.
+    # Secondary reported outcomes: **full-slice** treated/control-arm
+    # means of ``visit`` and ``conversion`` on the reshaped frame.
+    # These are *not* policy-conditioned — they are properties of the
+    # dataset, not of the optimizer output, and they are therefore
+    # identical across strategies and seeds on the same slice.
+    # Policy-filtered secondary outcomes (uplift- or CATE-conditioned
+    # subpopulations) are deferred to a later sprint per Sprint 31
+    # contract Section 4c. See :func:`_secondary_arm_aggregates` for
+    # the exact computation.
     secondary_outcomes: dict[str, float] = field(default_factory=dict)
 
 
@@ -561,17 +589,26 @@ class HillstromScenario:
                     best_policy_value = pv
                     best_params = params
         else:
+            # Run the engine directly on ``policy_value`` with
+            # ``minimize=False`` so that the engine's objective_name
+            # matches the projected prior graph's sink node. This is
+            # load-bearing for the causal path: optimizer/suggest.py
+            # uses ``graph.ancestors(objective_name)`` and
+            # ``graph.parents(objective_name)`` to compute causal focus
+            # variables, and off_policy.py's observational estimator
+            # skips its causal path entirely when the objective node
+            # is missing from the graph.
             graph = hillstrom_projected_prior_graph() if strategy == "causal" else None
             engine = ExperimentEngine(
                 search_space=space,
                 runner=runner,
                 causal_graph=graph,
-                objective_name="objective",
-                minimize=True,
+                objective_name=_HILLSTROM_ENGINE_OBJECTIVE,
+                minimize=False,
                 seed=seed,
             )
             engine.run_loop(budget)
-            best_result = engine.log.best_result("objective", minimize=True)
+            best_result = engine.log.best_result(_HILLSTROM_ENGINE_OBJECTIVE, minimize=False)
             if best_result is not None:
                 best_params = best_result.parameters
                 best_policy_value = best_result.metrics.get("policy_value", float("-inf"))

--- a/causal_optimizer/benchmarks/hillstrom.py
+++ b/causal_optimizer/benchmarks/hillstrom.py
@@ -284,6 +284,17 @@ def hillstrom_active_search_space() -> SearchSpace:
     )
     full = MarketingLogAdapter(data=stub).get_search_space()
     by_name = {v.name: v for v in full.variables}
+    missing = [name for name in _ACTIVE_VAR_NAMES if name not in by_name]
+    if missing:
+        # Clearer failure mode than an opaque KeyError if MarketingLogAdapter
+        # ever renames or drops one of the 3 active Hillstrom dimensions.
+        msg = (
+            f"MarketingLogAdapter.get_search_space() is missing expected "
+            f"Hillstrom active variables {missing!r}. This breaks the "
+            f"Sprint 31 Hillstrom benchmark contract — the adapter must "
+            f"expose {sorted(_ACTIVE_VAR_NAMES)!r}."
+        )
+        raise RuntimeError(msg)
     variables = [
         Variable(
             name=name,

--- a/causal_optimizer/benchmarks/hillstrom.py
+++ b/causal_optimizer/benchmarks/hillstrom.py
@@ -260,6 +260,13 @@ def hillstrom_active_search_space() -> SearchSpace:
     per-call state to recompute. ``HillstromScenario.run_strategy``
     calls this on every ``(strategy, budget, seed)`` combination, so
     caching avoids rebuilding a throwaway adapter each time.
+
+    **Do not mutate the returned object.** Every caller shares the
+    same cached :class:`SearchSpace` instance. Appending or reassigning
+    ``variables`` on the returned space would corrupt it for all
+    subsequent callers in the process. Treat the returned search space
+    as read-only; if you need a modified copy, construct a new
+    :class:`SearchSpace` from its ``variables`` list.
     """
     # Build a throwaway adapter against a minimal placeholder frame to
     # extract the canonical bounds. Runs exactly once per process thanks
@@ -558,17 +565,11 @@ class HillstromScenario:
         # 3 active-only dimensions. Frozen dimensions are injected by
         # HillstromPolicyRunner before the adapter call and must never leak
         # back into the experiment log — if they did, downstream readers
-        # would mis-identify the Hillstrom search scope. This assertion
-        # guards the "loader + wrapped runner" contract boundary against a
-        # future engine change that could start forwarding runner-side
-        # metadata back into the logged parameters.
-        if best_params is not None:
-            assert set(best_params) == set(_ACTIVE_VAR_NAMES), (
-                f"HillstromScenario: best_params has unexpected keys "
-                f"{sorted(best_params)!r}; expected exactly "
-                f"{sorted(_ACTIVE_VAR_NAMES)!r}. Frozen Hillstrom dimensions "
-                f"must not appear in the experiment log."
-            )
+        # would mis-identify the Hillstrom search scope. This guards the
+        # "loader + wrapped runner" contract boundary against a future
+        # engine change that could start forwarding runner-side metadata
+        # back into the logged parameters.
+        _check_active_params_invariant(best_params)
 
         runtime = time.perf_counter() - t_start
 
@@ -595,6 +596,38 @@ class HillstromScenario:
             null_baseline=self._null_baseline,
             secondary_outcomes=secondary,
         )
+
+
+def _check_active_params_invariant(best_params: dict[str, Any] | None) -> None:
+    """Raise ``RuntimeError`` if ``best_params`` contains non-active keys.
+
+    Guards the "loader + wrapped runner" contract boundary: the
+    experiment log must only ever contain the 3 active Hillstrom
+    dimensions. Frozen dimensions are injected by
+    :class:`HillstromPolicyRunner` before the adapter call and must
+    never leak back into the optimizer log.
+
+    Raised as :class:`RuntimeError` (not :keyword:`assert`) so the
+    check still fires under ``python -O`` / ``PYTHONOPTIMIZE=1``.
+
+    Args:
+        best_params: The best parameter dict returned by the engine
+            log, or ``None`` if no valid result was produced.
+
+    Raises:
+        RuntimeError: If ``best_params`` is non-``None`` and contains
+            any key that is not in :data:`_ACTIVE_VAR_NAMES`.
+    """
+    if best_params is None:
+        return
+    if set(best_params) != set(_ACTIVE_VAR_NAMES):
+        msg = (
+            f"HillstromScenario: best_params has unexpected keys "
+            f"{sorted(best_params)!r}; expected exactly "
+            f"{sorted(_ACTIVE_VAR_NAMES)!r}. Frozen Hillstrom dimensions "
+            f"must not appear in the experiment log."
+        )
+        raise RuntimeError(msg)
 
 
 def _secondary_arm_aggregates(frame: pd.DataFrame) -> dict[str, float]:

--- a/scripts/hillstrom_benchmark.py
+++ b/scripts/hillstrom_benchmark.py
@@ -281,6 +281,14 @@ def main() -> None:
                         )
 
     # Null-control runs (primary slice only per Sprint 31 contract)
+    if args.null_control and "primary" not in scenarios:
+        logger.warning(
+            "--null-control was set but 'primary' is not in --slices %s; "
+            "null-control runs are scoped to the primary slice per Sprint 31 "
+            "contract Section 5g and will be skipped. Add 'primary' to --slices "
+            "to enable the null-control pass.",
+            slices,
+        )
     if args.null_control and "primary" in scenarios:
         null_budgets = [b for b in budgets if b <= 40] or [min(budgets)]
         primary = scenarios["primary"]

--- a/scripts/hillstrom_benchmark.py
+++ b/scripts/hillstrom_benchmark.py
@@ -37,6 +37,7 @@ import numpy as np
 import pandas as pd
 
 from causal_optimizer.benchmarks.hillstrom import (
+    VALID_STRATEGIES,
     HillstromBenchmarkResult,
     HillstromScenario,
     HillstromSliceType,
@@ -46,7 +47,6 @@ from causal_optimizer.benchmarks.provenance import collect_provenance
 
 logger = logging.getLogger(__name__)
 
-_VALID_STRATEGIES: frozenset[str] = frozenset({"random", "surrogate_only", "causal"})
 _VALID_SLICES: frozenset[str] = frozenset({"primary", "pooled"})
 
 
@@ -110,7 +110,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         action="store_true",
         help=(
             "When set, also run each strategy on a permuted-outcome copy of the "
-            "primary slice at B20 and B40. Null-control seeds are taken from --seeds."
+            "primary slice. Null-control uses the subset of --budgets that are "
+            "<= 40 (typically B20 and B40); if no budget in --budgets is <= 40, "
+            "the null pass falls back to min(--budgets). Null-control seeds are "
+            "taken from --seeds."
         ),
     )
     parser.add_argument(
@@ -141,9 +144,9 @@ def _validate_budgets(budgets: list[int]) -> None:
 
 def _validate_strategies(strategies: list[str]) -> None:
     for s in strategies:
-        if s not in _VALID_STRATEGIES:
+        if s not in VALID_STRATEGIES:
             print(
-                f"ERROR: Unknown strategy {s!r}. Must be one of {sorted(_VALID_STRATEGIES)}.",
+                f"ERROR: Unknown strategy {s!r}. Must be one of {sorted(VALID_STRATEGIES)}.",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/scripts/hillstrom_benchmark.py
+++ b/scripts/hillstrom_benchmark.py
@@ -327,13 +327,17 @@ def main() -> None:
 
     # Assemble JSON artifact with Hillstrom-specific provenance
     projected_graph = hillstrom_projected_prior_graph()
-    hillstrom_provenance = {
-        "slices": slices,
-        "null_control_enabled": bool(args.null_control),
-        "projected_graph_edge_count": len(projected_graph.edges),
-        "projected_graph_edges": [list(edge) for edge in projected_graph.edges],
-        "null_baselines": {name: scenario.null_baseline for name, scenario in scenarios.items()},
-    }
+    hillstrom_provenance = _sanitize_for_json(
+        {
+            "slices": slices,
+            "null_control_enabled": bool(args.null_control),
+            "projected_graph_edge_count": len(projected_graph.edges),
+            "projected_graph_edges": [list(edge) for edge in projected_graph.edges],
+            "null_baselines": {
+                name: scenario.null_baseline for name, scenario in scenarios.items()
+            },
+        }
+    )
     output_data = {
         "benchmark": "sprint_31_hillstrom",
         "suite_runtime_seconds": suite_runtime,

--- a/scripts/hillstrom_benchmark.py
+++ b/scripts/hillstrom_benchmark.py
@@ -1,0 +1,348 @@
+"""Hillstrom benchmark runner — Sprint 31 first non-energy benchmark.
+
+Runs random, surrogate-only, and causal strategies on a Hillstrom CSV
+at one or more budgets and seeds, across the primary and pooled
+slices, with an optional permuted-outcome null-control pass. Writes a
+provenance-stamped JSON artifact.
+
+The full Hillstrom CSV is local-only. The committed fixture
+``tests/fixtures/hillstrom_fixture.csv`` is a small synthetic,
+Hillstrom-shaped file intended for CI and smoke runs.
+
+Usage::
+
+    python scripts/hillstrom_benchmark.py \
+        --data-path tests/fixtures/hillstrom_fixture.csv \
+        --slices primary,pooled \
+        --budgets 20,40,80 \
+        --seeds 0,1,2,3,4 \
+        --strategies random,surrogate_only,causal \
+        --null-control \
+        --output hillstrom_results.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import logging
+import math
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from causal_optimizer.benchmarks.hillstrom import (
+    HillstromBenchmarkResult,
+    HillstromScenario,
+    HillstromSliceType,
+    hillstrom_projected_prior_graph,
+)
+from causal_optimizer.benchmarks.provenance import collect_provenance
+
+logger = logging.getLogger(__name__)
+
+_VALID_STRATEGIES: frozenset[str] = frozenset({"random", "surrogate_only", "causal"})
+_VALID_SLICES: frozenset[str] = frozenset({"primary", "pooled"})
+
+
+def _sanitize_for_json(obj: Any) -> Any:
+    """Recursively convert nested dict/list to JSON-safe Python types."""
+    if isinstance(obj, dict):
+        return {k: _sanitize_for_json(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_sanitize_for_json(v) for v in obj]
+    if isinstance(obj, np.integer):
+        return int(obj)
+    if isinstance(obj, np.floating):
+        val = float(obj)
+        return None if (math.isnan(val) or math.isinf(val)) else val
+    if isinstance(obj, np.bool_):
+        return bool(obj)
+    if isinstance(obj, float) and (math.isnan(obj) or math.isinf(obj)):
+        return None
+    return obj
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run the Sprint 31 Hillstrom benchmark across strategies, budgets, and seeds.",
+    )
+    parser.add_argument(
+        "--data-path",
+        required=True,
+        help=(
+            "Path to a Hillstrom CSV file. Must contain segment, spend, visit, "
+            "conversion, and history_segment columns with the canonical MineThatData "
+            "schema."
+        ),
+    )
+    parser.add_argument(
+        "--slices",
+        default="primary",
+        help=("Comma-separated slices to run (default: 'primary'). Valid values: primary, pooled."),
+    )
+    parser.add_argument(
+        "--budgets",
+        default="20,40,80",
+        help="Comma-separated experiment budgets (default: '20,40,80').",
+    )
+    parser.add_argument(
+        "--seeds",
+        default="0,1,2,3,4",
+        help="Comma-separated RNG seeds (default: '0,1,2,3,4').",
+    )
+    parser.add_argument(
+        "--strategies",
+        default="random,surrogate_only,causal",
+        help="Comma-separated strategies (default: 'random,surrogate_only,causal').",
+    )
+    parser.add_argument(
+        "--null-control",
+        action="store_true",
+        help=(
+            "When set, also run each strategy on a permuted-outcome copy of the "
+            "primary slice at B20 and B40. Null-control seeds are taken from --seeds."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        default="hillstrom_results.json",
+        help="Output JSON artifact path (default: 'hillstrom_results.json').",
+    )
+    return parser.parse_args(argv)
+
+
+def _parse_int_list(raw: str, label: str) -> list[int]:
+    try:
+        return [int(x.strip()) for x in raw.split(",")]
+    except ValueError as exc:
+        print(f"ERROR: --{label} must be comma-separated integers: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _validate_budgets(budgets: list[int]) -> None:
+    for b in budgets:
+        if b <= 0:
+            print(
+                f"ERROR: All budgets must be positive integers, got {b!r}.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+def _validate_strategies(strategies: list[str]) -> None:
+    for s in strategies:
+        if s not in _VALID_STRATEGIES:
+            print(
+                f"ERROR: Unknown strategy {s!r}. Must be one of {sorted(_VALID_STRATEGIES)}.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+def _validate_slices(slices: list[str]) -> None:
+    for s in slices:
+        if s not in _VALID_SLICES:
+            print(
+                f"ERROR: Unknown slice {s!r}. Must be one of {sorted(_VALID_SLICES)}.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+
+def _fmt_mean_std(values: list[float]) -> str:
+    if not values:
+        return "N/A"
+    arr = np.array(values)
+    return f"{arr.mean():.4f} +/- {arr.std():.4f}"
+
+
+def _print_summary(results: list[HillstromBenchmarkResult]) -> None:
+    """Print a compact summary grouped by (slice, null_control, strategy, budget)."""
+    groups: dict[tuple[str, bool, str, int], list[HillstromBenchmarkResult]] = {}
+    for r in results:
+        key = (r.slice_type, r.is_null_control, r.strategy, r.budget)
+        groups.setdefault(key, []).append(r)
+
+    header = (
+        f"{'Slice':<10} {'Null':<5} {'Strategy':<16} {'Budget':>6}  "
+        f"{'Policy Value':>24}  {'μ (baseline)':>14}"
+    )
+    print(header)
+    print("-" * len(header))
+    for (slice_type, is_null, strategy, budget), group in sorted(groups.items()):
+        pvals = [r.policy_value for r in group if math.isfinite(r.policy_value)]
+        mu = group[0].null_baseline if group[0].null_baseline is not None else float("nan")
+        print(
+            f"{slice_type:<10} "
+            f"{'yes' if is_null else 'no':<5} "
+            f"{strategy:<16} {budget:>6}  "
+            f"{_fmt_mean_std(pvals):>24}  "
+            f"{mu:>14.4f}"
+        )
+
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+
+def _load_raw(data_path: str) -> pd.DataFrame:
+    """Load a Hillstrom CSV or Parquet file."""
+    suffix = Path(data_path).suffix.lower()
+    if suffix == ".parquet":
+        return pd.read_parquet(data_path)
+    return pd.read_csv(data_path)
+
+
+def main() -> None:
+    """Entry point: parse args, run scenarios, write JSON artifact."""
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    args = parse_args()
+
+    slices = [s.strip() for s in args.slices.split(",") if s.strip()]
+    _validate_slices(slices)
+
+    budgets = _parse_int_list(args.budgets, "budgets")
+    _validate_budgets(budgets)
+
+    seeds = _parse_int_list(args.seeds, "seeds")
+
+    strategies = [s.strip() for s in args.strategies.split(",")]
+    _validate_strategies(strategies)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    raw = _load_raw(args.data_path)
+    logger.info(
+        "Loaded Hillstrom frame from %s (%d rows, %d cols)",
+        args.data_path,
+        len(raw),
+        len(raw.columns),
+    )
+
+    scenarios: dict[str, HillstromScenario] = {}
+    for slice_name in slices:
+        slice_type = HillstromSliceType(slice_name)
+        scenarios[slice_name] = HillstromScenario(raw, slice_type=slice_type)
+        logger.info(
+            "Prepared %s slice: %d rows, μ=%.4f",
+            slice_name,
+            len(scenarios[slice_name].real_slice),
+            scenarios[slice_name].null_baseline,
+        )
+
+    results: list[HillstromBenchmarkResult] = []
+    # Real slice runs
+    real_total = len(slices) * len(budgets) * len(seeds) * len(strategies)
+    idx = 0
+    t_suite_start = time.perf_counter()
+
+    for slice_name in slices:
+        scenario = scenarios[slice_name]
+        for budget in budgets:
+            for seed in seeds:
+                for strategy in strategies:
+                    idx += 1
+                    logger.info(
+                        "[%d/%d] slice=%s strategy=%s budget=%d seed=%d",
+                        idx,
+                        real_total,
+                        slice_name,
+                        strategy,
+                        budget,
+                        seed,
+                    )
+                    try:
+                        result = scenario.run_strategy(strategy, budget=budget, seed=seed)
+                        results.append(result)
+                    except Exception:  # pragma: no cover - defensive
+                        logger.warning(
+                            "slice=%s strategy=%s budget=%d seed=%d failed; skipping.",
+                            slice_name,
+                            strategy,
+                            budget,
+                            seed,
+                            exc_info=True,
+                        )
+
+    # Null-control runs (primary slice only per Sprint 31 contract)
+    if args.null_control and "primary" in scenarios:
+        null_budgets = [b for b in budgets if b <= 40] or [min(budgets)]
+        primary = scenarios["primary"]
+        null_total = len(null_budgets) * len(seeds) * len(strategies)
+        null_idx = 0
+        for budget in null_budgets:
+            for seed in seeds:
+                for strategy in strategies:
+                    null_idx += 1
+                    logger.info(
+                        "[null %d/%d] slice=primary strategy=%s budget=%d seed=%d",
+                        null_idx,
+                        null_total,
+                        strategy,
+                        budget,
+                        seed,
+                    )
+                    try:
+                        result = primary.run_strategy(
+                            strategy,
+                            budget=budget,
+                            seed=seed,
+                            null_control=True,
+                        )
+                        results.append(result)
+                    except Exception:  # pragma: no cover - defensive
+                        logger.warning(
+                            "null slice=primary strategy=%s budget=%d seed=%d failed; skipping.",
+                            strategy,
+                            budget,
+                            seed,
+                            exc_info=True,
+                        )
+
+    suite_runtime = time.perf_counter() - t_suite_start
+
+    # Assemble JSON artifact with Hillstrom-specific provenance
+    projected_graph = hillstrom_projected_prior_graph()
+    hillstrom_provenance = {
+        "slices": slices,
+        "null_control_enabled": bool(args.null_control),
+        "projected_graph_edge_count": len(projected_graph.edges),
+        "projected_graph_edges": [list(edge) for edge in projected_graph.edges],
+        "null_baselines": {name: scenario.null_baseline for name, scenario in scenarios.items()},
+    }
+    output_data = {
+        "benchmark": "sprint_31_hillstrom",
+        "suite_runtime_seconds": suite_runtime,
+        "results": [_sanitize_for_json(dataclasses.asdict(r)) for r in results],
+        "provenance": collect_provenance(
+            seeds=seeds,
+            budgets=budgets,
+            strategies=strategies,
+            dataset_path=str(args.data_path),
+        )
+        | {"hillstrom": hillstrom_provenance},
+    }
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(output_data, f, indent=2, allow_nan=False)
+    logger.info("Wrote %d results to %s", len(results), output_path)
+
+    if results:
+        print()
+        _print_summary(results)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/hillstrom_fixture.csv
+++ b/tests/fixtures/hillstrom_fixture.csv
@@ -1,0 +1,301 @@
+recency,history_segment,history,mens,womens,zip_code,newbie,channel,segment,visit,conversion,spend
+11,"6) $750 - $1,000",753.67,0,1,Urban,0,Multichannel,No E-Mail,0,0,0.0
+10,1) $0 - $100,85.65,1,0,Rural,1,Web,No E-Mail,0,0,0.0
+1,4) $350 - $500,453.15,1,0,Urban,0,Multichannel,Mens E-Mail,0,0,0.0
+9,5) $500 - $750,541.48,1,0,Suburban,0,Phone,No E-Mail,0,0,0.0
+2,"6) $750 - $1,000",848.14,0,1,Urban,0,Multichannel,Womens E-Mail,0,0,0.0
+9,3) $200 - $350,270.4,0,1,Urban,0,Multichannel,Mens E-Mail,1,0,0.0
+10,"7) $1,000 +",1243.67,0,1,Rural,1,Phone,Womens E-Mail,0,0,0.0
+2,"6) $750 - $1,000",764.53,1,0,Urban,0,Web,No E-Mail,0,0,0.0
+6,2) $100 - $200,133.85,1,0,Urban,1,Web,Mens E-Mail,1,0,0.0
+2,5) $500 - $750,624.7,1,1,Rural,0,Phone,No E-Mail,0,0,0.0
+7,"6) $750 - $1,000",797.9,1,0,Rural,0,Multichannel,Womens E-Mail,1,1,38.93
+12,3) $200 - $350,246.13,1,1,Urban,1,Phone,No E-Mail,0,0,0.0
+1,"6) $750 - $1,000",975.83,1,1,Urban,0,Phone,No E-Mail,0,0,0.0
+5,"7) $1,000 +",1553.1,1,1,Rural,0,Phone,Mens E-Mail,1,0,0.0
+12,"6) $750 - $1,000",937.5,1,0,Rural,0,Multichannel,No E-Mail,0,0,0.0
+4,"6) $750 - $1,000",866.24,1,0,Rural,0,Phone,Womens E-Mail,0,0,0.0
+2,5) $500 - $750,700.51,1,0,Suburban,1,Web,Mens E-Mail,0,0,0.0
+6,2) $100 - $200,137.27,1,1,Urban,1,Multichannel,Mens E-Mail,0,0,0.0
+7,"6) $750 - $1,000",905.47,1,0,Rural,0,Phone,Mens E-Mail,0,0,0.0
+8,3) $200 - $350,301.59,0,1,Urban,1,Multichannel,Womens E-Mail,0,0,0.0
+4,4) $350 - $500,478.0,1,0,Urban,1,Phone,No E-Mail,0,0,0.0
+12,3) $200 - $350,228.14,1,0,Rural,1,Multichannel,No E-Mail,0,0,0.0
+7,3) $200 - $350,261.19,1,0,Suburban,0,Phone,No E-Mail,0,0,0.0
+4,2) $100 - $200,139.24,1,1,Urban,1,Phone,No E-Mail,0,0,0.0
+12,"7) $1,000 +",1959.21,0,1,Urban,0,Multichannel,No E-Mail,0,0,0.0
+12,2) $100 - $200,154.09,1,0,Suburban,1,Multichannel,No E-Mail,0,0,0.0
+6,1) $0 - $100,52.95,1,1,Urban,1,Multichannel,Mens E-Mail,0,0,0.0
+1,"7) $1,000 +",1438.39,1,1,Rural,0,Multichannel,Mens E-Mail,1,1,38.88
+8,4) $350 - $500,472.2,0,1,Suburban,0,Web,No E-Mail,0,0,0.0
+7,4) $350 - $500,493.3,0,1,Suburban,1,Phone,Mens E-Mail,0,0,0.0
+2,"6) $750 - $1,000",863.78,1,0,Suburban,0,Phone,Womens E-Mail,1,0,0.0
+8,3) $200 - $350,216.74,1,0,Suburban,1,Web,Womens E-Mail,0,0,0.0
+11,1) $0 - $100,30.21,1,1,Suburban,1,Web,Mens E-Mail,0,0,0.0
+2,"6) $750 - $1,000",960.3,1,0,Rural,0,Web,No E-Mail,1,0,0.0
+9,2) $100 - $200,124.25,1,0,Suburban,0,Phone,No E-Mail,0,0,0.0
+2,4) $350 - $500,372.57,1,0,Suburban,0,Web,No E-Mail,0,0,0.0
+9,"7) $1,000 +",1569.21,1,1,Suburban,0,Phone,Womens E-Mail,0,0,0.0
+6,"7) $1,000 +",1772.94,1,0,Urban,0,Phone,Mens E-Mail,1,0,0.0
+1,3) $200 - $350,337.82,1,0,Rural,0,Phone,No E-Mail,0,0,0.0
+12,"6) $750 - $1,000",853.51,1,1,Suburban,1,Web,Mens E-Mail,0,0,0.0
+2,5) $500 - $750,541.37,1,0,Rural,0,Web,Mens E-Mail,0,0,0.0
+8,4) $350 - $500,439.07,1,0,Rural,1,Phone,Womens E-Mail,0,0,0.0
+3,1) $0 - $100,17.29,1,0,Rural,1,Web,Womens E-Mail,0,0,0.0
+12,3) $200 - $350,332.06,1,0,Rural,1,Phone,Mens E-Mail,0,0,0.0
+9,5) $500 - $750,504.54,0,1,Rural,1,Phone,No E-Mail,0,0,0.0
+10,"7) $1,000 +",1725.77,0,1,Suburban,0,Phone,Mens E-Mail,0,0,0.0
+6,1) $0 - $100,56.69,1,0,Rural,1,Web,No E-Mail,0,0,0.0
+6,"6) $750 - $1,000",920.65,0,1,Urban,0,Multichannel,Womens E-Mail,0,0,0.0
+8,"6) $750 - $1,000",803.04,1,1,Rural,0,Phone,No E-Mail,0,0,0.0
+10,"7) $1,000 +",1782.96,0,1,Urban,0,Phone,Womens E-Mail,0,0,0.0
+11,3) $200 - $350,335.6,0,1,Rural,1,Phone,Mens E-Mail,1,0,0.0
+1,1) $0 - $100,74.36,1,1,Urban,1,Web,Mens E-Mail,0,0,0.0
+8,2) $100 - $200,160.87,1,0,Suburban,1,Multichannel,No E-Mail,0,0,0.0
+2,"6) $750 - $1,000",921.14,1,0,Urban,1,Phone,Mens E-Mail,0,0,0.0
+4,"7) $1,000 +",1202.09,1,1,Urban,0,Web,Mens E-Mail,0,0,0.0
+10,5) $500 - $750,511.29,1,1,Rural,1,Multichannel,Mens E-Mail,1,0,0.0
+4,1) $0 - $100,65.25,1,1,Rural,0,Multichannel,Mens E-Mail,0,0,0.0
+10,1) $0 - $100,90.16,1,0,Urban,1,Web,Mens E-Mail,0,0,0.0
+6,4) $350 - $500,442.51,1,0,Urban,0,Multichannel,Womens E-Mail,1,0,0.0
+3,5) $500 - $750,574.01,1,1,Rural,1,Multichannel,No E-Mail,0,0,0.0
+5,1) $0 - $100,76.0,1,0,Rural,0,Multichannel,Mens E-Mail,0,0,0.0
+7,5) $500 - $750,612.46,1,1,Urban,1,Phone,No E-Mail,0,0,0.0
+10,4) $350 - $500,429.63,0,1,Suburban,0,Phone,Womens E-Mail,0,0,0.0
+8,1) $0 - $100,94.0,0,1,Urban,0,Phone,No E-Mail,1,0,0.0
+12,1) $0 - $100,43.46,1,0,Rural,1,Multichannel,Mens E-Mail,0,0,0.0
+11,4) $350 - $500,354.51,1,1,Suburban,0,Web,Womens E-Mail,0,0,0.0
+10,"6) $750 - $1,000",997.15,0,1,Urban,0,Phone,Womens E-Mail,0,0,0.0
+8,"6) $750 - $1,000",762.53,1,1,Urban,0,Web,Mens E-Mail,0,0,0.0
+4,4) $350 - $500,469.05,1,1,Suburban,0,Phone,Womens E-Mail,0,0,0.0
+5,3) $200 - $350,349.01,1,0,Rural,0,Multichannel,No E-Mail,0,0,0.0
+2,"7) $1,000 +",1461.1,0,1,Urban,1,Web,Womens E-Mail,1,0,0.0
+5,4) $350 - $500,492.51,1,1,Rural,0,Multichannel,No E-Mail,1,1,47.06
+12,3) $200 - $350,267.44,0,1,Suburban,0,Phone,Womens E-Mail,0,0,0.0
+6,4) $350 - $500,404.95,1,1,Rural,0,Web,No E-Mail,0,0,0.0
+2,1) $0 - $100,71.98,1,0,Rural,1,Phone,Mens E-Mail,0,0,0.0
+8,3) $200 - $350,213.76,1,1,Urban,1,Multichannel,Mens E-Mail,1,0,0.0
+12,4) $350 - $500,479.09,1,0,Urban,0,Web,No E-Mail,0,0,0.0
+11,"7) $1,000 +",1542.08,1,0,Rural,0,Web,Womens E-Mail,1,1,32.46
+4,"6) $750 - $1,000",830.12,0,1,Urban,0,Web,Mens E-Mail,1,1,23.02
+6,"6) $750 - $1,000",902.56,1,0,Urban,1,Phone,No E-Mail,1,0,0.0
+7,4) $350 - $500,431.68,1,0,Suburban,1,Multichannel,Mens E-Mail,0,0,0.0
+3,1) $0 - $100,24.42,1,1,Rural,1,Web,Womens E-Mail,0,0,0.0
+4,3) $200 - $350,268.47,0,1,Rural,0,Multichannel,No E-Mail,0,0,0.0
+3,"7) $1,000 +",1007.51,1,0,Suburban,1,Phone,No E-Mail,0,0,0.0
+12,1) $0 - $100,33.61,1,0,Urban,0,Phone,Womens E-Mail,0,0,0.0
+9,"7) $1,000 +",1980.82,1,0,Suburban,1,Multichannel,No E-Mail,0,0,0.0
+11,5) $500 - $750,721.21,0,1,Rural,1,Phone,Womens E-Mail,0,0,0.0
+10,2) $100 - $200,117.64,1,0,Urban,0,Phone,Mens E-Mail,0,0,0.0
+12,"6) $750 - $1,000",994.17,0,1,Suburban,1,Multichannel,Womens E-Mail,0,0,0.0
+2,"6) $750 - $1,000",946.87,1,1,Urban,1,Phone,No E-Mail,1,0,0.0
+11,1) $0 - $100,82.12,1,1,Urban,0,Phone,No E-Mail,1,0,0.0
+1,1) $0 - $100,14.39,1,0,Urban,0,Web,Mens E-Mail,0,0,0.0
+6,5) $500 - $750,663.06,1,1,Rural,0,Phone,Womens E-Mail,0,0,0.0
+8,"7) $1,000 +",1394.48,1,0,Rural,1,Phone,Womens E-Mail,0,0,0.0
+5,1) $0 - $100,73.78,1,0,Urban,0,Phone,Mens E-Mail,0,0,0.0
+2,5) $500 - $750,521.5,1,0,Rural,0,Phone,Mens E-Mail,1,0,0.0
+3,1) $0 - $100,82.31,1,0,Suburban,1,Phone,Mens E-Mail,0,0,0.0
+10,5) $500 - $750,555.2,0,1,Rural,0,Multichannel,No E-Mail,0,0,0.0
+4,5) $500 - $750,677.63,1,0,Rural,0,Phone,Womens E-Mail,0,0,0.0
+4,1) $0 - $100,60.16,0,1,Urban,1,Phone,Mens E-Mail,1,1,36.96
+12,5) $500 - $750,641.02,1,0,Rural,1,Phone,Mens E-Mail,0,0,0.0
+2,"7) $1,000 +",1469.96,1,0,Suburban,1,Web,Womens E-Mail,0,0,0.0
+11,"7) $1,000 +",1679.53,1,0,Urban,0,Multichannel,No E-Mail,0,0,0.0
+12,1) $0 - $100,21.41,1,0,Urban,0,Web,No E-Mail,0,0,0.0
+8,2) $100 - $200,136.08,1,0,Rural,0,Phone,Womens E-Mail,1,1,38.72
+2,2) $100 - $200,192.97,1,1,Suburban,1,Phone,Womens E-Mail,1,0,0.0
+2,4) $350 - $500,428.91,0,1,Suburban,0,Web,Womens E-Mail,0,0,0.0
+4,2) $100 - $200,194.86,1,0,Urban,0,Phone,Womens E-Mail,0,0,0.0
+7,"6) $750 - $1,000",782.01,1,1,Rural,1,Multichannel,Mens E-Mail,0,0,0.0
+2,"6) $750 - $1,000",852.17,0,1,Urban,1,Multichannel,No E-Mail,0,0,0.0
+6,"6) $750 - $1,000",862.76,1,0,Urban,1,Web,No E-Mail,0,0,0.0
+2,2) $100 - $200,165.88,1,0,Suburban,0,Multichannel,No E-Mail,0,0,0.0
+7,1) $0 - $100,16.61,1,0,Rural,1,Phone,Womens E-Mail,0,0,0.0
+1,"7) $1,000 +",1392.48,0,1,Urban,0,Phone,Womens E-Mail,0,0,0.0
+9,3) $200 - $350,200.69,0,1,Urban,1,Multichannel,No E-Mail,0,0,0.0
+1,5) $500 - $750,501.37,1,0,Suburban,0,Multichannel,Mens E-Mail,0,0,0.0
+3,"7) $1,000 +",1496.59,1,1,Urban,1,Phone,No E-Mail,0,0,0.0
+3,1) $0 - $100,53.65,0,1,Suburban,0,Web,Womens E-Mail,0,0,0.0
+10,1) $0 - $100,37.45,0,1,Urban,1,Phone,No E-Mail,0,0,0.0
+1,1) $0 - $100,42.5,1,0,Urban,0,Web,Womens E-Mail,0,0,0.0
+6,2) $100 - $200,187.43,0,1,Urban,1,Multichannel,Mens E-Mail,0,0,0.0
+8,1) $0 - $100,66.83,0,1,Rural,0,Multichannel,Mens E-Mail,0,0,0.0
+7,"6) $750 - $1,000",851.25,0,1,Rural,0,Web,Mens E-Mail,0,0,0.0
+9,5) $500 - $750,658.56,1,1,Suburban,0,Multichannel,Womens E-Mail,0,0,0.0
+10,"7) $1,000 +",1301.76,0,1,Suburban,1,Web,No E-Mail,0,0,0.0
+5,"6) $750 - $1,000",764.96,1,1,Rural,0,Multichannel,No E-Mail,0,0,0.0
+10,"7) $1,000 +",1063.12,1,0,Urban,0,Phone,Womens E-Mail,0,0,0.0
+4,2) $100 - $200,131.07,1,0,Suburban,1,Web,No E-Mail,0,0,0.0
+12,3) $200 - $350,346.38,1,0,Rural,0,Web,No E-Mail,1,0,0.0
+7,"6) $750 - $1,000",870.73,1,0,Rural,0,Web,Womens E-Mail,0,0,0.0
+9,2) $100 - $200,136.16,1,1,Urban,1,Phone,No E-Mail,0,0,0.0
+11,1) $0 - $100,93.07,1,1,Rural,1,Phone,Mens E-Mail,1,0,0.0
+10,5) $500 - $750,512.28,0,1,Suburban,1,Multichannel,No E-Mail,0,0,0.0
+11,"6) $750 - $1,000",800.47,0,1,Rural,1,Phone,Mens E-Mail,0,0,0.0
+7,"7) $1,000 +",1437.84,1,0,Urban,0,Web,Mens E-Mail,0,0,0.0
+1,"7) $1,000 +",1653.19,1,0,Suburban,0,Web,Womens E-Mail,0,0,0.0
+6,1) $0 - $100,67.29,1,1,Rural,0,Web,Womens E-Mail,0,0,0.0
+3,"6) $750 - $1,000",998.7,1,0,Urban,1,Phone,Mens E-Mail,0,0,0.0
+11,"6) $750 - $1,000",909.4,0,1,Rural,1,Phone,No E-Mail,0,0,0.0
+3,5) $500 - $750,515.08,1,0,Urban,0,Phone,No E-Mail,1,0,0.0
+3,"6) $750 - $1,000",836.92,1,0,Rural,1,Phone,Mens E-Mail,0,0,0.0
+3,"6) $750 - $1,000",876.44,1,1,Suburban,0,Phone,Womens E-Mail,0,0,0.0
+8,4) $350 - $500,369.67,1,1,Urban,0,Phone,Mens E-Mail,0,0,0.0
+7,1) $0 - $100,89.47,0,1,Urban,1,Phone,Mens E-Mail,0,0,0.0
+12,4) $350 - $500,456.22,1,0,Rural,1,Multichannel,Womens E-Mail,0,0,0.0
+5,2) $100 - $200,127.34,1,1,Urban,1,Web,Mens E-Mail,0,0,0.0
+4,1) $0 - $100,48.11,0,1,Suburban,1,Phone,Womens E-Mail,1,0,0.0
+1,1) $0 - $100,36.08,0,1,Urban,1,Web,No E-Mail,0,0,0.0
+1,5) $500 - $750,592.32,1,0,Rural,1,Phone,Womens E-Mail,0,0,0.0
+5,4) $350 - $500,480.08,1,0,Suburban,0,Web,Mens E-Mail,0,0,0.0
+12,4) $350 - $500,362.17,0,1,Rural,0,Phone,Womens E-Mail,0,0,0.0
+7,"6) $750 - $1,000",806.29,1,0,Urban,1,Phone,No E-Mail,0,0,0.0
+11,4) $350 - $500,483.48,0,1,Urban,0,Phone,Womens E-Mail,0,0,0.0
+2,5) $500 - $750,574.07,1,0,Suburban,0,Web,Mens E-Mail,0,0,0.0
+2,1) $0 - $100,5.79,1,0,Suburban,0,Web,Womens E-Mail,1,1,24.0
+11,"6) $750 - $1,000",953.62,1,1,Rural,0,Web,Womens E-Mail,0,0,0.0
+2,4) $350 - $500,414.49,1,0,Rural,1,Web,Womens E-Mail,0,0,0.0
+1,2) $100 - $200,137.83,1,0,Rural,0,Multichannel,No E-Mail,0,0,0.0
+5,"6) $750 - $1,000",848.81,0,1,Urban,0,Multichannel,Womens E-Mail,0,0,0.0
+12,"6) $750 - $1,000",965.45,1,0,Urban,1,Web,Womens E-Mail,1,0,0.0
+9,1) $0 - $100,69.04,0,1,Rural,0,Web,No E-Mail,0,0,0.0
+2,2) $100 - $200,109.78,1,0,Suburban,0,Web,Womens E-Mail,0,0,0.0
+11,1) $0 - $100,79.61,0,1,Rural,0,Phone,Womens E-Mail,0,0,0.0
+11,2) $100 - $200,140.2,1,0,Suburban,1,Web,No E-Mail,0,0,0.0
+10,1) $0 - $100,63.93,1,0,Urban,0,Phone,Mens E-Mail,1,0,0.0
+11,5) $500 - $750,689.99,0,1,Suburban,1,Multichannel,Womens E-Mail,0,0,0.0
+3,4) $350 - $500,481.5,1,1,Rural,0,Web,No E-Mail,0,0,0.0
+12,"7) $1,000 +",1582.64,1,0,Suburban,1,Multichannel,Mens E-Mail,1,0,0.0
+4,"6) $750 - $1,000",919.49,1,1,Urban,0,Multichannel,Womens E-Mail,1,0,0.0
+10,5) $500 - $750,729.46,1,0,Urban,1,Web,Mens E-Mail,0,0,0.0
+7,4) $350 - $500,364.07,1,0,Rural,0,Multichannel,No E-Mail,0,0,0.0
+10,1) $0 - $100,78.78,0,1,Rural,1,Web,Mens E-Mail,0,0,0.0
+8,1) $0 - $100,60.64,1,1,Rural,0,Phone,Mens E-Mail,0,0,0.0
+8,5) $500 - $750,507.72,1,0,Urban,0,Phone,Mens E-Mail,0,0,0.0
+8,1) $0 - $100,5.09,1,1,Suburban,0,Phone,Womens E-Mail,0,0,0.0
+10,1) $0 - $100,53.13,1,0,Rural,0,Multichannel,No E-Mail,0,0,0.0
+9,2) $100 - $200,174.4,1,0,Suburban,0,Web,Womens E-Mail,1,1,30.31
+2,"7) $1,000 +",1902.89,1,0,Suburban,1,Phone,Womens E-Mail,0,0,0.0
+10,4) $350 - $500,381.77,1,0,Suburban,0,Web,No E-Mail,0,0,0.0
+7,5) $500 - $750,645.06,0,1,Urban,0,Phone,No E-Mail,0,0,0.0
+4,3) $200 - $350,278.32,1,0,Urban,1,Multichannel,Womens E-Mail,1,0,0.0
+7,2) $100 - $200,179.66,1,0,Rural,0,Multichannel,No E-Mail,0,0,0.0
+12,3) $200 - $350,211.66,1,1,Urban,0,Phone,No E-Mail,0,0,0.0
+11,1) $0 - $100,90.98,1,1,Urban,0,Multichannel,Mens E-Mail,0,0,0.0
+11,"6) $750 - $1,000",768.52,1,0,Suburban,0,Web,Womens E-Mail,0,0,0.0
+6,2) $100 - $200,108.67,0,1,Rural,0,Phone,Mens E-Mail,1,1,47.31
+10,3) $200 - $350,270.88,1,0,Suburban,0,Multichannel,No E-Mail,0,0,0.0
+5,"7) $1,000 +",1921.68,1,1,Suburban,0,Phone,Womens E-Mail,0,0,0.0
+9,5) $500 - $750,545.22,0,1,Suburban,1,Phone,Mens E-Mail,0,0,0.0
+8,4) $350 - $500,460.02,1,0,Urban,0,Phone,No E-Mail,0,0,0.0
+3,4) $350 - $500,398.94,1,0,Urban,1,Web,No E-Mail,0,0,0.0
+4,"6) $750 - $1,000",999.71,0,1,Urban,1,Web,Mens E-Mail,0,0,0.0
+1,2) $100 - $200,125.04,1,0,Rural,0,Phone,Mens E-Mail,0,0,0.0
+2,5) $500 - $750,632.14,1,0,Rural,0,Phone,No E-Mail,0,0,0.0
+6,"7) $1,000 +",1320.85,1,1,Urban,1,Phone,Womens E-Mail,0,0,0.0
+6,5) $500 - $750,602.08,1,0,Urban,1,Multichannel,Womens E-Mail,0,0,0.0
+2,4) $350 - $500,477.58,0,1,Urban,0,Multichannel,No E-Mail,0,0,0.0
+6,2) $100 - $200,102.12,0,1,Rural,1,Multichannel,No E-Mail,0,0,0.0
+8,2) $100 - $200,158.17,1,0,Suburban,1,Web,No E-Mail,0,0,0.0
+3,"7) $1,000 +",1903.9,1,0,Rural,0,Web,No E-Mail,0,0,0.0
+5,4) $350 - $500,449.0,1,1,Suburban,0,Multichannel,No E-Mail,0,0,0.0
+5,3) $200 - $350,271.58,1,0,Rural,1,Web,No E-Mail,0,0,0.0
+7,3) $200 - $350,265.88,1,0,Suburban,0,Web,No E-Mail,0,0,0.0
+5,5) $500 - $750,561.39,1,0,Urban,1,Phone,Mens E-Mail,0,0,0.0
+9,4) $350 - $500,473.66,1,1,Rural,0,Web,Mens E-Mail,0,0,0.0
+4,5) $500 - $750,690.75,1,0,Rural,1,Phone,Womens E-Mail,0,0,0.0
+6,2) $100 - $200,155.03,0,1,Rural,0,Phone,No E-Mail,0,0,0.0
+5,5) $500 - $750,682.45,1,0,Rural,0,Multichannel,Womens E-Mail,0,0,0.0
+3,4) $350 - $500,459.97,1,1,Urban,0,Multichannel,Womens E-Mail,1,1,57.62
+9,"7) $1,000 +",1851.72,1,1,Urban,0,Phone,Mens E-Mail,0,0,0.0
+3,2) $100 - $200,161.87,1,0,Suburban,1,Phone,Womens E-Mail,0,0,0.0
+4,2) $100 - $200,167.42,0,1,Urban,0,Phone,Mens E-Mail,0,0,0.0
+10,4) $350 - $500,476.41,1,0,Suburban,1,Multichannel,Womens E-Mail,0,0,0.0
+12,4) $350 - $500,371.25,1,0,Urban,1,Phone,Mens E-Mail,0,0,0.0
+9,5) $500 - $750,630.47,1,1,Suburban,0,Phone,Womens E-Mail,1,0,0.0
+11,3) $200 - $350,297.7,1,1,Suburban,1,Phone,Mens E-Mail,0,0,0.0
+11,"7) $1,000 +",1515.13,1,1,Suburban,1,Multichannel,No E-Mail,1,0,0.0
+6,4) $350 - $500,467.42,1,0,Rural,1,Web,No E-Mail,0,0,0.0
+10,1) $0 - $100,76.38,1,0,Suburban,0,Multichannel,Mens E-Mail,0,0,0.0
+4,1) $0 - $100,44.49,1,0,Suburban,1,Multichannel,No E-Mail,0,0,0.0
+6,"7) $1,000 +",1051.72,1,0,Urban,1,Phone,Womens E-Mail,0,0,0.0
+7,1) $0 - $100,94.54,1,0,Suburban,1,Multichannel,Womens E-Mail,0,0,0.0
+12,"7) $1,000 +",1855.48,0,1,Urban,0,Web,No E-Mail,0,0,0.0
+11,2) $100 - $200,153.07,1,0,Urban,1,Web,Mens E-Mail,0,0,0.0
+6,1) $0 - $100,20.02,0,1,Suburban,0,Phone,No E-Mail,0,0,0.0
+8,3) $200 - $350,254.19,1,0,Urban,0,Multichannel,Mens E-Mail,0,0,0.0
+3,5) $500 - $750,559.62,1,0,Suburban,0,Multichannel,Womens E-Mail,1,1,41.19
+10,3) $200 - $350,290.98,1,0,Urban,1,Web,Mens E-Mail,0,0,0.0
+7,"6) $750 - $1,000",753.53,1,0,Rural,1,Phone,No E-Mail,0,0,0.0
+7,5) $500 - $750,568.48,1,0,Rural,0,Multichannel,No E-Mail,0,0,0.0
+10,3) $200 - $350,257.78,1,0,Urban,1,Multichannel,No E-Mail,1,0,0.0
+8,5) $500 - $750,626.05,0,1,Suburban,0,Web,Womens E-Mail,1,0,0.0
+1,"7) $1,000 +",1806.4,1,1,Suburban,0,Web,Mens E-Mail,0,0,0.0
+4,3) $200 - $350,214.15,1,0,Suburban,1,Phone,No E-Mail,0,0,0.0
+3,2) $100 - $200,177.02,1,0,Suburban,1,Phone,Mens E-Mail,0,0,0.0
+9,3) $200 - $350,267.23,1,0,Rural,1,Multichannel,Mens E-Mail,0,0,0.0
+1,"6) $750 - $1,000",854.44,1,0,Suburban,1,Web,No E-Mail,0,0,0.0
+3,2) $100 - $200,115.18,1,0,Urban,0,Phone,Mens E-Mail,0,0,0.0
+8,"7) $1,000 +",1169.98,1,0,Suburban,1,Multichannel,Womens E-Mail,1,0,0.0
+9,5) $500 - $750,528.8,1,1,Urban,0,Phone,No E-Mail,0,0,0.0
+7,5) $500 - $750,628.06,1,0,Suburban,1,Phone,Womens E-Mail,1,0,0.0
+11,3) $200 - $350,334.21,1,0,Urban,0,Phone,Womens E-Mail,0,0,0.0
+12,"7) $1,000 +",1482.38,1,0,Urban,0,Web,No E-Mail,1,0,0.0
+2,1) $0 - $100,92.24,0,1,Rural,0,Web,No E-Mail,0,0,0.0
+12,3) $200 - $350,228.51,1,0,Urban,1,Phone,Womens E-Mail,1,0,0.0
+8,3) $200 - $350,250.85,1,0,Rural,0,Web,Mens E-Mail,1,0,0.0
+8,4) $350 - $500,405.25,1,0,Rural,1,Web,No E-Mail,0,0,0.0
+2,4) $350 - $500,379.54,1,0,Suburban,1,Web,Mens E-Mail,0,0,0.0
+8,2) $100 - $200,153.39,1,0,Rural,0,Web,Womens E-Mail,1,0,0.0
+9,2) $100 - $200,179.37,1,1,Urban,1,Multichannel,Mens E-Mail,0,0,0.0
+7,1) $0 - $100,9.28,1,0,Urban,0,Multichannel,Womens E-Mail,0,0,0.0
+2,5) $500 - $750,717.26,1,0,Urban,0,Phone,Mens E-Mail,0,0,0.0
+7,3) $200 - $350,297.26,0,1,Suburban,1,Multichannel,No E-Mail,0,0,0.0
+12,4) $350 - $500,464.63,1,0,Suburban,0,Web,Womens E-Mail,0,0,0.0
+9,5) $500 - $750,509.88,1,0,Rural,0,Phone,No E-Mail,0,0,0.0
+2,5) $500 - $750,617.91,1,0,Suburban,0,Web,Mens E-Mail,0,0,0.0
+12,4) $350 - $500,439.73,0,1,Urban,1,Multichannel,Mens E-Mail,0,0,0.0
+12,5) $500 - $750,543.63,1,1,Rural,0,Multichannel,Womens E-Mail,0,0,0.0
+3,5) $500 - $750,520.07,1,1,Rural,0,Web,Mens E-Mail,0,0,0.0
+10,5) $500 - $750,645.11,0,1,Rural,1,Phone,Womens E-Mail,0,0,0.0
+5,5) $500 - $750,592.39,0,1,Suburban,0,Phone,Mens E-Mail,0,0,0.0
+8,3) $200 - $350,309.18,1,1,Suburban,1,Phone,No E-Mail,0,0,0.0
+6,2) $100 - $200,108.89,1,1,Suburban,0,Multichannel,Mens E-Mail,0,0,0.0
+10,"6) $750 - $1,000",787.53,0,1,Rural,1,Web,Womens E-Mail,0,0,0.0
+12,3) $200 - $350,332.95,0,1,Urban,1,Web,Womens E-Mail,0,0,0.0
+10,4) $350 - $500,399.03,1,0,Rural,0,Multichannel,No E-Mail,0,0,0.0
+12,2) $100 - $200,187.21,1,0,Urban,0,Multichannel,Mens E-Mail,1,0,0.0
+12,4) $350 - $500,464.34,0,1,Suburban,1,Multichannel,No E-Mail,0,0,0.0
+2,4) $350 - $500,403.88,1,0,Urban,1,Phone,Womens E-Mail,0,0,0.0
+4,5) $500 - $750,649.11,1,0,Suburban,0,Web,Mens E-Mail,0,0,0.0
+9,4) $350 - $500,433.38,1,1,Rural,1,Multichannel,Mens E-Mail,0,0,0.0
+8,3) $200 - $350,262.54,0,1,Rural,0,Multichannel,Mens E-Mail,0,0,0.0
+1,"7) $1,000 +",1096.93,1,1,Rural,1,Phone,Womens E-Mail,1,1,67.36
+2,4) $350 - $500,453.78,1,0,Urban,1,Web,Womens E-Mail,0,0,0.0
+7,"6) $750 - $1,000",896.88,1,0,Urban,1,Multichannel,Womens E-Mail,1,0,0.0
+8,"6) $750 - $1,000",884.86,1,0,Rural,1,Phone,Mens E-Mail,0,0,0.0
+3,4) $350 - $500,437.45,1,0,Suburban,0,Web,No E-Mail,0,0,0.0
+3,"7) $1,000 +",1273.16,1,1,Urban,1,Phone,Womens E-Mail,1,1,13.92
+2,1) $0 - $100,52.74,1,0,Rural,1,Multichannel,Womens E-Mail,1,1,27.17
+7,"7) $1,000 +",1723.32,1,0,Suburban,1,Phone,Mens E-Mail,0,0,0.0
+1,"6) $750 - $1,000",843.35,1,0,Urban,1,Phone,Mens E-Mail,1,0,0.0
+7,4) $350 - $500,400.75,0,1,Rural,1,Phone,Womens E-Mail,1,1,21.77
+6,"6) $750 - $1,000",762.74,1,0,Suburban,1,Phone,Mens E-Mail,0,0,0.0
+6,4) $350 - $500,381.76,1,0,Suburban,1,Web,Mens E-Mail,0,0,0.0
+9,2) $100 - $200,195.05,0,1,Rural,1,Phone,Womens E-Mail,0,0,0.0
+7,"6) $750 - $1,000",774.19,1,1,Suburban,0,Web,Womens E-Mail,1,0,0.0
+9,2) $100 - $200,114.58,1,0,Suburban,0,Web,Womens E-Mail,0,0,0.0
+10,3) $200 - $350,336.83,1,1,Suburban,0,Web,No E-Mail,0,0,0.0
+12,4) $350 - $500,453.57,1,1,Urban,0,Multichannel,Mens E-Mail,0,0,0.0
+10,"6) $750 - $1,000",859.25,1,0,Urban,0,Web,Mens E-Mail,0,0,0.0
+7,3) $200 - $350,256.29,1,0,Rural,0,Web,No E-Mail,0,0,0.0
+6,4) $350 - $500,492.5,1,1,Urban,0,Multichannel,Womens E-Mail,1,1,16.9
+3,1) $0 - $100,26.24,1,0,Suburban,1,Phone,Womens E-Mail,1,0,0.0
+8,1) $0 - $100,60.39,1,1,Urban,0,Multichannel,No E-Mail,0,0,0.0
+2,1) $0 - $100,55.76,0,1,Urban,1,Multichannel,Mens E-Mail,0,0,0.0
+12,1) $0 - $100,12.23,1,1,Suburban,0,Phone,Womens E-Mail,0,0,0.0
+11,"7) $1,000 +",1893.13,1,1,Rural,0,Phone,Womens E-Mail,1,1,31.59
+2,"6) $750 - $1,000",851.71,1,0,Suburban,1,Web,Mens E-Mail,0,0,0.0
+10,"6) $750 - $1,000",757.9,1,1,Urban,1,Phone,Mens E-Mail,0,0,0.0
+2,1) $0 - $100,61.42,0,1,Urban,1,Web,Womens E-Mail,0,0,0.0

--- a/tests/integration/test_hillstrom_benchmark.py
+++ b/tests/integration/test_hillstrom_benchmark.py
@@ -1,0 +1,132 @@
+"""Integration tests for the Sprint 31 Hillstrom benchmark scenario.
+
+These exercise the full ``HillstromScenario.run_strategy`` path end to
+end on the committed fixture, including the engine loop and the
+adapter. They are intentionally small (3 experiments per strategy) so
+they run quickly inside CI and do not depend on the optional
+Ax/BoTorch stack — each strategy is exercised with a budget that can
+complete under either the RF fallback or the Ax primary backend.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from causal_optimizer.benchmarks.hillstrom import (
+    HillstromBenchmarkResult,
+    HillstromScenario,
+    HillstromSliceType,
+)
+
+FIXTURE_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "hillstrom_fixture.csv"
+
+
+@pytest.fixture
+def raw_hillstrom() -> pd.DataFrame:
+    return pd.read_csv(FIXTURE_PATH)
+
+
+class TestHillstromScenarioPrimary:
+    """Primary slice ``Womens E-Mail vs No E-Mail``."""
+
+    def test_scenario_reshapes_into_primary_slice(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        reshaped = scenario.real_slice
+        # Treatment is binary and both arms are present
+        assert set(reshaped["treatment"].unique()) == {0, 1}
+        # Propensity is a scalar 0.5 on every row
+        assert (reshaped["propensity"] == 0.5).all()
+        # Null baseline equals raw mean spend of the reshaped frame
+        expected_mu = float(reshaped["outcome"].mean())
+        assert scenario.null_baseline == expected_mu
+
+    def test_random_strategy_returns_finite_policy_value(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        result = scenario.run_strategy("random", budget=8, seed=0)
+        assert isinstance(result, HillstromBenchmarkResult)
+        assert result.strategy == "random"
+        assert result.budget == 8
+        assert result.seed == 0
+        assert result.slice_type == "primary"
+        assert result.is_null_control is False
+        assert np.isfinite(result.policy_value)
+        assert result.selected_parameters is not None
+        assert set(result.selected_parameters.keys()) == {
+            "eligibility_threshold",
+            "regularization",
+            "treatment_budget_pct",
+        }
+
+    def test_surrogate_only_strategy_runs_on_fixture(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        result = scenario.run_strategy("surrogate_only", budget=8, seed=0)
+        assert result.strategy == "surrogate_only"
+        assert np.isfinite(result.policy_value)
+
+    def test_causal_strategy_runs_on_fixture(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        result = scenario.run_strategy("causal", budget=8, seed=0)
+        assert result.strategy == "causal"
+        assert np.isfinite(result.policy_value)
+
+    def test_unknown_strategy_raises(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        with pytest.raises(ValueError, match="Unknown strategy"):
+            scenario.run_strategy("magic", budget=1, seed=0)
+
+    def test_secondary_outcomes_reported(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        result = scenario.run_strategy("random", budget=8, seed=1)
+        # Secondary-outcome aggregates should be populated on a real (non-null)
+        # run; the contract treats these as post-hoc diagnostics, not
+        # optimization objectives.
+        assert "treated_visit_rate" in result.secondary_outcomes
+        assert "control_visit_rate" in result.secondary_outcomes
+        for val in result.secondary_outcomes.values():
+            assert 0.0 <= val <= 1.0
+
+
+class TestHillstromScenarioPooled:
+    """Pooled secondary slice ``Any E-Mail vs No E-Mail``."""
+
+    def test_pooled_propensity_is_two_thirds(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.POOLED)
+        reshaped = scenario.real_slice
+        expected = 2.0 / 3.0
+        assert (reshaped["propensity"] == expected).all()
+
+    def test_pooled_scenario_runs_random_strategy(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.POOLED)
+        result = scenario.run_strategy("random", budget=8, seed=0)
+        assert result.slice_type == "pooled"
+        assert np.isfinite(result.policy_value)
+
+
+class TestHillstromNullControl:
+    """Permuted-outcome null-control path on the primary slice."""
+
+    def test_null_control_preserves_mu(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        # Running under null_control must leave the scenario's internal
+        # baseline μ unchanged — it was computed once from the real frame.
+        mu_before = scenario.null_baseline
+        _ = scenario.run_strategy("random", budget=8, seed=0, null_control=True)
+        assert scenario.null_baseline == mu_before
+
+    def test_null_control_result_is_flagged(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        result = scenario.run_strategy("random", budget=8, seed=0, null_control=True)
+        assert result.is_null_control is True
+        assert result.null_baseline == scenario.null_baseline
+
+    def test_null_control_determinism_under_fixed_seed(self, raw_hillstrom: pd.DataFrame) -> None:
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        a = scenario.run_strategy("random", budget=8, seed=42, null_control=True)
+        b = scenario.run_strategy("random", budget=8, seed=42, null_control=True)
+        # Random strategy is seed-deterministic → same best policy_value
+        assert a.policy_value == b.policy_value
+        assert a.selected_parameters == b.selected_parameters

--- a/tests/unit/test_hillstrom_benchmark.py
+++ b/tests/unit/test_hillstrom_benchmark.py
@@ -388,12 +388,12 @@ class TestDefensiveGuards:
     def test_secondary_outcomes_empty_when_visit_or_conversion_missing(
         self, raw_hillstrom: pd.DataFrame
     ) -> None:
-        from causal_optimizer.benchmarks.hillstrom import _secondary_outcomes_under_policy
+        from causal_optimizer.benchmarks.hillstrom import _secondary_arm_aggregates
 
         df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
         # Drop the retained secondary outcome columns; the guard must
         # return an empty dict rather than raising or silently producing
         # garbage aggregates.
         without_secondary = df.drop(columns=["visit", "conversion"])
-        result = _secondary_outcomes_under_policy(without_secondary)
+        result = _secondary_arm_aggregates(without_secondary)
         assert result == {}

--- a/tests/unit/test_hillstrom_benchmark.py
+++ b/tests/unit/test_hillstrom_benchmark.py
@@ -226,6 +226,47 @@ class TestActiveSearchSpace:
         assert "social_share_of_remainder" not in names
         assert "min_propensity_clip" not in names
 
+    def test_active_space_raises_if_adapter_drops_expected_variable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Defensive guard: a future MarketingLogAdapter change that
+        renames or drops one of the 3 active Hillstrom dimensions must
+        fail with a clear RuntimeError pointing at the contract, not an
+        opaque KeyError deep inside a list comprehension.
+        """
+        from causal_optimizer.benchmarks import hillstrom as hb
+        from causal_optimizer.types import SearchSpace, Variable, VariableType
+
+        def fake_get_search_space(self: object) -> SearchSpace:
+            # Returns a search space missing "regularization" entirely.
+            return SearchSpace(
+                variables=[
+                    Variable(
+                        name="eligibility_threshold",
+                        variable_type=VariableType.CONTINUOUS,
+                        lower=0.0,
+                        upper=1.0,
+                    ),
+                    Variable(
+                        name="treatment_budget_pct",
+                        variable_type=VariableType.CONTINUOUS,
+                        lower=0.1,
+                        upper=1.0,
+                    ),
+                ]
+            )
+
+        monkeypatch.setattr(MarketingLogAdapter, "get_search_space", fake_get_search_space)
+        # Clear the lru_cache so the next call actually re-invokes the
+        # patched get_search_space rather than returning a cached result
+        # built against the real adapter.
+        hb.hillstrom_active_search_space.cache_clear()
+        try:
+            with pytest.raises(RuntimeError, match="missing expected Hillstrom active variables"):
+                hb.hillstrom_active_search_space()
+        finally:
+            hb.hillstrom_active_search_space.cache_clear()
+
     def test_active_space_bounds_match_adapter(self) -> None:
         # Bounds must be inherited from MarketingLogAdapter to keep the
         # search space numerically identical to the adapter's native ranges

--- a/tests/unit/test_hillstrom_benchmark.py
+++ b/tests/unit/test_hillstrom_benchmark.py
@@ -200,6 +200,46 @@ class TestProjectedPriorGraph:
         # And the projection must drop exactly 7 edges (14 - 7 = 7)
         assert len(full - projected) == 7
 
+    def test_graph_sink_node_is_the_engine_objective(self) -> None:
+        """Regression guard: the projected graph's sink node must be the
+        same string the engine uses as ``objective_name``. If these ever
+        drift again, ``graph.ancestors(objective_name)`` and
+        ``graph.parents(objective_name)`` will return empty sets and the
+        causal optimizer will silently lose its graph signal — the
+        causal path collapses to surrogate-only behavior without any
+        test failure. Pin the coupling explicitly.
+        """
+        from causal_optimizer.benchmarks.hillstrom import _HILLSTROM_ENGINE_OBJECTIVE
+
+        graph = hillstrom_projected_prior_graph()
+        # ``policy_value`` is the Hillstrom objective — the same name
+        # the adapter reports and the engine consumes.
+        assert _HILLSTROM_ENGINE_OBJECTIVE == "policy_value"
+        assert _HILLSTROM_ENGINE_OBJECTIVE in graph.nodes
+        # The objective must have both ancestors and direct parents in
+        # the projected graph; any of the active search variables must
+        # reach it, or the causal path is a no-op.
+        ancestors = graph.ancestors(_HILLSTROM_ENGINE_OBJECTIVE)
+        parents = graph.parents(_HILLSTROM_ENGINE_OBJECTIVE)
+        assert ancestors, (
+            f"projected graph has no ancestors for objective "
+            f"{_HILLSTROM_ENGINE_OBJECTIVE!r}; the causal path would "
+            f"lose its graph signal"
+        )
+        assert parents, (
+            f"projected graph has no direct parents for objective "
+            f"{_HILLSTROM_ENGINE_OBJECTIVE!r}; the causal path would "
+            f"lose its graph signal"
+        )
+        # At least one active search variable must appear in the
+        # ancestor set — otherwise the causal optimizer's focus-variable
+        # pruning has nothing to work with.
+        active = {"eligibility_threshold", "regularization", "treatment_budget_pct"}
+        assert active & ancestors, (
+            f"no active search variable in ancestors("
+            f"{_HILLSTROM_ENGINE_OBJECTIVE!r}): {sorted(ancestors)!r}"
+        )
+
 
 # ── Active search space ──────────────────────────────────────────────
 

--- a/tests/unit/test_hillstrom_benchmark.py
+++ b/tests/unit/test_hillstrom_benchmark.py
@@ -395,5 +395,5 @@ class TestDefensiveGuards:
         # return an empty dict rather than raising or silently producing
         # garbage aggregates.
         without_secondary = df.drop(columns=["visit", "conversion"])
-        result = _secondary_outcomes_under_policy(without_secondary, {})
+        result = _secondary_outcomes_under_policy(without_secondary)
         assert result == {}

--- a/tests/unit/test_hillstrom_benchmark.py
+++ b/tests/unit/test_hillstrom_benchmark.py
@@ -397,3 +397,62 @@ class TestDefensiveGuards:
         without_secondary = df.drop(columns=["visit", "conversion"])
         result = _secondary_arm_aggregates(without_secondary)
         assert result == {}
+
+
+class TestActiveParamsInvariant:
+    """The active-only-parameter invariant guard."""
+
+    def test_none_is_accepted(self) -> None:
+        from causal_optimizer.benchmarks.hillstrom import _check_active_params_invariant
+
+        # When the engine produces no best result, None is passed
+        # through without raising.
+        _check_active_params_invariant(None)
+
+    def test_active_only_params_are_accepted(self) -> None:
+        from causal_optimizer.benchmarks.hillstrom import _check_active_params_invariant
+
+        _check_active_params_invariant(
+            {
+                "eligibility_threshold": 0.3,
+                "regularization": 1.0,
+                "treatment_budget_pct": 0.5,
+            }
+        )
+
+    def test_frozen_param_leak_raises(self) -> None:
+        from causal_optimizer.benchmarks.hillstrom import _check_active_params_invariant
+
+        # Simulate a hypothetical future engine change that leaks
+        # a frozen Hillstrom dimension back into the experiment log.
+        leaked = {
+            "eligibility_threshold": 0.3,
+            "regularization": 1.0,
+            "treatment_budget_pct": 0.5,
+            "email_share": 1.0,  # leaked frozen dimension
+        }
+        with pytest.raises(RuntimeError, match="unexpected keys"):
+            _check_active_params_invariant(leaked)
+
+    def test_missing_active_key_raises(self) -> None:
+        from causal_optimizer.benchmarks.hillstrom import _check_active_params_invariant
+
+        # A subset of the active dims is also a violation — the log
+        # is supposed to be exactly the 3 active keys, no more and
+        # no less.
+        with pytest.raises(RuntimeError, match="unexpected keys"):
+            _check_active_params_invariant({"eligibility_threshold": 0.3})
+
+    def test_error_message_names_the_frozen_dim(self) -> None:
+        from causal_optimizer.benchmarks.hillstrom import _check_active_params_invariant
+
+        leaked = {
+            "eligibility_threshold": 0.3,
+            "regularization": 1.0,
+            "treatment_budget_pct": 0.5,
+            "min_propensity_clip": 0.01,
+        }
+        with pytest.raises(RuntimeError) as excinfo:
+            _check_active_params_invariant(leaked)
+        assert "min_propensity_clip" in str(excinfo.value)
+        assert "Frozen Hillstrom dimensions" in str(excinfo.value)

--- a/tests/unit/test_hillstrom_benchmark.py
+++ b/tests/unit/test_hillstrom_benchmark.py
@@ -1,0 +1,399 @@
+"""Unit tests for the Sprint 31 Hillstrom benchmark harness.
+
+Covers the invariants pinned by the Sprint 31 Hillstrom benchmark contract:
+
+1. slice mapping: primary ``Womens E-Mail vs No E-Mail`` and pooled
+   ``Any E-Mail vs No E-Mail``.
+2. per-slice propensity: exactly ``0.5`` on the primary slice,
+   exactly ``2.0 / 3.0`` on the pooled slice.
+3. projected prior graph: 7 edges over the active-only subgraph with
+   the 3 frozen Hillstrom dimensions removed.
+4. active search space: exactly the 3 tuned dimensions
+   (``eligibility_threshold``, ``regularization``,
+   ``treatment_budget_pct``).
+5. wrapped runner pre-bakes the 3 frozen dimensions into every
+   forwarded parameter dict.
+6. null-control permutation preserves the marginal of ``spend`` and
+   is deterministic under a fixed seed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from causal_optimizer.benchmarks.hillstrom import (
+    HILLSTROM_FROZEN_PARAMS,
+    HILLSTROM_POOLED_PROPENSITY,
+    HILLSTROM_PRIMARY_PROPENSITY,
+    HillstromPolicyRunner,
+    HillstromSliceType,
+    hillstrom_active_search_space,
+    hillstrom_null_baseline,
+    hillstrom_projected_prior_graph,
+    load_hillstrom_slice,
+    permute_hillstrom_spend,
+)
+from causal_optimizer.domain_adapters.marketing_logs import MarketingLogAdapter
+from causal_optimizer.types import VariableType
+
+FIXTURE_PATH = Path(__file__).resolve().parent.parent / "fixtures" / "hillstrom_fixture.csv"
+
+
+@pytest.fixture
+def raw_hillstrom() -> pd.DataFrame:
+    """Load the committed Hillstrom-shaped fixture CSV."""
+    return pd.read_csv(FIXTURE_PATH)
+
+
+# ── Slice mapping ────────────────────────────────────────────────────
+
+
+class TestSliceMapping:
+    """Primary and pooled slice column mapping."""
+
+    def test_primary_slice_drops_mens(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        mens_count = int((raw_hillstrom["segment"] == "Mens E-Mail").sum())
+        assert mens_count > 0, "fixture should contain Mens E-Mail rows"
+        expected_n = len(raw_hillstrom) - mens_count
+        assert len(df) == expected_n
+
+    def test_primary_slice_has_both_arms(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        assert set(df["treatment"].unique()) == {0, 1}
+
+    def test_primary_slice_treatment_maps_correctly(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        # Count Womens rows in the fixture — they should all map to treatment=1
+        womens_in_raw = int((raw_hillstrom["segment"] == "Womens E-Mail").sum())
+        assert int((df["treatment"] == 1).sum()) == womens_in_raw
+        # Every control row should have come from "No E-Mail" in the raw frame
+        control_in_raw = int((raw_hillstrom["segment"] == "No E-Mail").sum())
+        assert int((df["treatment"] == 0).sum()) == control_in_raw
+
+    def test_pooled_slice_keeps_all_rows(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.POOLED)
+        assert len(df) == len(raw_hillstrom)
+
+    def test_pooled_slice_treatment_is_any_email(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.POOLED)
+        email_count = int(
+            (
+                (raw_hillstrom["segment"] == "Mens E-Mail")
+                | (raw_hillstrom["segment"] == "Womens E-Mail")
+            ).sum()
+        )
+        assert int((df["treatment"] == 1).sum()) == email_count
+
+    def test_outcome_is_spend(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        assert "outcome" in df.columns
+        # outcome should be a pass-through of the original spend values for the
+        # non-dropped rows
+        non_mens = raw_hillstrom[raw_hillstrom["segment"] != "Mens E-Mail"]
+        np.testing.assert_allclose(np.sort(df["outcome"].values), np.sort(non_mens["spend"].values))
+
+    def test_channel_constant_email(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        assert (df["channel"] == "email").all()
+
+    def test_segment_bucketed_from_history_segment(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        assert set(df["segment"].unique()) <= {"low", "medium", "high_value"}
+        # Every high_value row must come from one of the top three history_segment
+        # buckets in the raw frame
+        high_raw_segments = raw_hillstrom[
+            raw_hillstrom["history_segment"].isin(
+                ["5) $500 - $750", "6) $750 - $1,000", "7) $1,000 +"]
+            )
+        ]
+        # After dropping Mens, the count of high_value rows in the reshaped frame
+        # must equal the count of high-segment non-Mens rows in the raw frame
+        high_non_mens = int((high_raw_segments["segment"] != "Mens E-Mail").sum())
+        assert int((df["segment"] == "high_value").sum()) == high_non_mens
+
+    def test_cost_constant(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        # Treated rows share a single fixed cost; control rows are zero
+        treated_costs = df.loc[df["treatment"] == 1, "cost"].unique()
+        control_costs = df.loc[df["treatment"] == 0, "cost"].unique()
+        assert len(treated_costs) == 1
+        assert len(control_costs) == 1
+        assert float(treated_costs[0]) > 0.0
+        assert float(control_costs[0]) == 0.0
+
+
+# ── Propensity invariants ────────────────────────────────────────────
+
+
+class TestPropensityInvariants:
+    """The two contract-level propensity pin-downs."""
+
+    def test_primary_propensity_exactly_half(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        # Must be exactly 0.5 on every row — no rounded 0.5000001 drift
+        assert (df["propensity"] == 0.5).all()
+        assert HILLSTROM_PRIMARY_PROPENSITY == 0.5
+
+    def test_pooled_propensity_exactly_two_thirds(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.POOLED)
+        expected = 2.0 / 3.0
+        # Every row must equal 2/3 exactly (bitwise equality after 2.0/3.0
+        # computation); this is the invariant the Sprint 31 smoke test asserts
+        assert (df["propensity"] == expected).all()
+        assert expected == HILLSTROM_POOLED_PROPENSITY
+
+    def test_pooled_propensity_is_not_one_half(self) -> None:
+        # Regression guard against the "most likely implementation bug" flagged
+        # in the Sprint 31 contract: swapping 0.5 onto the pooled slice.
+        assert HILLSTROM_POOLED_PROPENSITY != 0.5
+
+
+# ── Projected prior graph ────────────────────────────────────────────
+
+
+class TestProjectedPriorGraph:
+    """The 7-edge sub-DAG enumerated in Sprint 31 contract Section 4a.i."""
+
+    def test_edge_count_is_seven(self) -> None:
+        graph = hillstrom_projected_prior_graph()
+        assert len(graph.edges) == 7
+
+    def test_edges_match_contract_exactly(self) -> None:
+        graph = hillstrom_projected_prior_graph()
+        expected = {
+            ("eligibility_threshold", "treated_fraction"),
+            ("treatment_budget_pct", "treated_fraction"),
+            ("regularization", "treated_fraction"),
+            ("regularization", "policy_value"),
+            ("treated_fraction", "total_cost"),
+            ("treated_fraction", "policy_value"),
+            ("treated_fraction", "effective_sample_size"),
+        }
+        assert set(graph.edges) == expected
+
+    def test_no_frozen_variable_is_a_tail(self) -> None:
+        graph = hillstrom_projected_prior_graph()
+        frozen_nodes = {"email_share", "social_share_of_remainder", "min_propensity_clip"}
+        tails = {u for u, _ in graph.edges}
+        assert not (tails & frozen_nodes), "no frozen variable may appear as an edge tail"
+
+    def test_no_frozen_variable_appears_as_node(self) -> None:
+        graph = hillstrom_projected_prior_graph()
+        frozen_nodes = {"email_share", "social_share_of_remainder", "min_propensity_clip"}
+        assert not (set(graph.nodes) & frozen_nodes)
+
+    def test_full_adapter_graph_has_all_seven_projected_edges(
+        self, raw_hillstrom: pd.DataFrame
+    ) -> None:
+        # Sanity check: the 7 projected edges must all be present in the
+        # full adapter graph — i.e., the projection is a strict sub-DAG.
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        adapter = MarketingLogAdapter(data=df, seed=0)
+        full = set(adapter.get_prior_graph().edges)
+        projected = set(hillstrom_projected_prior_graph().edges)
+        assert projected.issubset(full)
+        # And the projection must drop exactly 7 edges (14 - 7 = 7)
+        assert len(full - projected) == 7
+
+
+# ── Active search space ──────────────────────────────────────────────
+
+
+class TestActiveSearchSpace:
+    """The 3-variable tuned search space."""
+
+    def test_active_space_has_three_variables(self) -> None:
+        space = hillstrom_active_search_space()
+        assert len(space.variables) == 3
+
+    def test_active_space_names(self) -> None:
+        space = hillstrom_active_search_space()
+        assert set(space.variable_names) == {
+            "eligibility_threshold",
+            "regularization",
+            "treatment_budget_pct",
+        }
+
+    def test_active_space_does_not_contain_frozen_vars(self) -> None:
+        space = hillstrom_active_search_space()
+        names = set(space.variable_names)
+        assert "email_share" not in names
+        assert "social_share_of_remainder" not in names
+        assert "min_propensity_clip" not in names
+
+    def test_active_space_bounds_match_adapter(self) -> None:
+        # Bounds must be inherited from MarketingLogAdapter to keep the
+        # search space numerically identical to the adapter's native ranges
+        # for the 3 tuned dimensions.
+        space = hillstrom_active_search_space()
+        adapter_space = MarketingLogAdapter(
+            data=pd.DataFrame(
+                {
+                    "treatment": [0, 1],
+                    "outcome": [0.0, 1.0],
+                    "cost": [0.0, 0.0],
+                }
+            )
+        ).get_search_space()
+        adapter_vars = {v.name: v for v in adapter_space.variables}
+        for var in space.variables:
+            assert var.variable_type == VariableType.CONTINUOUS
+            assert var.lower == adapter_vars[var.name].lower
+            assert var.upper == adapter_vars[var.name].upper
+
+
+class TestFrozenParameterConstants:
+    """The frozen-dimension constants must match the Sprint 31 contract."""
+
+    def test_frozen_params_dict(self) -> None:
+        assert HILLSTROM_FROZEN_PARAMS == {
+            "email_share": 1.0,
+            "social_share_of_remainder": 0.0,
+            "min_propensity_clip": 0.01,
+        }
+
+
+# ── Wrapped runner ───────────────────────────────────────────────────
+
+
+class TestHillstromPolicyRunner:
+    """The runner that pre-bakes frozen dims into every parameter dict."""
+
+    def test_runner_injects_frozen_params(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        adapter = MarketingLogAdapter(data=df, seed=0)
+        runner = HillstromPolicyRunner(adapter=adapter)
+        active_params = {
+            "eligibility_threshold": 0.3,
+            "regularization": 1.0,
+            "treatment_budget_pct": 0.5,
+        }
+        # The runner must accept an active-only dict and still produce
+        # finite policy_value / total_cost
+        metrics = runner.run(active_params)
+        assert "policy_value" in metrics
+        assert np.isfinite(metrics["policy_value"])
+        # ... and it must not mutate the caller's dict
+        assert "email_share" not in active_params
+        assert "min_propensity_clip" not in active_params
+
+    def test_runner_forwarded_params_match_frozen_constants(
+        self, raw_hillstrom: pd.DataFrame
+    ) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        adapter = MarketingLogAdapter(data=df, seed=0)
+        runner = HillstromPolicyRunner(adapter=adapter)
+        active_params = {
+            "eligibility_threshold": 0.0,
+            "regularization": 0.001,
+            "treatment_budget_pct": 1.0,
+        }
+        forwarded = runner._forward_params(active_params)
+        for key, val in HILLSTROM_FROZEN_PARAMS.items():
+            assert forwarded[key] == val, f"{key}: frozen at {val}, got {forwarded[key]}"
+        for key in ("eligibility_threshold", "regularization", "treatment_budget_pct"):
+            assert forwarded[key] == active_params[key]
+
+
+# ── Null-control path ────────────────────────────────────────────────
+
+
+class TestNullControl:
+    """Permuted-outcome null control setup."""
+
+    def test_permutation_preserves_multiset(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        shuffled = permute_hillstrom_spend(df, seed=0)
+        # Multiset equality: every original value appears exactly once in the shuffled
+        np.testing.assert_allclose(
+            np.sort(shuffled["outcome"].values), np.sort(df["outcome"].values)
+        )
+
+    def test_permutation_preserves_treatment_column(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        shuffled = permute_hillstrom_spend(df, seed=0)
+        assert (shuffled["treatment"].values == df["treatment"].values).all()
+
+    def test_permutation_preserves_propensity_column(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        shuffled = permute_hillstrom_spend(df, seed=0)
+        np.testing.assert_array_equal(shuffled["propensity"].values, df["propensity"].values)
+
+    def test_permutation_is_deterministic_under_same_seed(
+        self, raw_hillstrom: pd.DataFrame
+    ) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        a = permute_hillstrom_spend(df, seed=42)
+        b = permute_hillstrom_spend(df, seed=42)
+        np.testing.assert_array_equal(a["outcome"].values, b["outcome"].values)
+
+    def test_null_baseline_equals_raw_mean_spend(self, raw_hillstrom: pd.DataFrame) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        mu = hillstrom_null_baseline(df)
+        # Contract Section 5g: μ = mean(spend) on the reshaped frame, and
+        # shuffling preserves the column so permuted frames have the same μ
+        expected = float(df["outcome"].mean())
+        assert mu == expected
+        shuffled = permute_hillstrom_spend(df, seed=123)
+        assert hillstrom_null_baseline(shuffled) == mu
+
+    def test_null_control_runs_on_fixture(self, raw_hillstrom: pd.DataFrame) -> None:
+        """Smoke test: the adapter + runner pipeline runs end-to-end on a
+        shuffled frame without raising, returning a finite policy_value.
+        """
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        shuffled = permute_hillstrom_spend(df, seed=7)
+        adapter = MarketingLogAdapter(data=shuffled, seed=0)
+        runner = HillstromPolicyRunner(adapter=adapter)
+        metrics = runner.run(
+            {
+                "eligibility_threshold": 0.2,
+                "regularization": 0.5,
+                "treatment_budget_pct": 0.5,
+            }
+        )
+        assert np.isfinite(metrics["policy_value"])
+        assert np.isfinite(metrics["effective_sample_size"])
+
+
+# ── Defensive guards + HillstromScenario property coverage ─────────
+
+
+class TestDefensiveGuards:
+    """Validation errors and property accessors."""
+
+    def test_load_hillstrom_slice_rejects_missing_columns(self) -> None:
+        bad = pd.DataFrame({"segment": ["Womens E-Mail"], "spend": [1.0]})
+        with pytest.raises(ValueError, match="missing required columns"):
+            load_hillstrom_slice(bad, slice_type=HillstromSliceType.PRIMARY)
+
+    def test_permute_hillstrom_spend_rejects_missing_outcome(
+        self, raw_hillstrom: pd.DataFrame
+    ) -> None:
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        with pytest.raises(ValueError, match="column 'not_an_outcome' not in reshaped frame"):
+            permute_hillstrom_spend(df, seed=0, outcome_col="not_an_outcome")
+
+    def test_scenario_slice_type_property(self, raw_hillstrom: pd.DataFrame) -> None:
+        from causal_optimizer.benchmarks.hillstrom import HillstromScenario
+
+        scenario = HillstromScenario(raw_hillstrom, slice_type=HillstromSliceType.POOLED)
+        assert scenario.slice_type is HillstromSliceType.POOLED
+
+    def test_secondary_outcomes_empty_when_visit_or_conversion_missing(
+        self, raw_hillstrom: pd.DataFrame
+    ) -> None:
+        from causal_optimizer.benchmarks.hillstrom import _secondary_outcomes_under_policy
+
+        df = load_hillstrom_slice(raw_hillstrom, slice_type=HillstromSliceType.PRIMARY)
+        # Drop the retained secondary outcome columns; the guard must
+        # return an empty dict rather than raising or silently producing
+        # garbage aggregates.
+        without_secondary = df.drop(columns=["visit", "conversion"])
+        result = _secondary_outcomes_under_policy(without_secondary, {})
+        assert result == {}

--- a/tests/unit/test_hillstrom_benchmark_script.py
+++ b/tests/unit/test_hillstrom_benchmark_script.py
@@ -1,0 +1,208 @@
+"""Unit tests for ``scripts/hillstrom_benchmark.py`` CLI helpers.
+
+Covers the pure-logic pieces of the Hillstrom benchmark runner:
+argument parsing, validation helpers, and the JSON sanitizer. The
+end-to-end CLI run is exercised indirectly by the integration tests
+and by a fixture-backed smoke run; these unit tests lock the helpers'
+behavior so future edits do not silently drift.
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+# scripts/hillstrom_benchmark.py is not a package module; resolve it
+# the same way tests/integration/conftest.py resolves
+# scripts/energy_predictive_benchmark.py.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import hillstrom_benchmark as hb  # noqa: E402
+
+
+class TestSanitizeForJson:
+    """``_sanitize_for_json`` must return JSON-safe Python types."""
+
+    def test_passes_through_plain_dict(self) -> None:
+        obj = {"a": 1, "b": "two"}
+        assert hb._sanitize_for_json(obj) == obj
+
+    def test_recurses_into_nested_dict(self) -> None:
+        obj = {"outer": {"inner": 1.5}}
+        assert hb._sanitize_for_json(obj) == {"outer": {"inner": 1.5}}
+
+    def test_recurses_into_list(self) -> None:
+        assert hb._sanitize_for_json([1, 2, 3]) == [1, 2, 3]
+
+    def test_recurses_into_tuple_returns_list(self) -> None:
+        assert hb._sanitize_for_json((1, 2)) == [1, 2]
+
+    def test_numpy_integer_becomes_python_int(self) -> None:
+        out = hb._sanitize_for_json(np.int64(42))
+        assert out == 42
+        assert isinstance(out, int)
+        assert not isinstance(out, np.integer)
+
+    def test_numpy_float_becomes_python_float(self) -> None:
+        out = hb._sanitize_for_json(np.float64(1.5))
+        assert out == 1.5
+        assert isinstance(out, float)
+        assert not isinstance(out, np.floating)
+
+    def test_numpy_bool_becomes_python_bool(self) -> None:
+        out = hb._sanitize_for_json(np.bool_(True))
+        assert out is True
+
+    def test_python_nan_becomes_none(self) -> None:
+        assert hb._sanitize_for_json(float("nan")) is None
+
+    def test_python_inf_becomes_none(self) -> None:
+        assert hb._sanitize_for_json(float("inf")) is None
+        assert hb._sanitize_for_json(float("-inf")) is None
+
+    def test_numpy_nan_becomes_none(self) -> None:
+        assert hb._sanitize_for_json(np.float64("nan")) is None
+
+    def test_nested_nan_in_dict_is_sanitized(self) -> None:
+        out = hb._sanitize_for_json({"loss": float("nan"), "acc": 0.9})
+        assert out == {"loss": None, "acc": 0.9}
+
+
+class TestParseIntList:
+    """``_parse_int_list`` converts comma-separated args into int lists."""
+
+    def test_happy_path(self) -> None:
+        assert hb._parse_int_list("0,1,2", "seeds") == [0, 1, 2]
+
+    def test_strips_whitespace(self) -> None:
+        assert hb._parse_int_list("0, 1 , 2", "seeds") == [0, 1, 2]
+
+    def test_single_value(self) -> None:
+        assert hb._parse_int_list("42", "seeds") == [42]
+
+    def test_non_integer_exits_with_error(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            hb._parse_int_list("not-a-number", "seeds")
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "--seeds must be comma-separated integers" in captured.err
+
+
+class TestValidateBudgets:
+    def test_accepts_positive_budgets(self) -> None:
+        hb._validate_budgets([1, 20, 80])  # must not raise
+
+    def test_rejects_zero(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            hb._validate_budgets([0])
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "must be positive integers" in captured.err
+
+    def test_rejects_negative(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            hb._validate_budgets([-5])
+        captured = capsys.readouterr()
+        assert "must be positive integers" in captured.err
+
+
+class TestValidateStrategies:
+    def test_accepts_all_valid(self) -> None:
+        hb._validate_strategies(["random", "surrogate_only", "causal"])
+
+    def test_rejects_unknown(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            hb._validate_strategies(["magic"])
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "Unknown strategy 'magic'" in captured.err
+
+    def test_error_message_lists_valid_strategies(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit):
+            hb._validate_strategies(["bad"])
+        captured = capsys.readouterr()
+        # Must mention all three valid strategies from the shared
+        # VALID_STRATEGIES frozenset, not a local copy.
+        assert "random" in captured.err
+        assert "surrogate_only" in captured.err
+        assert "causal" in captured.err
+
+
+class TestValidateSlices:
+    def test_accepts_primary_and_pooled(self) -> None:
+        hb._validate_slices(["primary"])
+        hb._validate_slices(["pooled"])
+        hb._validate_slices(["primary", "pooled"])
+
+    def test_rejects_unknown_slice(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with pytest.raises(SystemExit) as excinfo:
+            hb._validate_slices(["sideways"])
+        assert excinfo.value.code == 1
+        captured = capsys.readouterr()
+        assert "Unknown slice 'sideways'" in captured.err
+
+
+class TestParseArgs:
+    def test_required_data_path(self) -> None:
+        args = hb.parse_args(["--data-path", "x.csv"])
+        assert args.data_path == "x.csv"
+        assert args.slices == "primary"
+        assert args.budgets == "20,40,80"
+        assert args.seeds == "0,1,2,3,4"
+        assert args.strategies == "random,surrogate_only,causal"
+        assert args.null_control is False
+        assert args.output == "hillstrom_results.json"
+
+    def test_null_control_flag_enables(self) -> None:
+        args = hb.parse_args(["--data-path", "x.csv", "--null-control"])
+        assert args.null_control is True
+
+    def test_missing_data_path_errors(self) -> None:
+        with pytest.raises(SystemExit):
+            hb.parse_args([])
+
+
+class TestSharedStrategiesSourceOfTruth:
+    """Regression guard: the CLI's valid strategies must equal the
+    benchmark module's public ``VALID_STRATEGIES`` frozenset. The two
+    used to be duplicated; a silent divergence was the motivation for
+    consolidation."""
+
+    def test_cli_imports_from_benchmark_module(self) -> None:
+        from causal_optimizer.benchmarks.hillstrom import VALID_STRATEGIES
+
+        assert hb.VALID_STRATEGIES is VALID_STRATEGIES
+
+
+class TestFmtMeanStd:
+    """Summary-table formatting helper."""
+
+    def test_empty_list_returns_na(self) -> None:
+        assert hb._fmt_mean_std([]) == "N/A"
+
+    def test_single_value(self) -> None:
+        out = hb._fmt_mean_std([1.0])
+        assert "1.0000" in out
+        assert "+/-" in out
+
+    def test_multiple_values(self) -> None:
+        out = hb._fmt_mean_std([1.0, 2.0, 3.0])
+        # mean = 2.0, std = ~0.8165
+        assert "2.0000" in out
+
+    def test_handles_nonfinite(self) -> None:
+        # Infinite values are not filtered by _fmt_mean_std itself (the
+        # filtering happens in _print_summary). Sanity check that they
+        # do not crash the helper.
+        out = hb._fmt_mean_std([1.0, float("inf")])
+        assert isinstance(out, str)
+        # Output contains either a number or 'inf'; the test only
+        # asserts no exception.
+        assert out  # not empty
+        assert math.isinf(float("inf"))  # sanity anchor

--- a/tests/unit/test_hillstrom_benchmark_script.py
+++ b/tests/unit/test_hillstrom_benchmark_script.py
@@ -180,6 +180,64 @@ class TestSharedStrategiesSourceOfTruth:
         assert hb.VALID_STRATEGIES is VALID_STRATEGIES
 
 
+class TestMainEndToEnd:
+    """End-to-end CLI smoke test: exercises ``main()`` on the fixture.
+
+    The individual CLI helpers are covered by the tests above; this test
+    covers the I/O orchestration path that stitches them together
+    (scenario construction, strategy loop, JSON write). A ``random``
+    strategy with budget 3 and seeds 0 keeps the runtime well under a
+    second so it is safe to include in the fast suite.
+    """
+
+    def test_main_writes_json_artifact_with_results_and_provenance(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import json
+
+        fixture_path = Path(__file__).resolve().parent.parent / "fixtures" / "hillstrom_fixture.csv"
+        output_path = tmp_path / "smoke.json"
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "hillstrom_benchmark.py",
+                "--data-path",
+                str(fixture_path),
+                "--slices",
+                "primary",
+                "--budgets",
+                "3",
+                "--seeds",
+                "0",
+                "--strategies",
+                "random",
+                "--output",
+                str(output_path),
+            ],
+        )
+
+        hb.main()
+
+        assert output_path.exists()
+        payload = json.loads(output_path.read_text())
+        assert payload["benchmark"] == "sprint_31_hillstrom"
+        assert len(payload["results"]) == 1
+        result = payload["results"][0]
+        assert result["strategy"] == "random"
+        assert result["slice_type"] == "primary"
+        assert result["is_null_control"] is False
+        assert result["budget"] == 3
+        assert result["seed"] == 0
+        # Provenance must include Hillstrom-specific fields
+        assert "hillstrom" in payload["provenance"]
+        hillstrom_prov = payload["provenance"]["hillstrom"]
+        assert hillstrom_prov["projected_graph_edge_count"] == 7
+        assert "primary" in hillstrom_prov["null_baselines"]
+        assert hillstrom_prov["null_control_enabled"] is False
+
+
 class TestLoadRaw:
     """``_load_raw`` dispatches on file extension."""
 
@@ -205,15 +263,15 @@ class TestLoadRaw:
         original = pd.read_parquet
         calls: list[str] = []
 
-        def fake_read_parquet(path: str) -> pd.DataFrame:  # type: ignore[no-untyped-def]
+        def fake_read_parquet(path: str) -> pd.DataFrame:
             calls.append(str(path))
             return fake_frame
 
-        pd.read_parquet = fake_read_parquet  # type: ignore[assignment]
+        pd.read_parquet = fake_read_parquet
         try:
             df = hb._load_raw(str(tmp_path / "data.parquet"))
         finally:
-            pd.read_parquet = original  # type: ignore[assignment]
+            pd.read_parquet = original
 
         assert calls == [str(tmp_path / "data.parquet")]
         assert list(df.columns) == ["segment", "spend"]

--- a/tests/unit/test_hillstrom_benchmark_script.py
+++ b/tests/unit/test_hillstrom_benchmark_script.py
@@ -73,6 +73,30 @@ class TestSanitizeForJson:
         out = hb._sanitize_for_json({"loss": float("nan"), "acc": 0.9})
         assert out == {"loss": None, "acc": 0.9}
 
+    def test_hillstrom_provenance_nan_baseline_is_sanitized(self) -> None:
+        """Regression: an empty primary slice produces null_baseline=nan.
+
+        If the provenance dict is not passed through _sanitize_for_json
+        before json.dump(..., allow_nan=False), the write crashes. This
+        test pins the fix by building the exact shape of the provenance
+        dict with a nan baseline and verifying the sanitizer converts it
+        to None.
+        """
+        import json
+
+        provenance = hb._sanitize_for_json(
+            {
+                "slices": ["primary"],
+                "null_control_enabled": False,
+                "projected_graph_edge_count": 7,
+                "projected_graph_edges": [["a", "b"]],
+                "null_baselines": {"primary": float("nan")},
+            }
+        )
+        assert provenance["null_baselines"]["primary"] is None
+        # Must serialize without error under allow_nan=False
+        json.dumps(provenance, allow_nan=False)
+
 
 class TestParseIntList:
     """``_parse_int_list`` converts comma-separated args into int lists."""

--- a/tests/unit/test_hillstrom_benchmark_script.py
+++ b/tests/unit/test_hillstrom_benchmark_script.py
@@ -180,6 +180,45 @@ class TestSharedStrategiesSourceOfTruth:
         assert hb.VALID_STRATEGIES is VALID_STRATEGIES
 
 
+class TestLoadRaw:
+    """``_load_raw`` dispatches on file extension."""
+
+    def test_csv_path(self, tmp_path: Path) -> None:
+        import pandas as pd
+
+        csv_path = tmp_path / "data.csv"
+        pd.DataFrame({"a": [1, 2], "b": ["x", "y"]}).to_csv(csv_path, index=False)
+        df = hb._load_raw(str(csv_path))
+        assert list(df.columns) == ["a", "b"]
+        assert len(df) == 2
+
+    def test_parquet_path(self, tmp_path: Path) -> None:
+        """The ``.parquet`` branch must route to ``pd.read_parquet``.
+
+        We monkey-patch ``pd.read_parquet`` rather than writing a real
+        parquet file because parquet support may not be installed in
+        every test environment (it requires ``pyarrow`` or ``fastparquet``).
+        """
+        import pandas as pd
+
+        fake_frame = pd.DataFrame({"segment": ["Womens E-Mail"], "spend": [10.0]})
+        original = pd.read_parquet
+        calls: list[str] = []
+
+        def fake_read_parquet(path: str) -> pd.DataFrame:  # type: ignore[no-untyped-def]
+            calls.append(str(path))
+            return fake_frame
+
+        pd.read_parquet = fake_read_parquet  # type: ignore[assignment]
+        try:
+            df = hb._load_raw(str(tmp_path / "data.parquet"))
+        finally:
+            pd.read_parquet = original  # type: ignore[assignment]
+
+        assert calls == [str(tmp_path / "data.parquet")]
+        assert list(df.columns) == ["segment", "spend"]
+
+
 class TestFmtMeanStd:
     """Summary-table formatting helper."""
 


### PR DESCRIPTION
Closes #168.

## Summary

Implements the Sprint 31 Hillstrom benchmark under the launch contract locked in `thoughts/shared/docs/sprint-31-hillstrom-benchmark-contract.md` (PR #167, still pending review). Reuses `MarketingLogAdapter` unchanged via a narrow loader + wrapped runner.

- `causal_optimizer/benchmarks/hillstrom.py` — `HillstromLoader` (`load_hillstrom_slice`), `HillstromSliceType` enum, active 3-variable search space, 7-edge projected prior graph, `HillstromPolicyRunner` that pre-bakes the three frozen dimensions, permuted-outcome null-control helpers, `HillstromScenario` / `HillstromBenchmarkResult`.
- `scripts/hillstrom_benchmark.py` — CLI runner over (slice, budget, seed, strategy) with optional `--null-control` pass and Hillstrom-specific provenance stamping (projected-graph edge list, per-slice null baselines, full dataset hash).
- `tests/fixtures/hillstrom_fixture.csv` — 300-row Hillstrom-shaped synthetic fixture (three balanced arms) with zero-inflated spend and realistic arm-dependent response rates.
- Tests: 34 unit + 11 integration, 100% coverage on the new module.

## Contract fidelity

| Contract invariant | How the code enforces it |
|-------------------|--------------------------|
| Primary propensity = exactly `0.5` | `HILLSTROM_PRIMARY_PROPENSITY = 0.5`; loader fills the column with `np.full(..., 0.5)`; unit test asserts bitwise equality on every row |
| Pooled propensity = exactly `2/3` | `HILLSTROM_POOLED_PROPENSITY = 2.0 / 3.0`; loader fills the column with `np.full(..., 2.0/3.0)`; unit test asserts bitwise equality and `!= 0.5` |
| Frozen params pre-baked | `HILLSTROM_FROZEN_PARAMS = {email_share: 1.0, social_share_of_remainder: 0.0, min_propensity_clip: 0.01}`; `HillstromPolicyRunner._forward_params` injects all three into every forwarded call without mutating the caller's dict |
| 7-edge projected prior graph | `hillstrom_projected_prior_graph()` returns the 7 explicit edges; unit tests assert: exact edge set, no frozen variable as tail/node, strict-subset of the full 14-edge adapter graph |
| Null baseline = `μ = mean(spend)` on the unshuffled frame | `hillstrom_null_baseline(real_slice)` returns a scalar once at scenario construction time; unit test confirms the baseline is invariant under any permutation seed |
| `history_segment` bucket map uses raw CSV strings with numeric prefix | `_HISTORY_SEGMENT_TO_SEGMENT` keyed on `"1) $0 - $100"`, etc. |
| No changes to `domain_adapters/marketing_logs.py` | Loader wraps an unmodified `MarketingLogAdapter` instance; `git diff main -- causal_optimizer/domain_adapters/marketing_logs.py` is empty |

## Smoke verification

- `uv run pytest tests/unit/test_hillstrom_benchmark.py tests/integration/test_hillstrom_benchmark.py` → **45/45 pass** in 0.69s.
- `uv run pytest -m "not slow"` → **1096 passed**, 10 skipped, 0 failures.
- `--cov=causal_optimizer` → **100% line coverage** on `causal_optimizer/benchmarks/hillstrom.py` (155/155 statements).
- `uv run mypy causal_optimizer/` → clean.
- `uv run ruff check . && uv run ruff format --check .` → clean.
- `scripts/hillstrom_benchmark.py --data-path tests/fixtures/hillstrom_fixture.csv --slices primary --budgets 20 --seeds 0,1,2,3,4 --strategies random,surrogate_only,causal --null-control` completes in **~1m48s** under `ax_botorch` (30 adapter evaluations). Observed results on the fixture:
  - Real primary slice: causal / surrogate_only `4.24 ± 0.35` vs random `3.01 ± 0.22`.
  - Null control: all strategies `~3.2–3.3` vs `μ=2.45`. This is noisy on the 300-row fixture with only 18 nonzero spend rows — expected behavior, and exactly the scenario the contract's fallback ladder in Section 5g is designed for. **Not a benchmark verdict.** The contract explicitly cautions against drawing conclusions from fixture-sized smoke runs; a real benchmark run against the full Hillstrom CSV is a separate sprint-task.

## What this PR does not do

- Full Hillstrom benchmark runs (those need the full CSV, local-only).
- Multi-action three-arm policy — deferred to a later sprint per contract Section 4c.
- Any adapter code changes.
- Any optimizer-core default tuning.

## Test plan

- [ ] Unit tests: `uv run pytest tests/unit/test_hillstrom_benchmark.py -v`
- [ ] Integration tests: `uv run pytest tests/integration/test_hillstrom_benchmark.py -v`
- [ ] Full fast suite regression: `uv run pytest -m "not slow"`
- [ ] Coverage: `uv run pytest tests/unit/test_hillstrom_benchmark.py tests/integration/test_hillstrom_benchmark.py --cov=causal_optimizer --cov-report=term-missing` — expect 100% on `causal_optimizer/benchmarks/hillstrom.py`
- [ ] CLI smoke: `uv run python scripts/hillstrom_benchmark.py --data-path tests/fixtures/hillstrom_fixture.csv --slices primary --budgets 20 --seeds 0 --strategies random --output /tmp/hillstrom_smoke.json`
- [ ] Human approval before merge, per CLAUDE.md hard merge rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements the Sprint 31 Hillstrom benchmark harness as specified by the locked contract doc. It adds a loader (`load_hillstrom_slice`), a frozen-param injecting runner (`HillstromPolicyRunner`), three strategies (random / surrogate_only / causal), and a null-control permutation path — all wired together in `HillstromScenario` — with a 300-row synthetic fixture and 45 tests (34 unit + 11 integration) at 100% coverage. The three issues flagged in the prior review round (duplicated `_VALID_STRATEGIES`, misleading `--null-control` help text, and the `params`-unused secondary-outcomes signature) are all resolved in this version.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all contract invariants are correctly implemented and the three prior review comments are resolved.

All remaining findings are P2 style suggestions (split import block, mutable module-level dict). No correctness, data-integrity, or behavioral issues were found. Contract fidelity is solid: propensity pins, frozen-param injection, 7-edge projected graph, and null-control baseline are all implemented and pin-tested.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| causal_optimizer/benchmarks/hillstrom.py | Core benchmark module: contract constants, loader, projected prior graph, policy runner, null-control helpers, and scenario — well-structured with good defensive guards. Minor: module-level HILLSTROM_FROZEN_PARAMS dict is mutable. |
| scripts/hillstrom_benchmark.py | CLI runner over the strategy/budget/seed grid with JSON provenance output; imports VALID_STRATEGIES from the benchmark module (prior duplication issue resolved); null-control help text now accurately reflects the b <= 40 fallback logic. |
| causal_optimizer/benchmarks/__init__.py | Re-exports all new Hillstrom public symbols; uses two separate import blocks from the same hillstrom module — harmless but could be merged. |
| tests/unit/test_hillstrom_benchmark.py | 34 unit tests locking all contract invariants (slice mapping, propensity pins, edge set, search space bounds, frozen-param injection, null permutation); includes cache-clearing discipline around the monkeypatched lru_cache test. |
| tests/integration/test_hillstrom_benchmark.py | 11 integration tests exercising the full engine loop path for all three strategies on both slices and the null-control path; deliberately small budgets (8 experiments) for CI speed. |
| tests/unit/test_hillstrom_benchmark_script.py | Covers CLI helpers and an end-to-end main() smoke test; includes a regression guard confirming the script's VALID_STRATEGIES is the same object as the module's. |
| tests/fixtures/hillstrom_fixture.csv | 300-row synthetic fixture with three balanced arms, zero-inflated spend, and arm-dependent response rates. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Acausal_optimizer%2Fbenchmarks%2F__init__.py%3A23-25%0A**Two%20import%20blocks%20from%20the%20same%20module**%0A%0A%60VALID_STRATEGIES%20as%20HILLSTROM_VALID_STRATEGIES%60%20is%20split%20into%20its%20own%20block%20solely%20because%20it's%20a%20renamed%20import.%20Merging%20it%20into%20the%20first%20block%20is%20cleaner%20and%20avoids%20two%20separate%20module%20loads%20%28Python%20deduplicates%20them%2C%20but%20the%20visual%20split%20suggests%20a%20distinction%20that%20doesn't%20exist%20at%20runtime%29%3A%0A%0A%60%60%60suggestion%0Afrom%20causal_optimizer.benchmarks.hillstrom%20import%20%28%0A%20%20%20%20HILLSTROM_FROZEN_PARAMS%2C%0A%20%20%20%20HILLSTROM_POOLED_PROPENSITY%2C%0A%20%20%20%20HILLSTROM_PRIMARY_PROPENSITY%2C%0A%20%20%20%20VALID_STRATEGIES%20as%20HILLSTROM_VALID_STRATEGIES%2C%0A%20%20%20%20HillstromBenchmarkResult%2C%0A%20%20%20%20HillstromPolicyRunner%2C%0A%20%20%20%20HillstromScenario%2C%0A%20%20%20%20HillstromSliceType%2C%0A%20%20%20%20hillstrom_active_search_space%2C%0A%20%20%20%20hillstrom_null_baseline%2C%0A%20%20%20%20hillstrom_projected_prior_graph%2C%0A%20%20%20%20load_hillstrom_slice%2C%0A%20%20%20%20permute_hillstrom_spend%2C%0A%29%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Acausal_optimizer%2Fbenchmarks%2Fhillstrom.py%3A168-172%0A**%60HILLSTROM_FROZEN_PARAMS%60%20is%20a%20mutable%20module-level%20dict**%0A%0AAny%20code%20%28including%20test%20helpers%20or%20future%20callers%29%20that%20does%20%60HILLSTROM_FROZEN_PARAMS%5B%22email_share%22%5D%20%3D%202.0%60%20or%20%60HILLSTROM_FROZEN_PARAMS.pop%28...%29%60%20will%20silently%20corrupt%20the%20frozen%20params%20injected%20by%20every%20subsequent%20%60HillstromPolicyRunner._forward_params%60%20call%20in%20that%20process%20%E2%80%94%20including%20parallel%20benchmark%20runs.%20Wrapping%20it%20in%20%60types.MappingProxyType%60%20makes%20accidental%20mutation%20an%20immediate%20%60TypeError%60%3A%0A%0A%60%60%60python%0Aimport%20types%0A%0AHILLSTROM_FROZEN_PARAMS%3A%20types.MappingProxyType%5Bstr%2C%20float%5D%20%3D%20types.MappingProxyType%28%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%20%20%22email_share%22%3A%201.0%2C%0A%20%20%20%20%20%20%20%20%22social_share_of_remainder%22%3A%200.0%2C%0A%20%20%20%20%20%20%20%20%22min_propensity_clip%22%3A%200.01%2C%0A%20%20%20%20%7D%0A%29%0A%60%60%60%0A%0AThe%20%60_forward_params%60%20loop%20%28%60for%20key%2C%20value%20in%20HILLSTROM_FROZEN_PARAMS.items%28%29%60%29%20works%20unchanged%20on%20a%20%60MappingProxyType%60.%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: causal_optimizer/benchmarks/__init__.py
Line: 23-25

Comment:
**Two import blocks from the same module**

`VALID_STRATEGIES as HILLSTROM_VALID_STRATEGIES` is split into its own block solely because it's a renamed import. Merging it into the first block is cleaner and avoids two separate module loads (Python deduplicates them, but the visual split suggests a distinction that doesn't exist at runtime):

```suggestion
from causal_optimizer.benchmarks.hillstrom import (
    HILLSTROM_FROZEN_PARAMS,
    HILLSTROM_POOLED_PROPENSITY,
    HILLSTROM_PRIMARY_PROPENSITY,
    VALID_STRATEGIES as HILLSTROM_VALID_STRATEGIES,
    HillstromBenchmarkResult,
    HillstromPolicyRunner,
    HillstromScenario,
    HillstromSliceType,
    hillstrom_active_search_space,
    hillstrom_null_baseline,
    hillstrom_projected_prior_graph,
    load_hillstrom_slice,
    permute_hillstrom_spend,
)
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: causal_optimizer/benchmarks/hillstrom.py
Line: 168-172

Comment:
**`HILLSTROM_FROZEN_PARAMS` is a mutable module-level dict**

Any code (including test helpers or future callers) that does `HILLSTROM_FROZEN_PARAMS["email_share"] = 2.0` or `HILLSTROM_FROZEN_PARAMS.pop(...)` will silently corrupt the frozen params injected by every subsequent `HillstromPolicyRunner._forward_params` call in that process — including parallel benchmark runs. Wrapping it in `types.MappingProxyType` makes accidental mutation an immediate `TypeError`:

```python
import types

HILLSTROM_FROZEN_PARAMS: types.MappingProxyType[str, float] = types.MappingProxyType(
    {
        "email_share": 1.0,
        "social_share_of_remainder": 0.0,
        "min_propensity_clip": 0.01,
    }
)
```

The `_forward_params` loop (`for key, value in HILLSTROM_FROZEN_PARAMS.items()`) works unchanged on a `MappingProxyType`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: sanitize hillstrom\_provenance befor..."](https://github.com/datablogin/causal-optimizer/commit/bd118093429b6a4ca60234de3060a04f059df8f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28517457)</sub>

<!-- /greptile_comment -->