### PR TITLE
docs: Criteo Uplift access and adapter-gap audit

### DIFF
--- a/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
+++ b/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-16
 **Sprint:** 31 (General Causal Autoresearch: First Non-Energy Real-Data Benchmark)
-**Issue:** #171
+**Issue:** [#171](https://github.com/datablogin/causal-optimizer/issues/171)
 **Branch:** `sprint-31/criteo-uplift-audit`
 **Status:** Audit document. No code changes.
 
@@ -26,7 +26,7 @@ It answers six questions:
 | Item | Value |
 |------|-------|
 | Official page | <https://ailab.criteo.com/criteo-uplift-prediction-dataset/> |
-| Direct download (v2.1) | `http://go.criteo.net/criteo-research-uplift-v2.1.csv.gz` |
+| Direct download (v2.1) | `https://go.criteo.net/criteo-research-uplift-v2.1.csv.gz` |
 | Hugging Face mirror | <https://huggingface.co/datasets/criteo/criteo-uplift> |
 | Reference paper | Diemert et al., "A Large Scale Benchmark for Uplift Modeling", AdKDD 2018, KDD London |
 | Extended paper | Diemert et al., "A Large Scale Benchmark for Individual Treatment Effect Prediction and Uplift Modeling", 2021 (arXiv:2111.10106) |
@@ -227,7 +227,7 @@ onto the adapter contract:
 | `outcome` | `visit` (primary) or `conversion` (secondary) | Pass-through (binary 0/1, used as float) |
 | `cost` | synthesized | Fixed constant (e.g., 0.01 treated, 0.0 control) |
 | `propensity` | synthesized | Constant 0.85 (from known randomization ratio) |
-| `channel` | constant | `"email"` (or `"ad"` — degenerate, single channel) |
+| `channel` | constant | `"ad"` (degenerate, single channel; Criteo is display/RTB, not e-mail) |
 | `segment` | synthesized | Must be derived from f0-f11; no natural segment column exists |
 
 **What reuses cleanly:**
@@ -426,8 +426,9 @@ exposure-based analysis.
    exercised on Hillstrom before being applied to a harder dataset.
 
 3. **IPS variance diagnostics are understood.** The Hillstrom run
-   should establish baseline expectations for `weight_cv`, `max_ips_
-   weight`, and `effective_sample_size` on a dataset where propensities
+   should establish baseline expectations for `weight_cv`,
+   `max_ips_weight`, and `effective_sample_size` on a dataset where
+   propensities
    are balanced (0.5). Criteo's 85:15 imbalance will stress these
    diagnostics, and the team needs calibrated expectations.
 

--- a/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
+++ b/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
@@ -39,7 +39,7 @@ unauthenticated access and offers both CSV and Parquet formats.
 **Dataset versions:** The current recommended version is v2.1. The
 v2 release rebalanced the treatment ratio across multiple incrementality
 tests that were pooled into the dataset, eliminating hidden confounding
-from varying per-advertiser test designs. v2.1 is a minor update to v2.
+from varying per-advertiser test designs. v2.1 is a minor update to v2 and retains the v2 rebalancing.
 
 ## 2. License and Usage Restrictions
 
@@ -91,8 +91,11 @@ license tracking that Hillstrom did not need.
 1. Download: ~300 MB, one-time, no authentication
 2. Disk: ~300 MB compressed or ~311 MB uncompressed; both are small by
    modern standards
-3. Memory: loading the full 14M-row CSV into a pandas DataFrame will
-   consume approximately 1.7 GB. This is manageable on any modern
+3. Memory: loading the full 14M-row CSV into a pandas DataFrame at
+   default dtypes (float64) will consume approximately 1.7 GB. Using
+   int8 for the 4 binary columns and float32 for features would cut
+   this to ~850 MB, but the default estimate is the conservative
+   planning number. Either way, this is manageable on any modern
    development machine but is a meaningful step up from Hillstrom
    (64K rows, ~5 MB) or the marketing fixture (300 rows, ~30 KB).
 4. Per-run cost: a single `MarketingLogAdapter.run_experiment()` call
@@ -277,9 +280,15 @@ Hillstrom does not impose:
 1. **Extreme treatment imbalance (85:15).** Control observations have
    IPS weight `1 / (1 - 0.85) = 6.67`. This is higher than Hillstrom's
    maximum weight of 2.0 (from `1 / 0.5`). The `min_propensity_clip`
-   parameter does not help because `0.85` is within the adapter's
-   `[0.01, 0.5]` clip range (clipping the upper bound to `1 - 0.01 =
-   0.99` does not touch `0.85`). The 6.67x weight on 15% of
+   parameter does not help here. The adapter's `min_propensity_clip`
+   parameter range is `[0.01, 0.5]`, and the adapter clips propensities
+   symmetrically to `[clip, 1 - clip]`. At the default `clip = 0.01`,
+   propensities are clipped to `[0.01, 0.99]`. Since Criteo's constant
+   propensity of `0.85` falls inside this range, clipping never fires
+   and the control-arm weight remains `1 / (1 - 0.85) = 6.67`. Even at
+   the maximum `clip = 0.5`, the range becomes `[0.5, 0.5]`, which
+   would collapse all propensities to 0.5 — a distortion, not a fix.
+   The 6.67x weight on 15% of
    observations means control-arm observations dominate IPS estimates.
    This is not wrong, but it increases variance.
 
@@ -366,7 +375,9 @@ maximize `policy_value` relative to alternatives. It does not need to
 recover absolute incrementality. The non-uniform subsampling therefore
 does not invalidate the benchmark use case, but it means the project
 cannot compare Criteo effect sizes to Hillstrom or energy effect sizes
-in absolute terms. Claim language must note this.
+in absolute terms. The benchmark report's limitations section must
+state that absolute effect sizes are not comparable across datasets
+due to Criteo's non-uniform subsampling.
 
 ### 8d. Anonymized Features
 

--- a/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
+++ b/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
@@ -90,8 +90,8 @@ license tracking that Hillstrom did not need.
 **Local setup cost:**
 
 1. Download: ~300 MB, one-time, no authentication
-2. Disk: ~300 MB compressed or ~311 MB uncompressed; both are small by
-   modern standards
+2. Disk: ~300 MB gzip CSV or ~311 MB Parquet (Hugging Face); uncompressed
+   CSV is ~900 MB - 1.5 GB (see table above)
 3. Memory: loading the full 14M-row CSV into a pandas DataFrame at
    default dtypes (float64) will consume approximately 1.7 GB. Using
    int8 for the 4 binary columns and float32 for features would cut

--- a/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
+++ b/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
@@ -183,8 +183,8 @@ applies.
 **Primary objective recommendation:** Use `visit` (4.70% base rate) as
 the primary outcome for the first run. `conversion` (0.29%) is too rare
 for stable per-seed IPS-weighted estimates at the subsampled scale
-(1M rows x 0.29% = ~2,900 positive outcomes, of which ~435 are in the
-15% control arm). Track `conversion` as a secondary reported outcome.
+(1M rows x 0.29% = ~2,900 positive outcomes; of those,
+~15% are control = ~435 control-arm conversions). Track `conversion` as a secondary reported outcome.
 
 ## 6. Propensity Availability
 
@@ -290,7 +290,10 @@ Hillstrom does not impose:
    would collapse all propensities to 0.5 — a distortion, not a fix.
    The 6.67x weight on 15% of
    observations means control-arm observations dominate IPS estimates.
-   This is not wrong, but it increases variance.
+   This is not wrong, but it increases variance. Note that this is
+   structurally different from the typical clipping use case (estimated
+   propensities near 0 or 1): Criteo's propensity of 0.85 is moderate,
+   but its complement (0.15) creates high control-arm weights.
 
 2. **Rare binary outcomes (0.29% conversion, 4.70% visit).** IPS
    weighting on a sparse binary outcome amplifies noise. A single
@@ -424,6 +427,10 @@ exposure-based analysis.
 
 ### Entry Sprint: Sprint 33 (earliest), contingent on Hillstrom outcome
 
+**Dependency chain:** Sprint 31 proves the wrapper pattern on Hillstrom.
+Sprint 32 publishes the Hillstrom report and calibrates IPS diagnostics.
+Sprint 33 starts Criteo.
+
 **Prerequisites before starting Criteo:**
 
 1. **Hillstrom benchmark is stable.** The wrapper pattern (column
@@ -445,7 +452,9 @@ exposure-based analysis.
 
 4. **License tracking is in place.** A mechanism for attaching
    CC-BY-NC-SA-4.0 attribution to committed fixture data must exist
-   before Criteo data enters the repo.
+   before Criteo data enters the repo. Concrete proposal: add a
+   `tests/fixtures/DATA-LICENSES.md` file listing each fixture's
+   dataset name, license, required attribution, and row count.
 
 ### Recommended Sprint 33 Criteo Contract Shape
 

--- a/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
+++ b/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
@@ -1,0 +1,526 @@
+# Sprint 31 Criteo Uplift Access and Adapter-Gap Audit
+
+**Date:** 2026-04-16
+**Sprint:** 31 (General Causal Autoresearch: First Non-Energy Real-Data Benchmark)
+**Issue:** #171
+**Branch:** `sprint-31/criteo-uplift-audit`
+**Status:** Audit document. No code changes.
+
+## 0. Purpose
+
+This document is the access, licensing, and adapter-gap audit for the
+Criteo Uplift Prediction Dataset, the Priority 2 follow-on benchmark
+after Hillstrom in the Sprint 31 generalization research plan.
+
+It answers six questions:
+
+1. Can we legally use the dataset for this project?
+2. How big is it and what does local setup cost?
+3. What is the treatment and outcome structure?
+4. Are propensities explicit or do they need estimation?
+5. How far is the dataset from the current adapter contract?
+6. When should it enter the benchmark queue?
+
+## 1. Official Source and Download Path
+
+| Item | Value |
+|------|-------|
+| Official page | <https://ailab.criteo.com/criteo-uplift-prediction-dataset/> |
+| Direct download (v2.1) | `http://go.criteo.net/criteo-research-uplift-v2.1.csv.gz` |
+| Hugging Face mirror | <https://huggingface.co/datasets/criteo/criteo-uplift> |
+| Reference paper | Diemert et al., "A Large Scale Benchmark for Uplift Modeling", AdKDD 2018, KDD London |
+| Extended paper | Diemert et al., "A Large Scale Benchmark for Individual Treatment Effect Prediction and Uplift Modeling", 2021 (arXiv:2111.10106) |
+| Reference code | <https://github.com/criteo-research/large-scale-ITE-UM-benchmark> |
+
+**Registration requirements:** None. The direct download link works
+without authentication. The Hugging Face mirror also provides
+unauthenticated access and offers both CSV and Parquet formats.
+
+**Dataset versions:** The current recommended version is v2.1. The
+v2 release rebalanced the treatment ratio across multiple incrementality
+tests that were pooled into the dataset, eliminating hidden confounding
+from varying per-advertiser test designs. v2.1 is a minor update to v2.
+
+## 2. License and Usage Restrictions
+
+**License:** Creative Commons Attribution-NonCommercial-ShareAlike 4.0
+International (CC-BY-NC-SA-4.0).
+
+**What is permitted:**
+
+1. Non-commercial research use, including academic benchmarking
+2. Derivative works (e.g., subsampled fixtures, adapted formats) under
+   the same CC-BY-NC-SA-4.0 license
+3. Public sharing of results, analyses, and benchmark reports derived
+   from the data
+4. Redistribution with proper attribution and under the same license
+
+**What is restricted:**
+
+1. Commercial use of the raw data or derivative datasets
+2. Redistribution under a different license
+3. Attempts to recover original features or user identity (features are
+   anonymized and randomly projected)
+
+**Required attribution:** Cite the Diemert et al. 2018 paper in any
+publication or report using the dataset.
+
+**Project impact:** The CC-BY-NC-SA-4.0 license is compatible with this
+project's research benchmarking use case. However, any fixture subset
+committed to the repository must carry the same license and attribution.
+The project should include a `LICENSE-CRITEO` or `DATA-LICENSE` file
+alongside any committed Criteo fixture data, and the benchmark report
+must include the required citation.
+
+**Comparison to Hillstrom:** Hillstrom is public domain / unrestricted.
+Criteo has stricter licensing. This is manageable but requires explicit
+license tracking that Hillstrom did not need.
+
+## 3. Dataset Size and Local Setup Cost
+
+| Metric | Value |
+|--------|-------|
+| Rows | 13,979,592 |
+| Columns | 16 (12 features + 4 labels/indicators) |
+| Compressed size (gzip CSV) | ~297 MB |
+| Uncompressed CSV | ~311 MB (per Hugging Face metadata) |
+| In-memory (pandas float64) | ~1.7 GB estimated (14M rows x 16 cols x 8 bytes) |
+
+**Local setup cost:**
+
+1. Download: ~300 MB, one-time, no authentication
+2. Disk: ~300 MB compressed or ~311 MB uncompressed; both are small by
+   modern standards
+3. Memory: loading the full 14M-row CSV into a pandas DataFrame will
+   consume approximately 1.7 GB. This is manageable on any modern
+   development machine but is a meaningful step up from Hillstrom
+   (64K rows, ~5 MB) or the marketing fixture (300 rows, ~30 KB).
+4. Per-run cost: a single `MarketingLogAdapter.run_experiment()` call
+   iterates over the full DataFrame with numpy vectorized operations.
+   On 14M rows this will be slower than the 300-row fixture but should
+   remain under 1 second per call. The benchmark cost comes from
+   repetition: 3 strategies x 3 budgets x 10 seeds x up to 80
+   experiments = up to 7,200 adapter calls at the full dataset size.
+5. Subsampling recommendation: the Hillstrom benchmark contract
+   (Section 6a) already recommends subsampling to 1M rows for the
+   first Criteo run. At 1M rows, in-memory cost drops to ~120 MB and
+   per-call latency becomes negligible.
+
+**CI fixture:** A small deterministic subsample (e.g., 2,000-5,000 rows)
+should be committed to `tests/fixtures/` for CI, following the same
+pattern as the marketing log fixture. The subsample must preserve the
+treatment ratio (85:15) and carry the CC-BY-NC-SA-4.0 license notice.
+
+## 4. Treatment Structure
+
+**Treatment type:** Binary. Each row has `treatment = 1` (treated) or
+`treatment = 0` (control).
+
+**Assignment mechanism:** Randomized control trial (incrementality test).
+At a predefined point in time, each user was randomly assigned to either
+the treated or control population. The treatment variable indicates
+whether the advertising platform participated in the real-time bidding
+(RTB) auction for that user.
+
+**Treatment ratio:** 85% treated, 15% control. This imbalance is
+intentional and reflects real-world advertising economics: advertisers
+maintain only a small control holdout because withholding ads from
+potential customers costs revenue.
+
+**Exposure column:** The dataset includes a separate `exposure` column
+(binary) indicating whether the treated user was effectively exposed to
+an advertisement. The logical constraint is `treatment = 0` implies
+`exposure = 0` (control users are never exposed), but not all treated
+users are exposed (treatment = 1 does not guarantee exposure = 1). This
+creates an intent-to-treat (ITT) versus per-protocol distinction:
+
+- **ITT analysis** uses the `treatment` column directly. This is the
+  standard uplift modeling framing and is what the current adapter
+  supports.
+- **Per-protocol / exposure-based analysis** uses the `exposure` column.
+  This introduces noncompliance and requires instrumental variable
+  methods or sensitivity analysis that the current adapter does not
+  support.
+
+**Adapter compatibility:** The `treatment` column maps directly to the
+`MarketingLogAdapter`'s binary treatment requirement. The `exposure`
+column is a bonus for advanced analysis but is not needed for the
+first-pass benchmark. The first run should use `treatment` (ITT), not
+`exposure`.
+
+## 5. Outcome Structure
+
+| Column | Type | Description | Rate |
+|--------|------|-------------|------|
+| `visit` | int (0/1) | User visited after ad exposure window | 4.70% |
+| `conversion` | int (0/1) | User converted (purchased) after window | 0.29% |
+
+**No continuous outcome.** Unlike Hillstrom (which has `spend` as a
+continuous outcome), Criteo provides only binary outcomes. This is the
+single most important structural difference from the Hillstrom contract.
+
+**Implications for the adapter:**
+
+1. The `MarketingLogAdapter` computes `policy_value` as IPS-weighted
+   mean outcome. On binary 0/1 data, this becomes an IPS-weighted
+   conversion or visit rate.
+2. IPS-weighted means of rare binary events (0.29% conversion rate) are
+   noisy. The effective sample size (ESS) diagnostic already in the
+   adapter will be critical for monitoring this.
+3. The adapter does not enforce continuous outcomes, so binary outcomes
+   will work mechanically. But the optimizer's ability to separate
+   strategies on a 0.29% base-rate binary signal is an open empirical
+   question.
+
+**No cost column.** Like Hillstrom, Criteo does not ship a per-user
+cost. A fixed synthetic cost must be assigned (e.g., `0.01` per treated
+observation, `0.0` per control). The same pattern proven on Hillstrom
+applies.
+
+**Primary objective recommendation:** Use `visit` (4.70% base rate) as
+the primary outcome for the first run. `conversion` (0.29%) is too rare
+for stable per-seed IPS-weighted estimates at the subsampled scale
+(1M rows x 0.29% = ~2,900 positive outcomes, of which ~435 are in the
+15% control arm). Track `conversion` as a secondary reported outcome.
+
+## 6. Propensity Availability
+
+**Propensities are not explicit in the dataset.** The Criteo CSV does
+not include a per-user propensity score column.
+
+However, because treatment was randomized:
+
+1. The marginal propensity is known: `P(treatment = 1) = 0.85`.
+2. Whether propensity varies with covariates is not documented. The
+   v2 rebalancing equalized treatment ratios across incrementality
+   tests, so within-test randomization should yield approximately
+   constant propensity conditional on features.
+3. The safest first-pass assumption is **uniform propensity at 0.85**
+   for all treated users, analogous to the constant propensity used on
+   Hillstrom (0.5 on the primary slice, 2/3 on the pooled slice).
+
+**Adapter handling:** The `MarketingLogAdapter` falls back to marginal
+treatment rate as uniform propensity when the `propensity` column is
+absent. This fallback will produce `propensity = 0.85` on Criteo, which
+is correct under the uniform-propensity assumption. Alternatively, the
+wrapper can explicitly add a `propensity = 0.85` column for clarity.
+
+**Risk:** If propensity actually varies with covariates (e.g., different
+advertisers had different control holdout rates before the v2
+rebalancing), the uniform assumption introduces bias. The v2 rebalancing
+was designed to mitigate this, but the degree of residual heterogeneity
+is not documented. The first run should report `weight_cv` and
+`max_ips_weight` diagnostics to detect whether IPS weights are
+suspiciously variable despite the constant-propensity assumption.
+
+## 7. Adapter Compatibility Assessment
+
+### 7a. Can It Work with the Current MarketingLogAdapter via a Small Wrapper?
+
+**Yes, with caveats.** The same wrapper pattern designed for Hillstrom
+(a `CriteoLoader` analogous to `HillstromLoader`) can map Criteo columns
+onto the adapter contract:
+
+| Adapter column | Criteo source | Transform |
+|----------------|---------------|-----------|
+| `treatment` | `treatment` | Pass-through (already binary 0/1) |
+| `outcome` | `visit` (primary) or `conversion` (secondary) | Pass-through (binary 0/1, used as float) |
+| `cost` | synthesized | Fixed constant (e.g., 0.01 treated, 0.0 control) |
+| `propensity` | synthesized | Constant 0.85 (from known randomization ratio) |
+| `channel` | constant | `"email"` (or `"ad"` — degenerate, single channel) |
+| `segment` | synthesized | Must be derived from f0-f11; no natural segment column exists |
+
+**What reuses cleanly:**
+
+1. Binary treatment validation (already 0/1)
+2. IPS/IPW policy evaluation math
+3. Zero-support fallback
+4. Objective definition (`policy_value`, maximize)
+5. `ExperimentEngine` loop, phases, screening
+6. Benchmark runner and provenance stack
+7. Per-seed reporting, MWU testing, Cohen's d conventions
+
+**What requires wrapper logic (no adapter changes):**
+
+1. Subsampling to 1M rows with a fixed seed
+2. Synthesizing `cost` and `propensity` columns
+3. Synthesizing a `segment` column from anonymized features (or omitting
+   it and accepting the adapter's uniform segment scoring)
+4. Fixing degenerate search variables (`email_share = 1.0`,
+   `social_share_of_remainder = 0.0`, `min_propensity_clip = 0.01`)
+   as was done for Hillstrom
+5. Projecting the prior causal graph to active variables
+
+### 7b. Does It Need a New Adapter?
+
+**Not for the first run.** The `MarketingLogAdapter` via wrapper is
+sufficient for an ITT-based binary-treatment binary-outcome benchmark.
+
+A new adapter would be needed only if the project wants to:
+
+1. Use the `exposure` column for per-protocol analysis (requires
+   instrumental variable or noncompliance handling)
+2. Train a CATE/uplift model rather than evaluate a fixed policy
+3. Incorporate feature-dependent propensity estimation
+4. Support the 85:15 imbalance with specialized IPS variance reduction
+   (e.g., doubly robust estimation with outcome modeling)
+
+These are Sprint 33+ concerns, not first-run requirements.
+
+### 7c. Does It Need a New Policy-Evaluation Stack?
+
+**No for the first run. Possibly for a mature benchmark.**
+
+The current IPS/IPW stack will work but faces two stress tests that
+Hillstrom does not impose:
+
+1. **Extreme treatment imbalance (85:15).** Control observations have
+   IPS weight `1 / (1 - 0.85) = 6.67`. This is higher than Hillstrom's
+   maximum weight of 2.0 (from `1 / 0.5`). The `min_propensity_clip`
+   parameter does not help because `0.85` is within the adapter's
+   `[0.01, 0.5]` clip range (clipping the upper bound to `1 - 0.01 =
+   0.99` does not touch `0.85`). The 6.67x weight on 15% of
+   observations means control-arm observations dominate IPS estimates.
+   This is not wrong, but it increases variance.
+
+2. **Rare binary outcomes (0.29% conversion, 4.70% visit).** IPS
+   weighting on a sparse binary outcome amplifies noise. A single
+   control-arm conversion with weight 6.67 can swing the IPS estimate
+   materially. This is a known challenge in the uplift modeling
+   literature and is one reason Criteo is considered a harder benchmark
+   than Hillstrom.
+
+If the first run shows unacceptable IPS variance (ESS consistently
+below 100, `weight_cv` above 5.0, or null control failure), the project
+should consider:
+
+1. Self-normalized IPS (already implemented in the adapter)
+2. Doubly robust (DR) estimation with an outcome model — requires
+   adapter extension
+3. Trimmed IPS with explicit bias-variance tradeoff — requires adapter
+   extension
+
+These are diagnosable from the first run's diagnostics and do not need
+to be solved before starting.
+
+### 7d. Segment Column Gap
+
+The Hillstrom wrapper maps `history_segment` to the adapter's
+`"high_value" / "medium" / "low"` segment scoring. Criteo has no
+natural segment column — all 12 features are anonymized floats.
+
+Options for the first run:
+
+1. **Omit the segment column entirely.** The adapter assigns all
+   observations a default `segment_score = 0.2` (the `"low"` weight).
+   This makes the uplift score depend only on channel weight and
+   regularization, reducing effective heterogeneity.
+2. **Synthesize a segment from feature quantiles.** For example,
+   tertiles of `f0` mapped to `"high_value" / "medium" / "low"`. This
+   is arbitrary but creates heterogeneity for the optimizer to exploit.
+3. **Defer segment scoring.** Accept that the first Criteo run has less
+   policy heterogeneity than Hillstrom. This is honest and avoids
+   fabricating structure.
+
+**Recommendation:** Option 1 (omit segment) for the first run. The
+optimizer can still search over `eligibility_threshold`,
+`regularization`, and `treatment_budget_pct`. If the first run shows
+that all policies collapse to the same `policy_value` due to lack of
+heterogeneity, synthesize a segment column on the follow-up run.
+
+## 8. Biggest Positivity and Support Risks
+
+### 8a. Treatment Imbalance (85:15)
+
+The 85% treatment ratio means the control arm is small. On a 1M-row
+subsample: ~150,000 control observations. This is still large in
+absolute terms, but IPS weights on those observations are 6.67x, which
+amplifies any noise in control-arm outcomes.
+
+**Mitigation:** The adapter's self-normalized IPS already helps. Monitor
+`effective_sample_size` and `weight_cv` per seed. If ESS drops below
+~500 on the 1M subsample, the IPS estimates are unreliable.
+
+### 8b. Rare Outcomes
+
+Conversion at 0.29% means ~2,900 positive outcomes per 1M rows, of
+which ~435 are in the control arm. Visit at 4.70% means ~47,000
+positives, ~7,050 in control. The visit outcome is borderline adequate
+for IPS estimation; conversion is marginal.
+
+**Mitigation:** Use `visit` as primary outcome. Report `conversion` as
+secondary. If `visit`-based IPS estimates are still too noisy, consider
+using the full 14M rows instead of the 1M subsample.
+
+### 8c. Non-Uniform Sub-Sampling
+
+The Criteo documentation states the dataset was "non-uniformly
+sub-sampled so that the original incrementality level cannot be deduced."
+This means the observed treatment effects in the dataset are
+deliberately distorted from the true population effects. The dataset
+preserves *relative* signal (which features predict uplift) but not
+*absolute* incrementality levels.
+
+**Impact on the project:** The optimizer searches for policies that
+maximize `policy_value` relative to alternatives. It does not need to
+recover absolute incrementality. The non-uniform subsampling therefore
+does not invalidate the benchmark use case, but it means the project
+cannot compare Criteo effect sizes to Hillstrom or energy effect sizes
+in absolute terms. Claim language must note this.
+
+### 8d. Anonymized Features
+
+All 12 features are anonymized and randomly projected. This means:
+
+1. No interpretable causal graph can be constructed from domain
+   knowledge. Any prior graph must be either empty or data-driven.
+2. The adapter's segment scoring (which relies on named segments like
+   `"high_value"`) has no natural mapping.
+3. The optimizer cannot benefit from domain-specific variable focus.
+
+**Impact on causal guidance:** Without an informative prior graph, the
+causal strategy loses its primary advantage (focus on graph ancestors of
+the outcome). The first run will test whether the engine's other
+mechanisms (screening, phase transitions, exploitation) provide value
+even without a strong prior. This is a valid and interesting test of the
+engine's robustness — if causal matches surrogate-only without a prior,
+it demonstrates graceful degradation.
+
+Alternatively, the wrapper could use `GraphLearner` (auto-discovery)
+to learn a data-driven graph at the exploration-to-optimization phase
+transition. This would test the `discovery_method` pathway on a real
+dataset for the first time.
+
+### 8e. Exposure Noncompliance
+
+Not all treated users were exposed to ads. If the first run uses
+`treatment` (ITT), this dilutes the treatment effect estimate because
+some "treated" users never saw the ad. The dilution is not a bug — ITT
+is the standard causal estimand — but it reduces the signal the
+optimizer can exploit.
+
+If the dilution is severe enough to wash out any strategy differences,
+a follow-up run could filter to `exposure = 1` rows only. However, this
+introduces selection bias (exposure is not randomized) and would require
+either an IV approach or a sensitivity analysis, neither of which the
+current adapter supports.
+
+**Recommendation:** Start with ITT (use `treatment` column). Diagnose
+dilution from the first run's per-seed diagnostics before considering
+exposure-based analysis.
+
+## 9. Recommendation: When Criteo Should Enter the Benchmark Queue
+
+### Entry Sprint: Sprint 33 (earliest), contingent on Hillstrom outcome
+
+**Prerequisites before starting Criteo:**
+
+1. **Hillstrom benchmark is stable.** The wrapper pattern (column
+   mapping, synthesized cost, null control, projected causal graph,
+   pre-baked degenerate variables) must be proven end-to-end on
+   Hillstrom before being replicated for Criteo. This is the Sprint 31
+   Hillstrom contract.
+
+2. **Hillstrom report is published.** The evidence discipline (per-seed
+   diagnostics, MWU tests, null control, claim language) must be
+   exercised on Hillstrom before being applied to a harder dataset.
+
+3. **IPS variance diagnostics are understood.** The Hillstrom run
+   should establish baseline expectations for `weight_cv`, `max_ips_
+   weight`, and `effective_sample_size` on a dataset where propensities
+   are balanced (0.5). Criteo's 85:15 imbalance will stress these
+   diagnostics, and the team needs calibrated expectations.
+
+4. **License tracking is in place.** A mechanism for attaching
+   CC-BY-NC-SA-4.0 attribution to committed fixture data must exist
+   before Criteo data enters the repo.
+
+### Recommended Sprint 33 Criteo Contract Shape
+
+| Element | Specification |
+|---------|---------------|
+| Data | Subsample to 1M rows with fixed seed; full 14M for extended runs |
+| CI fixture | 2,000-5,000 rows committed with CC-BY-NC-SA-4.0 notice |
+| Treatment column | `treatment` (ITT, not exposure-based) |
+| Primary outcome | `visit` (4.70% base rate) |
+| Secondary outcome | `conversion` (0.29%, reported but not optimized) |
+| Cost | Fixed synthetic (e.g., 0.01 treated, 0.0 control) |
+| Propensity | Constant 0.85 (from known randomization ratio) |
+| Segment | Omitted (uniform scoring) on first run |
+| Search space | 3 tuned variables (same as Hillstrom: `eligibility_threshold`, `regularization`, `treatment_budget_pct`) |
+| Strategies | random, surrogate_only, causal |
+| Seeds | 10 |
+| Budgets | B20, B40, B80 |
+| Null control | Permuted `visit` column, B20 and B40 |
+| Prior graph | Either empty (test engine without prior) or data-driven via `GraphLearner` |
+| Success criterion | Causal >= surrogate_only at B80, p <= 0.05 |
+
+### Why Not Sprint 32
+
+Sprint 32 should be reserved for one of:
+
+1. Hillstrom follow-on (mens arm, pooled ablation, or covariate-
+   conditioned policies)
+2. Diagnosing any Hillstrom failures or near-parity results
+3. Completing the marketing offline policy benchmark with the existing
+   fixture data (if Hillstrom shows the wrapper pattern works)
+
+Starting Criteo before fully digesting Hillstrom would repeat the
+pattern the Sprint 31 plan warns against: moving to a harder dataset
+before proving the approach on a simpler one.
+
+### What Criteo Would Prove That Hillstrom Cannot
+
+1. **Scale tolerance.** 1M+ rows vs 42K rows tests whether the engine
+   and adapter perform acceptably at production-relevant data sizes.
+2. **Robustness to treatment imbalance.** 85:15 vs Hillstrom's 50:50
+   tests whether the IPS stack degrades gracefully under realistic
+   control-holdout ratios.
+3. **Engine value without a prior graph.** Anonymized features force the
+   engine to rely on screening and data-driven structure rather than
+   domain knowledge. This is a purer test of the engine's algorithmic
+   contribution.
+4. **Rare-outcome signal detection.** 4.70% visit rate (and especially
+   0.29% conversion) tests whether the optimizer can separate strategies
+   on sparse binary signals.
+
+### What Criteo Cannot Prove
+
+1. **Multi-action policy evaluation.** Criteo is binary treatment.
+   Multi-action requires Open Bandit Dataset (Priority 3).
+2. **Continuous-outcome optimization.** Both Criteo outcomes are binary.
+   Only Hillstrom `spend` and the energy benchmarks test continuous
+   objectives.
+3. **Domain-interpretable causal reasoning.** Anonymized features mean
+   any learned graph is opaque. Only Hillstrom and energy provide
+   interpretable variable names.
+
+## 10. Summary Decision Table
+
+| Question | Answer |
+|----------|--------|
+| Can we use it legally? | Yes, under CC-BY-NC-SA-4.0. Non-commercial research is permitted. |
+| Registration required? | No. Direct download, no authentication. |
+| Local setup cost? | ~300 MB download, ~1.7 GB memory for full load, ~120 MB for 1M subsample. Manageable. |
+| Treatment structure? | Binary (treated/control), randomized, 85:15 ratio. |
+| Outcomes? | Binary: `visit` (4.70%) and `conversion` (0.29%). No continuous outcome. |
+| Propensities explicit? | No, but known from randomization (uniform 0.85). Adapter fallback handles this. |
+| Works with current adapter? | Yes, via wrapper. Same pattern as Hillstrom. |
+| Needs new adapter? | No, for first run. Possibly for exposure-based or DR analysis later. |
+| Needs new policy-eval stack? | No, for first run. DR estimation is a Sprint 34+ consideration. |
+| Biggest risks? | 85:15 imbalance amplifies IPS variance; rare outcomes reduce signal; anonymized features prevent interpretable causal graph. |
+| When should it enter the queue? | Sprint 33, after Hillstrom is stable and the wrapper pattern is proven. |
+
+## 11. References
+
+1. Diemert, E., Betlei, A., Renaudin, C., & Amini, M.-R. (2018). "A Large Scale Benchmark for Uplift Modeling." AdKDD 2018 Workshop, KDD London.
+2. Diemert, E., Betlei, A., Renaudin, C., & Amini, M.-R. (2021). "A Large Scale Benchmark for Individual Treatment Effect Prediction and Uplift Modeling." arXiv:2111.10106.
+3. [Criteo AI Lab — Criteo Uplift Prediction Dataset](https://ailab.criteo.com/criteo-uplift-prediction-dataset/)
+4. [Hugging Face — criteo/criteo-uplift](https://huggingface.co/datasets/criteo/criteo-uplift)
+5. [GitHub — criteo-research/large-scale-ITE-UM-benchmark](https://github.com/criteo-research/large-scale-ITE-UM-benchmark)
+6. [scikit-uplift — fetch_criteo documentation](https://www.uplift-modeling.com/en/latest/api/datasets/fetch_criteo.html)
+7. [Sprint 31 Generalization Research Plan](../plans/22-sprint-31-generalization-research-plan.md)
+8. [Sprint 31 Hillstrom Benchmark Contract](sprint-31-hillstrom-benchmark-contract.md)
+9. [Sprint 30 General Causal Portability Brief](sprint-30-general-causal-portability-brief.md)
+10. [Real-Data Adapter Requirements](../plans/04-real-data-adapter-requirements.md)
+11. [MarketingLogAdapter Documentation](marketing-log-adapter.md)

--- a/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
+++ b/thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
@@ -83,7 +83,8 @@ license tracking that Hillstrom did not need.
 | Rows | 13,979,592 |
 | Columns | 16 (12 features + 4 labels/indicators) |
 | Compressed size (gzip CSV) | ~297 MB |
-| Uncompressed CSV | ~311 MB (per Hugging Face metadata) |
+| Parquet (Hugging Face) | ~311 MB (columnar + compressed; not uncompressed CSV) |
+| Uncompressed CSV | ~900 MB - 1.5 GB estimated (typical 3-5x gzip ratio on numeric CSV) |
 | In-memory (pandas float64) | ~1.7 GB estimated (14M rows x 16 cols x 8 bytes) |
 
 **Local setup cost:**
@@ -250,8 +251,10 @@ onto the adapter contract:
 3. Synthesizing a `segment` column from anonymized features (or omitting
    it and accepting the adapter's uniform segment scoring)
 4. Fixing degenerate search variables (`email_share = 1.0`,
-   `social_share_of_remainder = 0.0`, `min_propensity_clip = 0.01`)
-   as was done for Hillstrom
+   `social_share_of_remainder = 0.0`) as was done for Hillstrom.
+   Unlike Hillstrom, `min_propensity_clip` is not degenerate on Criteo
+   (see Section 7c) and may be tuned or pre-baked depending on the
+   Sprint 33 contract decision.
 5. Projecting the prior causal graph to active variables
 
 ### 7b. Does It Need a New Adapter?
@@ -279,21 +282,33 @@ Hillstrom does not impose:
 
 1. **Extreme treatment imbalance (85:15).** Control observations have
    IPS weight `1 / (1 - 0.85) = 6.67`. This is higher than Hillstrom's
-   maximum weight of 2.0 (from `1 / 0.5`). The `min_propensity_clip`
-   parameter does not help here. The adapter's `min_propensity_clip`
-   parameter range is `[0.01, 0.5]`, and the adapter clips propensities
-   symmetrically to `[clip, 1 - clip]`. At the default `clip = 0.01`,
-   propensities are clipped to `[0.01, 0.99]`. Since Criteo's constant
-   propensity of `0.85` falls inside this range, clipping never fires
-   and the control-arm weight remains `1 / (1 - 0.85) = 6.67`. Even at
-   the maximum `clip = 0.5`, the range becomes `[0.5, 0.5]`, which
-   would collapse all propensities to 0.5 — a distortion, not a fix.
-   The 6.67x weight on 15% of
+   maximum weight of 2.0 (from `1 / 0.5`). The adapter's
+   `min_propensity_clip` parameter clips propensities symmetrically to
+   `[clip, 1 - clip]` (search range `[0.01, 0.5]`). At the default
+   `clip = 0.01`, the range is `[0.01, 0.99]` and clipping does not
+   fire because `0.85 < 0.99`. However, any `clip > 0.15` clips the
+   0.85 propensity downward because `1 - clip < 0.85`:
+
+   - `clip = 0.2` -> range `[0.2, 0.8]` -> 0.85 clipped to 0.80 ->
+     control weight drops from 6.67 to 5.0
+   - `clip = 0.3` -> range `[0.3, 0.7]` -> control weight drops to 3.33
+   - `clip = 0.5` -> range `[0.5, 0.5]` -> control weight drops to 2.0
+     (matching Hillstrom, but at the cost of collapsing all propensities)
+
+   This is a bias-variance tradeoff: higher clip values reduce IPS
+   variance but introduce bias by distorting the known propensity. On
+   the Hillstrom first run, `min_propensity_clip` is pre-baked to `0.01`
+   because propensities are 0.5 and clipping is a no-op. On Criteo, the
+   Sprint 33 contract should consider whether to tune `clip` as a fourth
+   search variable or pre-bake it to a fixed value (e.g., `0.15` to
+   avoid clipping, or `0.25` for modest variance reduction).
+
+   Note that this is structurally different from the typical clipping
+   use case (estimated propensities near 0 or 1): Criteo's propensity
+   of 0.85 is moderate, but its complement (0.15) creates high
+   control-arm weights. The 6.67x weight (at default clip) on 15% of
    observations means control-arm observations dominate IPS estimates.
-   This is not wrong, but it increases variance. Note that this is
-   structurally different from the typical clipping use case (estimated
-   propensities near 0 or 1): Criteo's propensity of 0.85 is moderate,
-   but its complement (0.15) creates high control-arm weights.
+   This increases variance but is not wrong.
 
 2. **Rare binary outcomes (0.29% conversion, 4.70% visit).** IPS
    weighting on a sparse binary outcome amplifies noise. A single
@@ -468,7 +483,7 @@ Sprint 33 starts Criteo.
 | Cost | Fixed synthetic (e.g., 0.01 treated, 0.0 control) |
 | Propensity | Constant 0.85 (from known randomization ratio) |
 | Segment | Omitted (uniform scoring) on first run |
-| Search space | 3 tuned variables (same as Hillstrom: `eligibility_threshold`, `regularization`, `treatment_budget_pct`) |
+| Search space | 3-4 tuned variables: `eligibility_threshold`, `regularization`, `treatment_budget_pct`, and optionally `min_propensity_clip` (see Section 7c bias-variance tradeoff) |
 | Strategies | random, surrogate_only, causal |
 | Seeds | 10 |
 | Budgets | B20, B40, B80 |


### PR DESCRIPTION
## Summary

- Researches the Criteo Uplift Prediction Dataset (Priority 2 follow-on after Hillstrom) for Sprint 31 parallel workstream
- Documents licensing (CC-BY-NC-SA-4.0), download path, dataset size (~14M rows, ~300MB compressed), treatment structure (binary, 85:15 ratio), outcome structure (binary visit/conversion, no continuous outcome), and propensity availability (not explicit, but known from randomization)
- Assesses adapter compatibility: current `MarketingLogAdapter` works via wrapper (same pattern as Hillstrom), no new adapter needed for first run
- Identifies biggest risks: 85:15 treatment imbalance amplifies IPS variance, rare binary outcomes (0.29% conversion), anonymized features prevent interpretable causal graph
- Recommends Sprint 33 entry (after Hillstrom is stable and wrapper pattern is proven)

Resolves #171

## Test plan

- [x] Docs-only change, no code modified
- [x] Lint passes (`ruff check .`)
- [x] Format passes (`ruff format --check .`)
- [x] All 1048 unit tests pass
- [ ] Human review of audit conclusions and recommendations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-only PR adds a 526-line access and adapter-gap audit for the Criteo Uplift Prediction Dataset (CC-BY-NC-SA-4.0), covering licensing, dataset structure, wrapper compatibility with `MarketingLogAdapter`, and a recommended Sprint 33 entry point. The document is thorough and well-grounded, with two technical inaccuracies to address before the Sprint 33 contract is drafted:

- **Section 7c** incorrectly concludes that `min_propensity_clip` cannot reduce IPS variance from the 85:15 treatment imbalance. The adapter clips propensity to `[min_propensity_clip, 1 − min_propensity_clip]`, so any value above 0.15 will cap the 0.85 propensity and reduce the 6.67× control IPS weight — a meaningful variance-reduction lever that should be documented.
- **Section 3** reports the uncompressed CSV as ~311 MB, which is inconsistent with gzip decompression math; the figure likely reflects the HuggingFace Parquet representation rather than the raw CSV.

<h3>Confidence Score: 4/5</h3>

Safe to merge after correcting the min_propensity_clip analysis in Section 7c, which will inform the Sprint 33 contract.

One P1 factual error (min_propensity_clip variance-reduction claim) directly affects how the Sprint 33 benchmark contract will configure IPS variance mitigation; the correction is a few sentences. The P2 CSV size issue is labeled with a source caveat and the correct in-memory estimate is present, so planning won't be materially misled. No code is changed.

thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md — Section 7c (min_propensity_clip analysis) and Section 3 (uncompressed CSV size table entry)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md | New 526-line audit doc for Criteo Uplift dataset access and adapter compatibility; contains one factual error in the min_propensity_clip analysis (Section 7c) and a likely incorrect uncompressed CSV size figure (Section 3). |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Criteo Uplift v2.1 CSV\n(~300 MB gzip, 14M rows)"] --> B["CriteoLoader wrapper\n(analogous to HillstromLoader)"]
    B --> |"subsample to 1M rows\nseed-fixed"| C["Column mapping"]
    C --> |"treatment → treatment\nvisit/conversion → outcome\nsynth cost 0.01/0.0\nconst propensity 0.85"| D["MarketingLogAdapter\nrun_experiment()"]
    D --> |"IPS-weighted\npolicy_value"| E["ExperimentEngine\n(suggest → evaluate → update)"]
    E --> F{"Phase"}
    F --> |"Exploration 1–10"| G["LHS space-filling"]
    F --> |"Optimization 11–50"| H["Bayesian / RF surrogate"]
    F --> |"Exploitation 50+"| I["Local perturbation\n+ MAP-Elites"]
    G & H & I --> E
    E --> J["Benchmark report\n(per-seed diagnostics,\nMWU, Cohen's d)"]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Athoughts%2Fshared%2Fdocs%2Fsprint-31-criteo-uplift-access-and-gap-audit.md%3A279-284%0A**%60min_propensity_clip%60%20can%20reduce%20the%2085%3A15%20IPS%20weight**%0A%0AThe%20claim%20that%20%60min_propensity_clip%60%20%22does%20not%20help%22%20because%20%600.85%60%20is%20%22within%20the%20adapter's%20%60%5B0.01%2C%200.5%5D%60%20clip%20range%22%20is%20incorrect.%20The%20%60%5B0.01%2C%200.5%5D%60%20is%20the%20*search-space%20range%20for%20the%20parameter%20itself*%2C%20not%20the%20propensity%20clip%20range%20applied%20during%20evaluation.%0A%0AThe%20adapter%20clips%20propensity%20to%20%60%5Bmin_propensity_clip%2C%201%20-%20min_propensity_clip%5D%60%20%28verified%20in%20%60marketing_logs.py%60%20lines%20238%E2%80%93242%29.%20So%20any%20%60min_propensity_clip%20%3E%200.15%60%20clips%20the%200.85%20propensity%20value%20downward%20%E2%80%94%20for%20example%3A%0A%0A-%20%60min_propensity_clip%20%3D%200.2%60%20%E2%86%92%20clip%20range%20%60%5B0.2%2C%200.8%5D%60%20%E2%86%92%20propensity%200.85%20clipped%20to%200.80%20%E2%86%92%20control%20weight%20drops%20from%206.67%20to%205.0%0A-%20%60min_propensity_clip%20%3D%200.3%60%20%E2%86%92%20clip%20range%20%60%5B0.3%2C%200.7%5D%60%20%E2%86%92%20control%20weight%20drops%20to%203.33%0A-%20%60min_propensity_clip%20%3D%200.5%60%20%28upper%20search%20bound%29%20%E2%86%92%20clip%20range%20%60%5B0.5%2C%200.5%5D%60%20%E2%86%92%20control%20weight%20drops%20to%202.0%20%28matching%20Hillstrom%29%0A%0AThe%20Sprint%2033%20contract%20should%20either%20note%20this%20as%20a%20mitigation%20lever%20or%20acknowledge%20the%20explicit%20bias-variance%20tradeoff%20it%20introduces.%0A%0A%23%23%23%20Issue%202%20of%202%0Athoughts%2Fshared%2Fdocs%2Fsprint-31-criteo-uplift-access-and-gap-audit.md%3A83-85%0A**Uncompressed%20CSV%20size%20appears%20to%20reflect%20Parquet%2C%20not%20CSV**%0A%0AThe%20table%20lists%20%22Uncompressed%20CSV%20%7C%20~311%20MB%20%28per%20Hugging%20Face%20metadata%29%22%20but%20a%20gzip%20file%20that%20compresses%20to%20~297%20MB%20cannot%20decompress%20to%20only%20~311%20MB%20%E2%80%94%20that%20would%20imply%20a%20compression%20ratio%20of%20~1.05x%2C%20which%20is%20implausible%20for%20tabular%20numeric%20CSV%20data.%20The%20~311%20MB%20figure%20from%20HuggingFace%20likely%20corresponds%20to%20the%20Parquet%20representation%20%28columnar%20%2B%20compressed%29%2C%20not%20the%20uncompressed%20CSV.%20The%20in-memory%20estimate%20of%20~1.7%20GB%20in%20the%20row%20below%20is%20correct%2C%20and%20the%20rough%20uncompressed%20CSV%20size%20would%20be%20in%20the%20~900%20MB%E2%80%931.5%20GB%20range%20%28typical%203%E2%80%935x%20gzip%20ratio%20on%20numeric%20CSVs%29.%20The%20table%20entry%20could%20mislead%20storage%20planning%3B%20consider%20labeling%20it%20as%20%22Parquet%20%28HuggingFace%29%22%20or%20computing%20the%20CSV%20size%20directly.%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
Line: 279-284

Comment:
**`min_propensity_clip` can reduce the 85:15 IPS weight**

The claim that `min_propensity_clip` "does not help" because `0.85` is "within the adapter's `[0.01, 0.5]` clip range" is incorrect. The `[0.01, 0.5]` is the *search-space range for the parameter itself*, not the propensity clip range applied during evaluation.

The adapter clips propensity to `[min_propensity_clip, 1 - min_propensity_clip]` (verified in `marketing_logs.py` lines 238–242). So any `min_propensity_clip > 0.15` clips the 0.85 propensity value downward — for example:

- `min_propensity_clip = 0.2` → clip range `[0.2, 0.8]` → propensity 0.85 clipped to 0.80 → control weight drops from 6.67 to 5.0
- `min_propensity_clip = 0.3` → clip range `[0.3, 0.7]` → control weight drops to 3.33
- `min_propensity_clip = 0.5` (upper search bound) → clip range `[0.5, 0.5]` → control weight drops to 2.0 (matching Hillstrom)

The Sprint 33 contract should either note this as a mitigation lever or acknowledge the explicit bias-variance tradeoff it introduces.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-31-criteo-uplift-access-and-gap-audit.md
Line: 83-85

Comment:
**Uncompressed CSV size appears to reflect Parquet, not CSV**

The table lists "Uncompressed CSV | ~311 MB (per Hugging Face metadata)" but a gzip file that compresses to ~297 MB cannot decompress to only ~311 MB — that would imply a compression ratio of ~1.05x, which is implausible for tabular numeric CSV data. The ~311 MB figure from HuggingFace likely corresponds to the Parquet representation (columnar + compressed), not the uncompressed CSV. The in-memory estimate of ~1.7 GB in the row below is correct, and the rough uncompressed CSV size would be in the ~900 MB–1.5 GB range (typical 3–5x gzip ratio on numeric CSVs). The table entry could mislead storage planning; consider labeling it as "Parquet (HuggingFace)" or computing the CSV size directly.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["address claude review feedback (claudelo..."](https://github.com/datablogin/causal-optimizer/commit/ba1635696c6132144d3aaa29be65bf3e44782791) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28644888)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->