### PR TITLE
docs: Sprint 31 Hillstrom benchmark report (SURROGATE-ONLY ADVANTAGE)

### DIFF
--- a/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
+++ b/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
@@ -1,0 +1,384 @@
+# Sprint 31 Hillstrom Benchmark Report
+
+**Date:** 2026-04-16
+**Issue:** #170
+**Branch:** `sprint-31/hillstrom-full-benchmark`
+**Dataset:** MineThatData Hillstrom E-Mail (64,000 rows)
+**Backend:** RF surrogate (Ax/BoTorch not available in this environment)
+
+## Summary
+
+This is the first non-energy real-data benchmark for the causal optimizer. The
+Hillstrom dataset is a three-arm randomized marketing trial. The benchmark
+evaluates two binary slices: primary (Womens E-Mail vs No E-Mail) and pooled
+(Any E-Mail vs No E-Mail), across three strategies (random, surrogate_only,
+causal) at budgets 20, 40, and 80 with 10 seeds each. A permuted-outcome
+null-control pass is included for the primary slice.
+
+**Top-line result:** Surrogate-only outperforms causal at low and medium budgets
+on both slices. At B80 on the primary slice, causal shows a mean advantage
+(0.8644 vs 0.8293) driven by 3 seeds that discover a high-policy-value region,
+but the high variance makes the result statistically non-significant (p=0.817).
+At B80 on the pooled slice, surrogate-only reliably finds the optimal corner
+(eligibility_threshold=0.0, treatment_budget_pct=1.0) and outperforms causal
+at certified significance (p=0.019, two-sided MWU).
+
+## Verdicts
+
+| Slice | Budget | Causal vs Surrogate-Only | p-value (two-sided MWU) | Verdict | Direction |
+|-------|--------|--------------------------|-------------------------|---------|-----------|
+| Primary | B20 | s.o. wins 8/10 seeds | 0.060 | Trending | s.o. > causal |
+| Primary | B40 | s.o. wins 10/10 seeds | 0.0001 | Certified | s.o. > causal |
+| Primary | B80 | s.o. wins 7/10 seeds | 0.817 | Near-parity | causal mean > s.o. mean |
+| Pooled | B20 | s.o. wins 8/10 seeds | 0.017 | Certified | s.o. > causal |
+| Pooled | B40 | s.o. wins 9/10 seeds | 0.002 | Certified | s.o. > causal |
+| Pooled | B80 | s.o. wins 7/10 seeds | 0.019 | Certified | s.o. > causal |
+
+**Overall Hillstrom verdict: surrogate-only advantage.** The causal path does
+not show a consistent advantage over surrogate-only on this dataset under the
+RF backend. This is the expected null result for a domain where the projected
+prior graph has limited predictive leverage over a pure surrogate approach on a
+narrow 3-variable search space.
+
+## Configuration
+
+- **Slices:** primary (Womens E-Mail vs No E-Mail, 42,693 rows, propensity=0.5), pooled (Any E-Mail vs No E-Mail, 64,000 rows, propensity=2/3)
+- **Strategies:** random, surrogate_only, causal
+- **Budgets:** 20, 40, 80
+- **Seeds:** 0--9 (10 seeds per cell)
+- **Null control:** primary slice, budgets 20 and 40, permuted outcomes
+- **Frozen params:** email_share=1.0, social_share_of_remainder=0.0, min_propensity_clip=0.01
+- **Active search space:** eligibility_threshold, regularization, treatment_budget_pct (3 variables)
+- **Projected prior graph:** 7 edges over active nodes + intermediates
+- **Objective:** policy_value (maximize)
+- **Suite runtime:** 1302.8 seconds (21.7 minutes)
+
+## Per-Seed Detail Tables
+
+### Primary Slice (Real)
+
+#### Budget=20
+
+| Seed | random | surrogate_only | causal | Winner |
+|------|--------|----------------|--------|--------|
+| 0 | 0.8270 | 0.8293 | 0.8288 | s.o. |
+| 1 | 0.8267 | 0.8294 | 0.8288 | s.o. |
+| 2 | 0.8290 | 0.8293 | 0.8288 | s.o. |
+| 3 | 0.8287 | 0.8294 | 0.8288 | s.o. |
+| 4 | 0.8291 | 0.8293 | 0.8288 | s.o. |
+| 5 | 0.8239 | 0.8294 | 0.8288 | s.o. |
+| 6 | 0.8290 | 0.8228 | 0.8240 | causal |
+| 7 | 0.8289 | 0.8228 | 0.8231 | causal |
+| 8 | 0.8269 | 0.8287 | 0.8228 | s.o. |
+| 9 | 0.8268 | 0.8292 | 0.8275 | s.o. |
+
+#### Budget=40
+
+| Seed | random | surrogate_only | causal | Winner |
+|------|--------|----------------|--------|--------|
+| 0 | 0.8290 | 0.8294 | 0.8288 | s.o. |
+| 1 | 0.8288 | 0.8294 | 0.8288 | s.o. |
+| 2 | 0.8290 | 0.8294 | 0.8288 | s.o. |
+| 3 | 0.8287 | 0.8294 | 0.8288 | s.o. |
+| 4 | 0.8291 | 0.8294 | 0.8288 | s.o. |
+| 5 | 0.8290 | 0.8294 | 0.8288 | s.o. |
+| 6 | 0.8290 | 0.8293 | 0.8289 | s.o. |
+| 7 | 0.8289 | 0.8291 | 0.8287 | s.o. |
+| 8 | 0.8270 | 0.8293 | 0.8270 | s.o. |
+| 9 | 0.8291 | 0.8292 | 0.8275 | s.o. |
+
+#### Budget=80
+
+| Seed | random | surrogate_only | causal | Winner |
+|------|--------|----------------|--------|--------|
+| 0 | 0.8290 | 0.8294 | 0.8293 | s.o. |
+| 1 | 0.8288 | 0.8294 | 0.8293 | s.o. |
+| 2 | 0.8293 | 0.8294 | 0.8293 | s.o. |
+| 3 | 0.8287 | 0.8294 | 0.8294 | s.o. |
+| 4 | 0.8291 | 0.8294 | 0.8294 | s.o. |
+| 5 | 0.8290 | 0.8294 | 0.8294 | s.o. |
+| 6 | 0.8290 | 0.8293 | 0.8292 | s.o. |
+| 7 | 0.8289 | 0.8291 | 0.9255 | causal |
+| 8 | 0.8270 | 0.8293 | 0.9474 | causal |
+| 9 | 0.8291 | 0.8292 | 0.9656 | causal |
+
+Note: Seeds 7--9 at B80 find a qualitatively different region with
+eligibility_threshold=0.0, producing policy values 12--16% above the
+plateau where all other runs cluster (~0.829). These seeds have enough
+budget to explore past the exploitation phase transition and discover a
+corner solution. The surrogate-only path never finds this region because
+it converges too tightly on the local plateau.
+
+### Pooled Slice (Real)
+
+#### Budget=20
+
+| Seed | random | surrogate_only | causal | Winner |
+|------|--------|----------------|--------|--------|
+| 0 | 0.9507 | 0.9599 | 0.9309 | s.o. |
+| 1 | 0.9282 | 0.9520 | 0.9229 | s.o. |
+| 2 | 0.9232 | 0.8936 | 0.9574 | causal |
+| 3 | 0.9095 | 0.9596 | 0.9105 | s.o. |
+| 4 | 0.9554 | 0.9373 | 0.9459 | causal |
+| 5 | 0.9477 | 0.9596 | 0.9231 | s.o. |
+| 6 | 0.9455 | 0.9596 | 0.9446 | s.o. |
+| 7 | 0.9447 | 0.9596 | 0.9492 | s.o. |
+| 8 | 0.9307 | 0.9520 | 0.9492 | s.o. |
+| 9 | 0.9017 | 0.9642 | 0.9492 | s.o. |
+
+#### Budget=40
+
+| Seed | random | surrogate_only | causal | Winner |
+|------|--------|----------------|--------|--------|
+| 0 | 0.9642 | 0.9643 | 0.9309 | s.o. |
+| 1 | 0.9596 | 0.9640 | 0.9229 | s.o. |
+| 2 | 0.9232 | 0.8940 | 0.9574 | causal |
+| 3 | 0.9506 | 0.9642 | 0.9105 | s.o. |
+| 4 | 0.9554 | 0.9642 | 0.9520 | s.o. |
+| 5 | 0.9515 | 0.9643 | 0.9231 | s.o. |
+| 6 | 0.9455 | 0.9643 | 0.9446 | s.o. |
+| 7 | 0.9447 | 0.9643 | 0.9492 | s.o. |
+| 8 | 0.9307 | 0.9643 | 0.9492 | s.o. |
+| 9 | 0.9489 | 0.9643 | 0.9492 | s.o. |
+
+#### Budget=80
+
+| Seed | random | surrogate_only | causal | Winner |
+|------|--------|----------------|--------|--------|
+| 0 | 0.9642 | 1.2496 | 1.2496 | tie |
+| 1 | 0.9596 | 1.2496 | 0.9571 | s.o. |
+| 2 | 0.9521 | 0.9641 | 0.9596 | s.o. |
+| 3 | 0.9506 | 0.9642 | 1.2496 | causal |
+| 4 | 0.9554 | 0.9642 | 0.9641 | s.o. |
+| 5 | 0.9641 | 1.2496 | 1.2496 | tie |
+| 6 | 0.9594 | 1.2496 | 0.9595 | s.o. |
+| 7 | 0.9535 | 1.2496 | 0.9521 | s.o. |
+| 8 | 0.9519 | 1.2496 | 0.9521 | s.o. |
+| 9 | 0.9489 | 1.2496 | 0.9521 | s.o. |
+
+Note: The optimal corner (eligibility_threshold=0.0, treatment_budget_pct=1.0)
+yields policy_value=1.2496 on the pooled slice, which exceeds the null baseline
+of 1.0509. Surrogate-only finds this corner in 8/10 seeds at B80; causal finds
+it in only 3/10 seeds (1 win + 2 ties).
+
+## Summary Statistics
+
+### Primary Slice
+
+| Strategy | Budget | Mean | Std (ddof=0) | Min | Max |
+|----------|--------|------|--------------|-----|-----|
+| random | 20 | 0.8276 | 0.0016 | 0.8239 | 0.8291 |
+| surrogate_only | 20 | 0.8280 | 0.0026 | 0.8228 | 0.8294 |
+| causal | 20 | 0.8270 | 0.0025 | 0.8228 | 0.8288 |
+| random | 40 | 0.8288 | 0.0006 | 0.8270 | 0.8291 |
+| surrogate_only | 40 | 0.8293 | 0.0001 | 0.8291 | 0.8294 |
+| causal | 40 | 0.8285 | 0.0006 | 0.8270 | 0.8289 |
+| random | 80 | 0.8288 | 0.0006 | 0.8270 | 0.8293 |
+| surrogate_only | 80 | 0.8293 | 0.0001 | 0.8291 | 0.8294 |
+| causal | 80 | 0.8644 | 0.0543 | 0.8292 | 0.9656 |
+
+### Pooled Slice
+
+| Strategy | Budget | Mean | Std (ddof=0) | Min | Max |
+|----------|--------|------|--------------|-----|-----|
+| random | 20 | 0.9337 | 0.0173 | 0.9017 | 0.9554 |
+| surrogate_only | 20 | 0.9497 | 0.0200 | 0.8936 | 0.9642 |
+| causal | 20 | 0.9383 | 0.0145 | 0.9105 | 0.9574 |
+| random | 40 | 0.9474 | 0.0118 | 0.9232 | 0.9642 |
+| surrogate_only | 40 | 0.9572 | 0.0211 | 0.8940 | 0.9643 |
+| causal | 40 | 0.9389 | 0.0149 | 0.9105 | 0.9574 |
+| random | 80 | 0.9560 | 0.0052 | 0.9489 | 0.9642 |
+| surrogate_only | 80 | 1.1640 | 0.1308 | 0.9641 | 1.2496 |
+| causal | 80 | 1.0445 | 0.1343 | 0.9521 | 1.2496 |
+
+## Null Baseline
+
+| Slice | mu (mean spend) |
+|-------|-----------------|
+| Primary | 0.8654 |
+| Pooled | 1.0509 |
+
+All three strategies at all budgets find policy values below the null baseline
+on the primary slice (max=0.966 for causal B80 seed 9, which does exceed the
+baseline). On the pooled slice, surrogate-only B80 reliably exceeds the null
+baseline (mean=1.164 vs baseline=1.051).
+
+## Null Control (Primary Slice, Permuted Outcomes)
+
+### Budget=20
+
+| Seed | random | surrogate_only | causal | baseline |
+|------|--------|----------------|--------|----------|
+| 0 | 0.8368 | 0.8490 | 0.8423 | 0.8654 |
+| 1 | 0.8716 | 0.8729 | 0.8729 | 0.8654 |
+| 2 | 0.8786 | 0.8806 | 0.8785 | 0.8654 |
+| 3 | 0.9468 | 0.9504 | 0.9504 | 0.8654 |
+| 4 | 0.9055 | 0.9032 | 0.8926 | 0.8654 |
+| 5 | 0.8317 | 0.8045 | 0.8022 | 0.8654 |
+| 6 | 0.9077 | 0.9033 | 0.9029 | 0.8654 |
+| 7 | 0.9182 | 0.9181 | 0.8864 | 0.8654 |
+| 8 | 0.9317 | 0.9329 | 0.9324 | 0.8654 |
+| 9 | 0.8813 | 0.8697 | 0.8684 | 0.8654 |
+
+### Budget=40
+
+| Seed | random | surrogate_only | causal | baseline |
+|------|--------|----------------|--------|----------|
+| 0 | 0.8433 | 0.8490 | 0.8423 | 0.8654 |
+| 1 | 0.8716 | 0.8729 | 0.8729 | 0.8654 |
+| 2 | 0.8786 | 0.8807 | 0.8785 | 0.8654 |
+| 3 | 0.9468 | 0.9504 | 0.9504 | 0.8654 |
+| 4 | 0.9055 | 0.9036 | 0.8926 | 0.8654 |
+| 5 | 0.8317 | 0.8296 | 0.8022 | 0.8654 |
+| 6 | 0.9122 | 0.9033 | 0.9029 | 0.8654 |
+| 7 | 0.9214 | 0.9219 | 0.8864 | 0.8654 |
+| 8 | 0.9320 | 0.9330 | 0.9351 | 0.8654 |
+| 9 | 0.8813 | 0.8853 | 0.8684 | 0.8654 |
+
+### Null Control Summary
+
+| Strategy | Budget | Mean | Std (ddof=0) | Exceed baseline |
+|----------|--------|------|--------------|-----------------|
+| random | 20 | 0.8910 | 0.0362 | 8/10 |
+| surrogate_only | 20 | 0.8885 | 0.0405 | 8/10 |
+| causal | 20 | 0.8829 | 0.0400 | 8/10 |
+| random | 40 | 0.8925 | 0.0357 | 8/10 |
+| surrogate_only | 40 | 0.8930 | 0.0354 | 8/10 |
+| causal | 40 | 0.8832 | 0.0403 | 8/10 |
+
+The null-control pass shows that all three strategies produce policy values that
+exceed the null baseline in 8/10 permuted-outcome seeds, with similar means and
+standard deviations. This is consistent with the optimizer finding the same
+parameter region on the permuted data as on the real data -- the optimizer is
+successfully maximizing the IPS-weighted policy value even when the outcome is
+permuted (breaking the treatment-outcome link). The null-control pass confirms
+that the primary-slice policy values are dominated by the allocation policy's
+mechanics (which segment to treat, at what budget fraction) rather than by a
+true treatment effect signal.
+
+## Secondary Outcomes (Full-Slice Arm Aggregates)
+
+| Slice | Treated Visit Rate | Control Visit Rate | Treated Conversion Rate | Control Conversion Rate |
+|-------|--------------------|--------------------|-------------------------|-------------------------|
+| Primary | 15.14% | 10.62% | 0.88% | 0.57% |
+| Pooled | 16.70% | 10.62% | 1.07% | 0.57% |
+
+These are in-sample treated/control-arm means on the reshaped frame, not
+policy-conditioned. The Womens E-Mail treatment shows a 4.5pp lift in visit
+rate and a 0.31pp lift in conversion rate over control.
+
+## Causal vs Random
+
+| Slice | Budget | p-value (two-sided MWU) | Verdict | Direction |
+|-------|--------|-------------------------|---------|-----------|
+| Primary | B20 | 0.566 | Near-parity | random > causal |
+| Primary | B40 | 0.014 | Certified | random > causal |
+| Primary | B80 | 0.0004 | Certified | causal > random |
+| Pooled | B20 | 0.623 | Near-parity | causal > random |
+| Pooled | B40 | 0.241 | Near-parity | random > causal |
+| Pooled | B80 | 0.161 | Near-parity | causal > random |
+
+At B80 on the primary slice, the causal path significantly outperforms
+random (p=0.0004, two-sided MWU), with 9/10 causal wins. This confirms
+that the causal path does provide value relative to random search at high
+budget, even though it underperforms surrogate-only at low and medium budgets.
+
+## Interpretation
+
+1. **The primary slice has a very flat response surface.** Most runs on the
+   primary slice converge to policy values near 0.829, with less than 1% spread
+   across strategies and seeds at B20--B40. The surrogate-only path is slightly
+   better at finding this plateau (0.8293 vs 0.8285 for causal at B40), leading
+   to a statistically significant but practically tiny advantage.
+
+2. **The causal path occasionally discovers a higher-value region at B80.**
+   Three seeds (7, 8, 9) on the primary slice at B80 find solutions with
+   eligibility_threshold=0.0 that produce 12--16% higher policy values. This
+   suggests the causal graph's focus on the regularization-to-policy_value
+   edge helps the optimizer escape the local plateau when given enough budget.
+   However, the discovery is seed-dependent (3/10 seeds), making the mean
+   advantage noisy and not statistically significant.
+
+3. **On the pooled slice, the optimal corner is easier to find without causal
+   guidance.** The best pooled-slice policy (eligibility_threshold=0.0,
+   treatment_budget_pct=1.0) gives policy_value=1.2496, which is 19% above
+   the null baseline. Surrogate-only finds this corner in 8/10 seeds at B80;
+   causal finds it in only 3/10 seeds. The causal graph's variable-focusing
+   behavior may be narrowing exploration away from the corner.
+
+4. **No strategy consistently beats the null baseline on the primary slice.**
+   The primary slice has a weak treatment effect on spend, and all strategies
+   produce policy values mostly below the null baseline (0.865). The optimizer
+   is finding good policies within the search space but the treatment effect
+   is not strong enough for any policy to consistently improve over the no-
+   treatment baseline.
+
+5. **The RF backend is the active backend.** Ax/BoTorch was not available in
+   this environment, so all optimization runs used the RF surrogate fallback.
+   The causal path's behavior may differ under the Ax/BoTorch backend, which
+   was the primary backend for the energy benchmark wins. A follow-up run with
+   Ax/BoTorch would be needed to determine whether the causal advantage
+   pattern changes with a stronger surrogate.
+
+## Verdict Per Slice
+
+**Primary slice:** Near-parity at B20 and B80; certified surrogate-only
+advantage at B40. The causal path shows an interesting B80 tail where 3/10
+seeds find a qualitatively better region, but this is not statistically
+significant. Overall verdict: **NEAR-PARITY WITH CAUSAL B80 TAIL**.
+
+**Pooled slice:** Certified surrogate-only advantage at all three budgets.
+Surrogate-only more reliably finds the optimal corner at B80. Overall verdict:
+**SURROGATE-ONLY ADVANTAGE**.
+
+## What This Does Not Show
+
+1. This is a single non-energy dataset. It does not generalize the Hillstrom
+   result to all marketing datasets or all intervention domains.
+2. The benchmark ran on the RF fallback backend, not Ax/BoTorch. The certified
+   energy-domain causal wins were all Ax-primary. The Hillstrom result under
+   Ax/BoTorch is unknown.
+3. The 3-variable active search space is narrow compared to the energy
+   benchmarks. The causal graph's value may scale with dimensionality.
+4. This report does not claim a product-level generality win or loss from
+   Hillstrom alone. It is one data point in a broader generalization research
+   program.
+
+## Commands Run
+
+```bash
+uv run python scripts/hillstrom_benchmark.py \
+    --data-path /Users/robertwelborn/Projects/_local/causal-optimizer/data/hillstrom.csv \
+    --slices primary,pooled \
+    --budgets 20,40,80 \
+    --seeds 0,1,2,3,4,5,6,7,8,9 \
+    --strategies random,surrogate_only,causal \
+    --null-control \
+    --output /Users/robertwelborn/Projects/_local/causal-optimizer/artifacts/sprint-31-hillstrom-benchmark/hillstrom_results.json
+```
+
+Suite runtime: 1302.8 seconds (21.7 minutes), 240 total runs (180 real + 60
+null control).
+
+## Runtime Detail
+
+| Slice | Budget | Strategy | Mean Runtime (s) |
+|-------|--------|----------|------------------|
+| primary | B20 | random | 0.10 |
+| primary | B20 | surrogate_only | 2.58 |
+| primary | B20 | causal | 2.51 |
+| primary | B40 | random | 0.20 |
+| primary | B40 | surrogate_only | 7.49 |
+| primary | B40 | causal | 7.96 |
+| primary | B80 | random | 0.38 |
+| primary | B80 | surrogate_only | 14.39 |
+| primary | B80 | causal | 15.72 |
+| pooled | B20 | random | 0.15 |
+| pooled | B20 | surrogate_only | 2.67 |
+| pooled | B20 | causal | 2.88 |
+| pooled | B40 | random | 0.29 |
+| pooled | B40 | surrogate_only | 7.29 |
+| pooled | B40 | causal | 10.75 |
+| pooled | B80 | random | 0.57 |
+| pooled | B80 | surrogate_only | 14.28 |
+| pooled | B80 | causal | 20.07 |

--- a/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
+++ b/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
@@ -29,10 +29,12 @@ at certified significance (p=0.019, two-sided MWU).
 |-------|--------|--------------------------|-------------------------|---------|-----------|
 | Primary | B20 | s.o. wins 8/10 seeds | 0.060 | Trending | s.o. > causal |
 | Primary | B40 | s.o. wins 10/10 seeds | 0.0001 | Certified | s.o. > causal |
-| Primary | B80 | s.o. wins 7/10 seeds | 0.817 | Near-parity | causal mean > s.o. mean |
+| Primary | B80 | s.o. wins 7/10 seeds | 0.817 | Near-parity (bimodal) | causal mean > s.o. mean |
 | Pooled | B20 | s.o. wins 8/10 seeds | 0.017 | Certified | s.o. > causal |
 | Pooled | B40 | s.o. wins 9/10 seeds | 0.002 | Certified | s.o. > causal |
 | Pooled | B80 | s.o. wins 7/10 seeds | 0.019 | Certified | s.o. > causal |
+
+Abbreviation: **s.o.** = `surrogate_only` throughout this report.
 
 **Overall Hillstrom verdict: surrogate-only advantage.** The causal path does
 not show a consistent advantage over surrogate-only on this dataset under the
@@ -159,7 +161,10 @@ it converges too tightly on the local plateau.
 Note: The optimal corner (eligibility_threshold=0.0, treatment_budget_pct=1.0)
 yields policy_value=1.2496 on the pooled slice, which exceeds the null baseline
 of 1.0509. Surrogate-only finds this corner in 7/10 seeds at B80; causal finds
-it in only 3/10 seeds (1 win + 2 ties).
+it in only 3/10 seeds (1 win + 2 ties). Seed 2 is a consistently difficult
+seed for surrogate-only on the pooled slice (worst s.o. value at B20, B40,
+and B80), suggesting a seed-specific initialization that steers the surrogate
+away from the optimal corner.
 
 ## Summary Statistics
 
@@ -193,10 +198,15 @@ it in only 3/10 seeds (1 win + 2 ties).
 
 ## Null Baseline
 
-| Slice | mu (mean spend) |
-|-------|-----------------|
+| Slice | Null baseline mu |
+|-------|------------------|
 | Primary | 0.8654 |
 | Pooled | 1.0509 |
+
+The null baseline is the raw scalar mean of the `spend` column on the
+unshuffled reshaped frame — the expected per-customer spend under a
+uniform-treatment policy. It is computed before any optimization or
+policy conditioning.
 
 Most runs on the primary slice fall below the null baseline (0.8654), with the
 exception of causal B80 seeds 7--9 (0.926--0.966), which discover a higher-value
@@ -248,13 +258,17 @@ baseline (mean=1.164 vs baseline=1.051).
 
 The null-control pass shows that all three strategies produce policy values that
 exceed the null baseline in 8/10 permuted-outcome seeds, with similar means and
-standard deviations. This is consistent with the optimizer finding the same
-parameter region on the permuted data as on the real data -- the optimizer is
-successfully maximizing the IPS-weighted policy value even when the outcome is
-permuted (breaking the treatment-outcome link). The null-control pass confirms
-that the primary-slice policy values are dominated by the allocation policy's
-mechanics (which segment to treat, at what budget fraction) rather than by a
-true treatment effect signal.
+standard deviations. **This means high policy values can still arise after
+permuting outcomes (breaking the treatment-outcome link).** The optimizer finds
+different parameter regions on the permuted data than on the real data —
+selected parameters diverge substantially between real and null runs — so the
+null pass does not show that the optimizer converges to the same solution
+regardless of signal. What it does show is that the IPS-weighted objective can
+be optimized above baseline even on noise, due to some combination of
+finite-sample IPS variance, multiple-comparison effects across the search
+trajectory, and allocation-policy mechanics. The primary-slice gains should
+therefore not be interpreted as clean treatment-effect evidence on their own
+without additional analysis to separate these factors.
 
 ## Secondary Outcomes (Full-Slice Arm Aggregates)
 
@@ -343,6 +357,18 @@ Surrogate-only more reliably finds the optimal corner at B80. Overall verdict:
 4. This report does not claim a product-level generality win or loss from
    Hillstrom alone. It is one data point in a broader generalization research
    program.
+
+## Reproducibility
+
+The benchmark script is committed at `scripts/hillstrom_benchmark.py`. The
+Hillstrom CSV is available from the official MineThatData source:
+<https://blog.minethatdata.com/2008/03/minethatdata-e-mail-analytics-and-data.html>
+
+The full Hillstrom dataset is local-only (not committed). The committed fixture
+at `tests/fixtures/hillstrom_fixture.csv` is a small synthetic,
+Hillstrom-shaped file for CI smoke tests — it does not reproduce benchmark
+results. The JSON artifact from this run is stored locally at
+`$ARTIFACTS_DIR/sprint-31-hillstrom-benchmark/hillstrom_results.json`.
 
 ## Commands Run
 

--- a/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
+++ b/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
@@ -158,7 +158,7 @@ it converges too tightly on the local plateau.
 
 Note: The optimal corner (eligibility_threshold=0.0, treatment_budget_pct=1.0)
 yields policy_value=1.2496 on the pooled slice, which exceeds the null baseline
-of 1.0509. Surrogate-only finds this corner in 8/10 seeds at B80; causal finds
+of 1.0509. Surrogate-only finds this corner in 7/10 seeds at B80; causal finds
 it in only 3/10 seeds (1 win + 2 ties).
 
 ## Summary Statistics
@@ -302,7 +302,7 @@ budget, even though it underperforms surrogate-only at low and medium budgets.
 3. **On the pooled slice, the optimal corner is easier to find without causal
    guidance.** The best pooled-slice policy (eligibility_threshold=0.0,
    treatment_budget_pct=1.0) gives policy_value=1.2496, which is 19% above
-   the null baseline. Surrogate-only finds this corner in 8/10 seeds at B80;
+   the null baseline. Surrogate-only finds this corner in 7/10 seeds at B80;
    causal finds it in only 3/10 seeds. The causal graph's variable-focusing
    behavior may be narrowing exploration away from the corner.
 

--- a/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
+++ b/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
@@ -198,9 +198,9 @@ it in only 3/10 seeds (1 win + 2 ties).
 | Primary | 0.8654 |
 | Pooled | 1.0509 |
 
-All three strategies at all budgets find policy values below the null baseline
-on the primary slice (max=0.966 for causal B80 seed 9, which does exceed the
-baseline). On the pooled slice, surrogate-only B80 reliably exceeds the null
+Most runs on the primary slice fall below the null baseline (0.8654), with the
+exception of causal B80 seeds 7--9 (0.926--0.966), which discover a higher-value
+region. On the pooled slice, surrogate-only B80 reliably exceeds the null
 baseline (mean=1.164 vs baseline=1.051).
 
 ## Null Control (Primary Slice, Permuted Outcomes)
@@ -322,8 +322,8 @@ budget, even though it underperforms surrogate-only at low and medium budgets.
 
 ## Verdict Per Slice
 
-**Primary slice:** Near-parity at B20 and B80; certified surrogate-only
-advantage at B40. The causal path shows an interesting B80 tail where 3/10
+**Primary slice:** Trending s.o. advantage at B20, certified s.o. advantage
+at B40, near-parity at B80. The causal path shows an interesting B80 tail where 3/10
 seeds find a qualitatively better region, but this is not statistically
 significant. Overall verdict: **NEAR-PARITY WITH CAUSAL B80 TAIL**.
 
@@ -348,13 +348,13 @@ Surrogate-only more reliably finds the optimal corner at B80. Overall verdict:
 
 ```bash
 uv run python scripts/hillstrom_benchmark.py \
-    --data-path /Users/robertwelborn/Projects/_local/causal-optimizer/data/hillstrom.csv \
+    --data-path $DATA_DIR/hillstrom.csv \
     --slices primary,pooled \
     --budgets 20,40,80 \
     --seeds 0,1,2,3,4,5,6,7,8,9 \
     --strategies random,surrogate_only,causal \
     --null-control \
-    --output /Users/robertwelborn/Projects/_local/causal-optimizer/artifacts/sprint-31-hillstrom-benchmark/hillstrom_results.json
+    --output $ARTIFACTS_DIR/sprint-31-hillstrom-benchmark/hillstrom_results.json
 ```
 
 Suite runtime: 1302.8 seconds (21.7 minutes), 240 total runs (180 real + 60

--- a/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
+++ b/thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
@@ -203,10 +203,8 @@ away from the optimal corner.
 | Primary | 0.8654 |
 | Pooled | 1.0509 |
 
-The null baseline is the raw scalar mean of the `spend` column on the
-unshuffled reshaped frame — the expected per-customer spend under a
-uniform-treatment policy. It is computed before any optimization or
-policy conditioning.
+The null baseline is `μ = mean(spend)` on the unshuffled reshaped frame,
+computed before any optimization or policy conditioning.
 
 Most runs on the primary slice fall below the null baseline (0.8654), with the
 exception of causal B80 seeds 7--9 (0.926--0.966), which discover a higher-value


### PR DESCRIPTION
## Summary
- First non-energy real-data benchmark using the Hillstrom e-mail marketing dataset
- 10 seeds x 3 strategies x 2 slices x 3 budgets = 180 runs + 60 null-control runs
- Verdict: surrogate-only advantage on pooled slice; near-parity with causal B80 tail on primary slice
- RF backend only (Ax/BoTorch not available in benchmark environment)
- Closes #170

## Test plan
- [ ] Review benchmark report for statistical accuracy
- [ ] Verify null-control behavior matches expectations
- [ ] Check verdict classifications match evidence conventions (certified/trending/near-parity)
- [ ] Confirm p-values labeled as two-sided MWU per project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the Sprint 31 Hillstrom benchmark report — the first non-energy real-data benchmark — documenting 180 runs across 2 slices, 3 strategies, and 3 budgets. Two factual errors need to be corrected before merging:

- **Corner count (8/10 vs 7/10):** The pooled-B80 surrogate-only corner discovery is reported as 8/10 seeds in both the table note (line 161) and the Interpretation section (line 305), but counting the per-seed table rows with `s.o. = 1.2496` yields 7 seeds (0, 1, 5, 6, 7, 8, 9), not 8.
- **Null baseline claim (lines 201\u2013204):** The statement \"All three strategies at all budgets find policy values below the null baseline on the primary slice\" is internally contradicted \u2014 causal B80 seeds 7, 8, and 9 all exceed 0.8654 (values 0.9255, 0.9474, 0.9656). The parenthetical only names seed 9 and does not correct the universal claim.

<h3>Confidence Score: 3/5</h3>

Two P1 factual errors in reported statistics must be corrected before merging.

The 8/10 corner count appears twice and contradicts the raw per-seed table in the same document; the null baseline paragraph is self-contradictory. Both are straightforward one-line fixes, but they misrepresent the benchmark findings and should be corrected before this report is treated as the record of truth for Issue #170.

thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md — lines 161, 201–204, 305

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md | New benchmark report for Hillstrom dataset; contains two P1 factual errors: the pooled-B80 corner count for surrogate-only is stated as 8/10 in two places but the per-seed table shows 7/10, and the null-baseline section opens with a false universal claim that is immediately contradicted in the same sentence. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    DS[Hillstrom Dataset<br/>64,000 rows] --> P[Primary Slice<br/>Womens E-Mail vs No E-Mail<br/>42,693 rows]
    DS --> PL[Pooled Slice<br/>Any E-Mail vs No E-Mail<br/>64,000 rows]

    P --> B20P[Budget=20<br/>10 seeds]
    P --> B40P[Budget=40<br/>10 seeds]
    P --> B80P[Budget=80<br/>10 seeds]
    P --> NC[Null Control<br/>Permuted Outcomes<br/>B20 + B40]

    PL --> B20L[Budget=20<br/>10 seeds]
    PL --> B40L[Budget=40<br/>10 seeds]
    PL --> B80L[Budget=80<br/>10 seeds]

    B80L --> V1[Certified: s.o. > causal<br/>p=0.019]
    B80P --> V2[Near-parity<br/>p=0.817]
    B40P --> V3[Certified: s.o. > causal<br/>p=0.0001]
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%204%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%204%0Athoughts%2Fshared%2Fdocs%2Fsprint-31-hillstrom-benchmark-report.md%3A159-162%0A**Corner%20count%20stated%20as%208%2F10%20but%20table%20shows%207%2F10**%0A%0AThe%20note%20claims%20%22Surrogate-only%20finds%20this%20corner%20in%208%2F10%20seeds%20at%20B80%22%2C%20but%20counting%20the%20pooled%20B80%20per-seed%20table%20%28lines%20148%E2%80%93157%29%20gives%20%60s.o.%20%3D%201.2496%60%20for%20seeds%200%2C%201%2C%205%2C%206%2C%207%2C%208%2C%209%20%E2%80%94%20exactly%207%20seeds%2C%20not%208.%20The%20same%20incorrect%20count%20appears%20again%20in%20the%20Interpretation%20section%20%28line%20305%29.%20This%20directly%20contradicts%20the%20raw%20data%20in%20this%20report%20and%20will%20misrepresent%20the%20relative%20reliability%20of%20the%20two%20strategies.%0A%0A%60%60%60suggestion%0ANote%3A%20The%20optimal%20corner%20%28eligibility_threshold%3D0.0%2C%20treatment_budget_pct%3D1.0%29%0Ayields%20policy_value%3D1.2496%20on%20the%20pooled%20slice%2C%20which%20exceeds%20the%20null%20baseline%0Aof%201.0509.%20Surrogate-only%20finds%20this%20corner%20in%207%2F10%20seeds%20at%20B80%3B%20causal%20finds%0Ait%20in%20only%203%2F10%20seeds%20%281%20win%20%2B%202%20ties%29.%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%204%0Athoughts%2Fshared%2Fdocs%2Fsprint-31-hillstrom-benchmark-report.md%3A201-204%0A**Self-contradictory%20null%20baseline%20claim**%0A%0AThe%20opening%20clause%20%22All%20three%20strategies%20at%20all%20budgets%20find%20policy%20values%20below%20the%20null%20baseline%20on%20the%20primary%20slice%22%20is%20false%20%E2%80%94%20causal%20B80%20seeds%207%2C%208%2C%20and%209%20all%20exceed%20the%20primary%20null%20baseline%20of%200.8654%20%28values%200.9255%2C%200.9474%2C%200.9656%29.%20The%20parenthetical%20acknowledges%20only%20seed%209%20as%20the%20maximum%20without%20correcting%20the%20universal%20claim.%20This%20will%20mislead%20readers%20who%20don't%20cross-check%20the%20per-seed%20tables.%0A%0A%60%60%60suggestion%0AMost%20runs%20on%20the%20primary%20slice%20find%20policy%20values%20below%20the%20null%20baseline%0A%280.8654%29%3B%20the%20exception%20is%20causal%20B80%2C%20where%20seeds%207%2C%208%2C%20and%209%20exceed%20it%0A%280.9255%2C%200.9474%2C%200.9656%20respectively%20%E2%80%94%2012%E2%80%9316%25%20above%20baseline%29.%20On%20the%20pooled%20slice%2C%20surrogate-only%20B80%20reliably%20exceeds%20the%20null%0Abaseline%20%28mean%3D1.164%20vs%20baseline%3D1.051%29.%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%204%0Athoughts%2Fshared%2Fdocs%2Fsprint-31-hillstrom-benchmark-report.md%3A302-307%0A**Second%20occurrence%20of%208%2F10%20corner%20count**%0A%0AThis%20is%20the%20same%20incorrect%20count%20as%20the%20note%20at%20line%20161.%20Needs%20to%20be%20updated%20to%207%2F10%20to%20match%20the%20per-seed%20table.%0A%0A%60%60%60suggestion%0A3.%20**On%20the%20pooled%20slice%2C%20the%20optimal%20corner%20is%20easier%20to%20find%20without%20causal%0A%20%20%20guidance.**%20The%20best%20pooled-slice%20policy%20%28eligibility_threshold%3D0.0%2C%0A%20%20%20treatment_budget_pct%3D1.0%29%20gives%20policy_value%3D1.2496%2C%20which%20is%2019%25%20above%0A%20%20%20the%20null%20baseline.%20Surrogate-only%20finds%20this%20corner%20in%207%2F10%20seeds%20at%20B80%3B%0A%20%20%20causal%20finds%20it%20in%20only%203%2F10%20seeds.%20The%20causal%20graph's%20variable-focusing%0A%20%20%20behavior%20may%20be%20narrowing%20exploration%20away%20from%20the%20corner.%0A%60%60%60%0A%0A%23%23%23%20Issue%204%20of%204%0Athoughts%2Fshared%2Fdocs%2Fsprint-31-hillstrom-benchmark-report.md%3A349-358%0A**Hardcoded%20personal%20filesystem%20paths**%0A%0ABoth%20%60--data-path%60%20and%20%60--output%60%20are%20absolute%20paths%20rooted%20at%20%60%2FUsers%2Frobertwelborn%2FProjects%2F_local%2F%E2%80%A6%60.%20These%20commands%20won't%20run%20for%20any%20other%20team%20member%20without%20manual%20editing%2C%20which%20undermines%20reproducibility%20of%20the%20benchmark.%0A%0AConsider%20replacing%20with%20repository-relative%20paths%20or%20environment-variable%20placeholders%2C%20e.g.%3A%0A%0A%60%60%60bash%0Auv%20run%20python%20scripts%2Fhillstrom_benchmark.py%20%5C%0A%20%20%20%20--data-path%20data%2Fhillstrom.csv%20%5C%0A%20%20%20%20--slices%20primary%2Cpooled%20%5C%0A%20%20%20%20--budgets%2020%2C40%2C80%20%5C%0A%20%20%20%20--seeds%200%2C1%2C2%2C3%2C4%2C5%2C6%2C7%2C8%2C9%20%5C%0A%20%20%20%20--strategies%20random%2Csurrogate_only%2Ccausal%20%5C%0A%20%20%20%20--null-control%20%5C%0A%20%20%20%20--output%20artifacts%2Fsprint-31-hillstrom-benchmark%2Fhillstrom_results.json%0A%60%60%60%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
Line: 159-162

Comment:
**Corner count stated as 8/10 but table shows 7/10**

The note claims "Surrogate-only finds this corner in 8/10 seeds at B80", but counting the pooled B80 per-seed table (lines 148–157) gives `s.o. = 1.2496` for seeds 0, 1, 5, 6, 7, 8, 9 — exactly 7 seeds, not 8. The same incorrect count appears again in the Interpretation section (line 305). This directly contradicts the raw data in this report and will misrepresent the relative reliability of the two strategies.

```suggestion
Note: The optimal corner (eligibility_threshold=0.0, treatment_budget_pct=1.0)
yields policy_value=1.2496 on the pooled slice, which exceeds the null baseline
of 1.0509. Surrogate-only finds this corner in 7/10 seeds at B80; causal finds
it in only 3/10 seeds (1 win + 2 ties).
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
Line: 201-204

Comment:
**Self-contradictory null baseline claim**

The opening clause "All three strategies at all budgets find policy values below the null baseline on the primary slice" is false — causal B80 seeds 7, 8, and 9 all exceed the primary null baseline of 0.8654 (values 0.9255, 0.9474, 0.9656). The parenthetical acknowledges only seed 9 as the maximum without correcting the universal claim. This will mislead readers who don't cross-check the per-seed tables.

```suggestion
Most runs on the primary slice find policy values below the null baseline
(0.8654); the exception is causal B80, where seeds 7, 8, and 9 exceed it
(0.9255, 0.9474, 0.9656 respectively — 12–16% above baseline). On the pooled slice, surrogate-only B80 reliably exceeds the null
baseline (mean=1.164 vs baseline=1.051).
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
Line: 302-307

Comment:
**Second occurrence of 8/10 corner count**

This is the same incorrect count as the note at line 161. Needs to be updated to 7/10 to match the per-seed table.

```suggestion
3. **On the pooled slice, the optimal corner is easier to find without causal
   guidance.** The best pooled-slice policy (eligibility_threshold=0.0,
   treatment_budget_pct=1.0) gives policy_value=1.2496, which is 19% above
   the null baseline. Surrogate-only finds this corner in 7/10 seeds at B80;
   causal finds it in only 3/10 seeds. The causal graph's variable-focusing
   behavior may be narrowing exploration away from the corner.
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-31-hillstrom-benchmark-report.md
Line: 349-358

Comment:
**Hardcoded personal filesystem paths**

Both `--data-path` and `--output` are absolute paths rooted at `/Users/robertwelborn/Projects/_local/…`. These commands won't run for any other team member without manual editing, which undermines reproducibility of the benchmark.

Consider replacing with repository-relative paths or environment-variable placeholders, e.g.:

```bash
uv run python scripts/hillstrom_benchmark.py \
    --data-path data/hillstrom.csv \
    --slices primary,pooled \
    --budgets 20,40,80 \
    --seeds 0,1,2,3,4,5,6,7,8,9 \
    --strategies random,surrogate_only,causal \
    --null-control \
    --output artifacts/sprint-31-hillstrom-benchmark/hillstrom_results.json
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["address claude review feedback (claudelo..."](https://github.com/datablogin/causal-optimizer/commit/835b022074d05425ae0a2240515d6eeee80c6f4f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28651018)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->