### PR TITLE
docs: Sprint 32 Criteo Uplift benchmark contract

### DIFF
--- a/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
+++ b/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
@@ -1,0 +1,669 @@
+# Sprint 32 Criteo Uplift Benchmark Contract
+
+**Date:** 2026-04-16
+**Sprint:** 32 (Criteo Uplift Benchmark Contract)
+**Issue:** #177
+**Branch:** `sprint-32/criteo-benchmark-contract`
+**Predecessor:** Sprint 31 Hillstrom benchmark (PR #176), Criteo audit (PR #174)
+**Status:** Contract and execution brief. Not an implementation PR.
+
+## 0. Purpose
+
+This document is the benchmark contract for the project's first Criteo
+Uplift run. It does **not** implement the benchmark. It pins:
+
+1. what the first executable Criteo benchmark should optimize and report
+2. what must be frozen versus tunable in the first pass
+3. how to map Criteo columns into the existing `MarketingLogAdapter`
+4. what diagnostics and null controls are mandatory before trusting any
+   result
+5. what a pass and a failure would each mean for the project
+
+The binding constraint is that Criteo is the second marketing benchmark,
+not the first. Hillstrom (Sprint 31) already proved the wrapper pattern,
+exposed the RF-backend boundary, and established the evidence discipline.
+This contract builds on those lessons rather than relitigating them.
+
+## 1. Dataset Choice And Why Now
+
+### 1a. Why Criteo Is The Right Second Marketing Benchmark
+
+1. **Same problem class, harder stress test.** Criteo is a binary-
+   treatment uplift benchmark like Hillstrom, so it keeps the
+   intervention framing clean. But it is harder in every measurable
+   dimension: 14M rows vs 64K, 85:15 treatment imbalance vs 50:50,
+   binary outcomes vs continuous spend, anonymized features vs
+   interpretable covariates.
+2. **Tests whether the Hillstrom outcome was dataset-specific.** The
+   Sprint 31 lessons-learned doc identifies three possible explanations
+   for Hillstrom's surrogate-only advantage: (a) weak treatment effect
+   on a narrow search space, (b) RF-backend artifact, (c) a broader
+   sign that surrogate-only is stronger on binary uplift problems.
+   Criteo can distinguish (a) from (c).
+3. **Compatible with the proven wrapper pattern.** The Criteo audit
+   (PR #174) confirmed that a `CriteoLoader` wrapper over
+   `MarketingLogAdapter` is sufficient for the first run. No new
+   adapter or policy-evaluation stack is required.
+4. **Keeps the benchmark queue disciplined.** Open Bandit Dataset
+   requires a multi-action adapter rewrite. Starting Criteo first
+   means the next marketing benchmark tests scale and imbalance
+   tolerance without entangling a new architecture project.
+
+### 1b. Why Criteo Is Not Trivial
+
+1. **85:15 treatment imbalance.** Control observations carry IPS weight
+   `1 / (1 - 0.85) = 6.67`. This is 3.3x higher than Hillstrom's
+   maximum weight of 2.0. The IPS stack will be under real stress.
+2. **Binary outcomes only.** `visit` (4.70% base rate) and `conversion`
+   (0.29%) are both binary. IPS-weighted means of rare binary events
+   are noisy. There is no continuous outcome like Hillstrom's `spend`
+   to smooth the signal.
+3. **Anonymized features.** All 12 features are randomly projected
+   floats. No interpretable causal graph can be constructed from domain
+   knowledge. The causal strategy loses its primary advantage (graph-
+   ancestor focus) unless a data-driven graph is learned.
+4. **Non-uniform subsampling.** The dataset was deliberately subsampled
+   so that absolute incrementality levels cannot be recovered. Relative
+   signal (which features predict uplift) is preserved, but effect
+   sizes cannot be compared to Hillstrom or energy benchmarks in
+   absolute terms.
+5. **Exposure noncompliance.** Not all treated users saw an ad. The ITT
+   estimand (using `treatment`) dilutes the effect relative to a per-
+   protocol analysis (using `exposure`). The first run uses ITT only.
+
+## 2. What Hillstrom Changed About This Decision
+
+Sprint 31 produced five lessons that directly shape the Criteo contract:
+
+### 2a. Backend Differences Matter
+
+Hillstrom ran on the RF fallback backend. The strongest synthetic causal
+wins were Ax-primary. The Hillstrom result therefore does not tell us
+whether the causal path would have performed differently under Ax/BoTorch
+on the same data. **Criteo must attempt to run under the Ax/BoTorch
+backend.** If Ax is unavailable, the report must flag this as an open
+confound, exactly as the Hillstrom report did.
+
+### 2b. Null-Control Interpretation Matters
+
+Hillstrom's null-control pass showed that all three strategies can
+produce policy values above the null baseline on permuted data (8/10
+seeds exceeding baseline). This means high policy values alone are not
+clean treatment-effect evidence. **Criteo's null control must follow the
+same permuted-outcome discipline** and the report must separate
+"optimizer found a high-value policy under the estimator" from "clean
+treatment-effect evidence."
+
+### 2c. Narrow Search Spaces Can Blunt Graph Value
+
+Hillstrom's 3-variable active search space is much narrower than the
+energy benchmarks where causal guidance had the clearest wins. The causal
+graph may have more leverage when the search problem contains more
+irrelevant or weakly relevant directions. **Criteo's first run uses the
+same 3-variable active space as Hillstrom** (for comparability), but a
+follow-on run should consider widening the search space if the first run
+shows near-parity.
+
+### 2d. A Wrapper That Runs Is Not A Benchmark That Proves Generality
+
+The Hillstrom wrapper worked end to end. The benchmark still showed a
+surrogate-only advantage. **Criteo must not declare victory because the
+wrapper runs.** The verdict depends on strategy ordering, significance
+tests, and null-control behavior.
+
+### 2e. Marketing Benchmarks Need IPS-First Diagnostics
+
+Hillstrom's null-control and tail behavior both pointed to the same
+practical need: marketing benchmarks should make ESS, max weight, weight
+CV, and support coverage first-class diagnostics. **Criteo makes this
+even more important** because of its 85:15 imbalance and rare binary
+outcomes. If ESS drops below 100 on any seed, that seed's result is
+flagged as unreliable.
+
+## 3. Official Source, License, And Local-Data Expectations
+
+### 3a. Source And Access
+
+| Item | Value |
+|------|-------|
+| Official page | Criteo AI Lab |
+| Direct download (v2.1) | `http://go.criteo.net/criteo-research-uplift-v2.1.csv.gz` |
+| Hugging Face mirror | `criteo/criteo-uplift` on Hugging Face Datasets |
+| Reference paper | Diemert et al., "A Large Scale Benchmark for Uplift Modeling", AdKDD 2018, KDD London |
+| Registration | None. Direct download, no authentication. |
+
+### 3b. License
+
+**CC-BY-NC-SA-4.0** (Creative Commons Attribution-NonCommercial-
+ShareAlike 4.0 International).
+
+Permitted: non-commercial research use, derivative works under the same
+license, public sharing of results and reports.
+
+Restricted: commercial use, redistribution under a different license,
+attempts to recover original features or user identity.
+
+**Required attribution:** Cite Diemert et al. 2018 in any report.
+
+**Project impact:** Any CI fixture committed to the repo must carry the
+same CC-BY-NC-SA-4.0 license and attribution. A `LICENSE-CRITEO` file
+must be added alongside the fixture. This is stricter than Hillstrom
+(public domain / unrestricted).
+
+### 3c. Dataset Shape
+
+| Metric | Value |
+|--------|-------|
+| Rows | 13,979,592 |
+| Columns | 16 (12 features `f0`-`f11` + `treatment` + `exposure` + `visit` + `conversion`) |
+| Compressed size | ~297 MB (gzip CSV) |
+| Uncompressed size | ~311 MB |
+| In-memory (float64) | ~1.7 GB (full), ~120 MB (1M subsample) |
+
+### 3d. Local-Data Expectations
+
+1. **Full dataset:** downloaded once to a local path outside the repo.
+   Not committed. Not required for CI.
+2. **1M-row subsample:** generated from the full dataset with a fixed
+   seed. Used for all first-run benchmarks. Stored locally, not
+   committed.
+3. **CI fixture:** a 3,000-row deterministic subsample committed to
+   `tests/fixtures/criteo_uplift_fixture.csv` with a `LICENSE-CRITEO`
+   file. Must preserve the 85:15 treatment ratio. Used for smoke tests
+   and adapter validation only, not benchmark verdicts.
+
+## 4. First-Run Benchmark Shape
+
+### 4a. Strategies
+
+| # | Strategy | Description |
+|---|----------|-------------|
+| 1 | `random` | Uniform random parameter sampling |
+| 2 | `surrogate_only` | RF or Ax/BoTorch surrogate, no causal graph |
+| 3 | `causal` | Surrogate + causal graph guidance |
+
+Same three strategies as Hillstrom and the synthetic regression gate.
+
+### 4b. Seeds
+
+10 seeds (0-9). Same seed budget as Hillstrom and the Sprint 29
+regression gate. Minimum needed for two-sided MWU at p <= 0.05.
+
+### 4c. Budgets
+
+B20, B40, B80. Same as Hillstrom. Claim language locked on B80.
+
+### 4d. Primary Outcome
+
+**`visit`** (binary 0/1, 4.70% base rate).
+
+Rationale: `visit` has 16x the positive rate of `conversion` (4.70% vs
+0.29%). On a 1M-row subsample, `visit` produces ~47,000 positive
+outcomes (~7,050 in the control arm), which is adequate for IPS-weighted
+estimation. `conversion` produces ~2,900 positives (~435 in control),
+which is marginal for stable per-seed estimates.
+
+IPS-weighted `policy_value` on binary 0/1 data becomes an IPS-weighted
+visit rate. The optimizer searches for policies that maximize this rate.
+
+### 4e. Secondary Outcome
+
+**`conversion`** (binary 0/1, 0.29% base rate). Reported in the
+benchmark report as a secondary aggregate, but not used as the
+optimization target. If the first run shows that `visit`-based IPS
+estimates are too noisy, `conversion` will not rescue the benchmark.
+
+### 4f. Dataset Scale
+
+**Fixed-seed 1M-row subsample** for the first run.
+
+Implementation: `CriteoLoader` reads the full CSV/Parquet, samples 1M
+rows with `DataFrame.sample(n=1_000_000, random_state=CRITEO_SAMPLE_SEED)`,
+and passes the subsample to `MarketingLogAdapter`. The sample seed is a
+named constant, not a per-run seed. Every strategy-budget-seed
+combination operates on the same 1M rows.
+
+Rationale: 1M rows keeps per-call latency negligible (~120 MB in memory)
+while providing enough control-arm observations (~150,000) for stable
+IPS estimation. The full 14M can be used for extended runs if the first
+pass shows promise.
+
+### 4g. Total Experiment Count
+
+| Component | Count |
+|-----------|-------|
+| Real benchmark: 3 strategies x 3 budgets x 10 seeds | 90 runs |
+| Null control: 3 strategies x 2 budgets x 10 seeds | 60 runs |
+| **Total** | **150 runs** |
+
+At B80, each run executes up to 80 adapter calls. Worst-case total
+adapter calls: 150 x 80 = 12,000. At ~1M rows per call with vectorized
+numpy, this should complete within 1-2 hours on a modern machine.
+
+## 5. Wrapper Mapping Into MarketingLogAdapter
+
+### 5a. Criteo Columns
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `f0` - `f11` | float | Anonymized, randomly projected features |
+| `treatment` | int (0/1) | Binary treatment indicator |
+| `exposure` | int (0/1) | Whether treated user was exposed to an ad |
+| `visit` | int (0/1) | User visited after ad exposure window |
+| `conversion` | int (0/1) | User converted after window |
+
+### 5b. Adapter Required Columns
+
+| Adapter column | Criteo source | Transform |
+|----------------|---------------|-----------|
+| `treatment` (int 0/1) | `treatment` | Pass-through. Already binary 0/1. |
+| `outcome` (float) | `visit` | Pass-through. Binary 0/1 used as float. |
+| `cost` (float) | synthesized | `0.01` per treated observation, `0.0` per control. Fixed constant, not tuned. Does not affect `policy_value`. |
+
+### 5c. Adapter Optional Columns
+
+| Adapter column | Criteo source | Transform |
+|----------------|---------------|-----------|
+| `propensity` (float) | synthesized | Constant `0.85` for all rows. Known from the randomization design. See Section 6b for details. |
+| `channel` (str) | constant | `"email"` for all rows. Criteo is single-channel (ad display). Degenerate. |
+| `segment` (str) | omitted | Criteo has no natural segment column. All 12 features are anonymized. The adapter assigns uniform `segment_score = 0.2` to all rows. See Section 5d. |
+
+### 5d. Segment Column Decision
+
+Criteo has no natural segment column. Three options were considered:
+
+1. **Omit segment entirely.** Adapter assigns all rows
+   `segment_score = 0.2`. Uplift scores depend only on channel weight
+   and regularization. Less heterogeneity for the optimizer to exploit.
+2. **Synthesize from feature quantiles.** Map tertiles of `f0` to
+   `"high_value" / "medium" / "low"`. Creates heterogeneity but is
+   arbitrary.
+3. **Defer.** Accept reduced heterogeneity and diagnose from results.
+
+**Decision: Option 1 (omit segment) for the first run.** Rationale:
+synthesizing a segment from anonymized features would fabricate structure
+that does not exist in the data. If the first run shows all policies
+collapse to the same `policy_value`, the follow-on run should synthesize
+a segment and compare.
+
+### 5e. Features Dropped On First Run
+
+`f0` - `f11` (anonymized features) and `exposure` are dropped from the
+adapter input. The adapter's policy evaluation does not reference raw
+features. `exposure` is reserved for a future per-protocol analysis.
+
+The `CriteoLoader` should retain `conversion` on the subsample frame
+for secondary reporting, but it is not passed to the adapter as an
+input column.
+
+### 5f. Degenerate Column Consequences
+
+With segment omitted and channel constant, the adapter's uplift score
+computation simplifies:
+
+- `channel_weight` = constant (all rows get `email_share + 0.1`)
+- `segment_score` = constant (all rows get `0.2`)
+- `raw_score` = constant for all rows
+- After regularization and normalization, `uplift_score` = `0.5` for
+  all rows (uniform)
+
+This means `eligibility_threshold` becomes the sole policy lever that
+varies treatment assignment across observations. When
+`eligibility_threshold < 0.5`, all rows are eligible; when
+`eligibility_threshold > 0.5`, no rows are eligible. The optimizer
+searches a step-function response surface.
+
+**This is a known limitation of the first run.** It mirrors the
+Hillstrom behavior where the optimal corner (`eligibility_threshold=0.0`,
+`treatment_budget_pct=1.0`) dominated. On Criteo, the optimizer should
+discover the same corner if the treat-everyone policy is optimal under
+IPS weighting at 85:15 imbalance.
+
+The consequence is explicit: the first Criteo run tests whether the
+engine's phase transitions, surrogate modeling, and screening add value
+on a degenerate surface under heavy IPS variance. It does not test
+whether causal graph focus helps on a heterogeneous surface. That test
+requires a follow-on run with a synthesized segment or a wider search
+space.
+
+## 6. Search-Space And Propensity Decisions
+
+### 6a. Search Space
+
+| Variable | First-run treatment | Range |
+|----------|-------------------|-------|
+| `eligibility_threshold` | **Tuned** | [0.0, 1.0] |
+| `email_share` | **Fixed at `1.0`** | degenerate (single channel) |
+| `social_share_of_remainder` | **Fixed at `0.0`** | degenerate (single channel) |
+| `min_propensity_clip` | **Fixed at `0.01`** | see Section 6c |
+| `regularization` | **Tuned** | [0.001, 10.0] |
+| `treatment_budget_pct` | **Tuned** | [0.1, 1.0] |
+
+Effective active search space: **3 tuned continuous variables**
+(`eligibility_threshold`, `regularization`, `treatment_budget_pct`).
+Same dimensionality as Hillstrom, for direct comparability.
+
+### 6b. Propensity Decision
+
+**Constant `0.85` for all rows.**
+
+Justification: treatment was randomized at 85:15. The v2.1 release
+rebalanced treatment ratios across incrementality tests, so within-test
+propensity should be approximately constant conditional on features.
+The `MarketingLogAdapter` falls back to marginal treatment rate when the
+propensity column is absent, which would yield `0.85` automatically.
+However, the `CriteoLoader` should explicitly add `propensity = 0.85`
+for clarity and provenance.
+
+Risk: if residual propensity heterogeneity remains after v2 rebalancing,
+the constant assumption introduces bias. The first run should monitor
+`weight_cv` and `max_ips_weight` to detect whether IPS weights are
+suspiciously variable despite the constant-propensity assumption. Under
+a true constant propensity of 0.85:
+
+- Treated observations: IPS weight = `1 / 0.85 = 1.176`
+- Control observations: IPS weight = `1 / 0.15 = 6.667`
+
+Expected `weight_cv` under constant propensity and uniform policy
+assignment: calculable from the 85:15 mix. If observed `weight_cv`
+exceeds this expected value substantially, propensity heterogeneity may
+be present.
+
+### 6c. min_propensity_clip Decision
+
+**Fixed at `0.01` (conservative, not tuned).**
+
+The bias-variance tradeoff:
+
+- **Tunable:** the optimizer could search `min_propensity_clip` in
+  `[0.01, 0.5]`. But on Criteo, the propensity is a constant `0.85`,
+  which is within the adapter's clip range. The clip floor only fires
+  when `propensity < min_propensity_clip` or
+  `propensity > 1 - min_propensity_clip`. At `clip = 0.01`,
+  `1 - 0.01 = 0.99 > 0.85`, so no clipping occurs. At `clip = 0.15`,
+  `1 - 0.15 = 0.85`, which clips the propensity to exactly the
+  boundary — a no-op. At `clip > 0.15`, the control-arm propensity
+  `0.15` would be clipped upward, reducing IPS variance but introducing
+  bias.
+- **Fixed at 0.01:** the clip never fires on either arm. This is the
+  most conservative choice: no bias introduced, full IPS variance
+  preserved. The diagnostics (ESS, weight_cv, max_ips_weight) will
+  reveal whether that variance is tolerable.
+
+The decision is to fix at `0.01` and let the first run's diagnostics
+determine whether a wider clip is needed. If ESS is consistently below
+100, the follow-on run should consider tuning `min_propensity_clip` or
+fixing it at a higher value (e.g., `0.10`).
+
+### 6d. Prior Causal Graph
+
+The Hillstrom contract projected the full 14-edge adapter graph to a
+7-edge subgraph over active variables. The same projection applies on
+Criteo:
+
+```text
+eligibility_threshold  --> treated_fraction
+treatment_budget_pct   --> treated_fraction
+regularization         --> treated_fraction
+regularization         --> policy_value
+treated_fraction       --> total_cost
+treated_fraction       --> policy_value
+treated_fraction       --> effective_sample_size
+```
+
+Dropped edges (7 total): `email_share -> {total_cost, policy_value}`,
+`social_share_of_remainder -> {total_cost, policy_value}`,
+`min_propensity_clip -> {total_cost, policy_value,
+effective_sample_size}`.
+
+**Alternative: empty graph + auto-discovery.** Because Criteo features
+are anonymized, no domain-knowledge prior graph over features is
+possible. The projected policy-variable graph above encodes only the
+mechanical relationship between policy levers and metrics. A follow-on
+run could test `discovery_method="correlation"` at the exploration-to-
+optimization phase transition to learn a data-driven graph. This would
+be the first real-data test of the `GraphLearner` pathway.
+
+**Decision for first run:** use the projected 7-edge policy-variable
+graph, same as Hillstrom. This preserves comparability. Document the
+auto-discovery alternative as a follow-on recommendation.
+
+## 7. Diagnostics And Null-Control Requirements
+
+### 7a. Per-Seed Diagnostics
+
+The benchmark report must include, for each seed and budget:
+
+| Diagnostic | Source | Purpose |
+|------------|--------|---------|
+| `policy_value` | adapter metric | Primary objective |
+| `effective_sample_size` | adapter metric (Kish's ESS) | IPS reliability. **Flag if < 100.** |
+| `max_ips_weight` | adapter metric | Variance risk. Expected: 6.667 under constant propensity. **Flag if > 20.** |
+| `weight_cv` | adapter metric | Weight stability. **Flag if > 3.0.** |
+| `zero_support` | adapter metric (0/1) | Whether any observations match the policy. **Flag if 1.0.** |
+| `propensity_clip_fraction` | adapter metric | Should be 0.0 under `clip=0.01` with constant propensity 0.85. **Flag if > 0.** |
+| `treated_fraction` | adapter metric | Policy selectivity |
+| `total_cost` | adapter metric | Provenance only |
+
+These match the metrics `MarketingLogAdapter` already returns. No new
+metrics are required.
+
+### 7b. Aggregate Diagnostics
+
+1. Per-strategy `policy_value` mean, population std (ddof=0), wins out
+   of 10
+2. Per-comparison two-sided Mann-Whitney U p-value (causal vs s.o.,
+   causal vs random, s.o. vs random)
+3. Cohen's d using sample-pooled std (ddof=1)
+4. Claim language: `certified` (p <= 0.05), `trending` (0.05 < p <=
+   0.10), `near-parity` (p > 0.10)
+5. Optimizer-path provenance (Ax/BoTorch primary or RF fallback)
+6. Median ESS across seeds per strategy-budget cell. If median ESS <
+   100 for any cell, the cell's verdict is flagged as "low-ESS
+   unreliable"
+
+### 7c. Provenance Requirements
+
+The benchmark report must record:
+
+1. Criteo dataset version (v2.1)
+2. Subsample seed and row count (1M)
+3. Treatment ratio in the subsample (should be ~85:15)
+4. Visit rate in the subsample (should be ~4.70%)
+5. Number of positive outcomes in the control arm
+6. Optimizer backend (Ax/BoTorch or RF fallback)
+7. Fixed parameter values (`email_share=1.0`,
+   `social_share_of_remainder=0.0`, `min_propensity_clip=0.01`,
+   `cost=0.01/0.0`, `propensity=0.85`)
+8. Projected prior graph (7 edges)
+9. Diemert et al. 2018 citation
+
+### 7d. Null Control
+
+Permuted-outcome null control, following the Hillstrom discipline:
+
+1. **Permutation target:** shuffle the `visit` column across rows using
+   a deterministic permutation seeded per null-control seed. Preserve
+   treatment assignment, propensities, and all other columns. Call the
+   shuffled frame `D_null`.
+2. **Budgets:** B20 and B40 only. B80 is not required for the null
+   control.
+3. **Strategies:** all three (random, surrogate_only, causal).
+4. **Seeds:** 10.
+5. **Null baseline:** `mu = mean(visit)` on the unshuffled 1M-row
+   subsample. This is the raw visit rate (~0.047). Because shuffling is
+   a permutation of the same column values, `mu` is identical on `D`
+   and `D_null`.
+
+**Failure criterion:** the null control fails if any strategy's mean
+`policy_value` across the 10 null-control seeds exceeds `1.05 * mu` at
+any budget.
+
+Note: the tolerance is `5%`, wider than Hillstrom's initial `2%`
+threshold. Rationale: `visit` is a binary 0/1 column with a 4.70% base
+rate. IPS-weighted means of sparse binary outcomes on permuted data are
+inherently noisier than IPS-weighted means of continuous `spend`. The
+Hillstrom null control already showed that the `2%` threshold can be
+tight on right-skewed zero-inflated data. Starting at `5%` on a sparse
+binary outcome avoids a predictable fallback-ladder invocation.
+
+**Pre-committed fallback:** if more than 3 of 10 null-control seeds for
+any strategy exceed `1.05 * mu`:
+  (a) widen to `1.10 * mu` and re-evaluate the same seeds (no new runs);
+  (b) if `10%` still fails, the null control fails and blocks the real
+  verdict.
+
+If the null control fails, the implementation sprint must stop and
+diagnose before reporting any real-data verdict.
+
+## 8. What A Pass Would Mean
+
+### 8a. Success (Certified Criteo Win)
+
+All four conditions must hold:
+
+1. Causal `policy_value` at B80 is strictly greater than surrogate_only
+   at B80, with `p <= 0.05` under two-sided Mann-Whitney U.
+2. Causal is not statistically worse than random at B80.
+3. The null control passes.
+4. Median ESS at B80 is >= 100 for all strategies.
+
+A certified Criteo win would mean: the engine's causal guidance provides
+a measurable advantage on a large-scale, imbalanced, binary-treatment
+uplift benchmark with anonymized features. Combined with the synthetic
+wins (medium-noise, high-noise, dose-response), this would strengthen
+the generality claim beyond energy-only evidence.
+
+### 8b. Partial Success (Trending Signal)
+
+1. Causal mean beats surrogate-only in direction at B80.
+2. The comparison is `0.05 < p <= 0.10`.
+3. The null control passes.
+4. ESS is adequate (median >= 100).
+
+A trending signal would motivate: (a) extending to the full 14M rows,
+(b) tuning min_propensity_clip or synthesizing a segment column, (c) a
+follow-on run with auto-discovered causal graph.
+
+### 8c. Near-Parity
+
+1. No statistically significant difference between causal and
+   surrogate_only at any budget.
+2. The null control passes.
+3. ESS is adequate.
+
+Near-parity with adequate ESS would mean: the degenerate search surface
+and/or the lack of an informative prior graph prevents the causal path
+from differentiating. This is diagnosable and motivates a wider search
+space or synthesized heterogeneity in a follow-on run.
+
+### 8d. IPS Variance Failure
+
+1. Median ESS < 100 at B80 for any strategy.
+2. Or: `weight_cv > 5.0` consistently across seeds.
+3. Or: the null control fails.
+
+This would mean: the IPS stack is under too much stress at 85:15
+imbalance with binary outcomes. The project should consider: (a) using
+the full 14M rows, (b) implementing doubly robust estimation, (c)
+tuning `min_propensity_clip` to a bias-accepting value.
+
+## 9. What A Failure Would Mean
+
+### 9a. Surrogate-Only Advantage (Same As Hillstrom)
+
+If surrogate_only beats causal at certified significance on Criteo, the
+project has two consecutive marketing benchmarks where the causal path
+does not add value. This would narrow the generality claim:
+
+- Causal guidance helps on energy and synthetic benchmarks (confirmed).
+- Causal guidance does not help on marketing uplift benchmarks under the
+  current engine (two data points).
+
+This is a productive result. It localizes the boundary to the marketing
+uplift problem class and motivates investigation into whether the issue
+is: (a) the degenerate search surface, (b) the lack of a meaningful
+prior graph, (c) the IPS estimation variance, or (d) a real limit of
+the causal approach on binary uplift.
+
+### 9b. Causal Worse Than Random
+
+If causal is statistically worse than random at B80, this would be a
+regression signal. It would mean the causal graph is actively hurting
+the optimizer, not just failing to help. This would require immediate
+diagnosis before proceeding with any further marketing benchmarks.
+
+### 9c. Null Control Failure
+
+A null control failure would mean the IPS-weighted policy evaluation
+can be gamed even on noise. This blocks all other verdicts and requires
+diagnosing the IPS stack before continuing.
+
+## 10. Recommendation For The Implementation Sprint
+
+### 10a. Scope
+
+The implementation sprint should:
+
+1. Write a `CriteoLoader` wrapper that:
+   - reads the Criteo v2.1 CSV or Parquet
+   - subsamples to 1M rows with a fixed seed
+   - maps columns per Section 5b/5c
+   - pre-bakes frozen parameters per Section 6a
+   - projects the prior graph per Section 6d
+   - generates the permuted-outcome null control frame
+
+2. Commit a 3,000-row CI fixture with `LICENSE-CRITEO` attribution.
+
+3. Write a benchmark script modeled on `scripts/hillstrom_benchmark.py`.
+
+4. Run the full 150-run benchmark (90 real + 60 null control).
+
+5. Publish the Sprint 33 Criteo benchmark report following the evidence
+   discipline established on Hillstrom.
+
+### 10b. What Must Not Change
+
+1. `MarketingLogAdapter` source code (no adapter changes).
+2. Sprint 29 engine defaults (`causal_exploration_weight=0.0`).
+3. The 3-strategy, 10-seed, 3-budget evidence discipline.
+4. The claim language conventions (certified / trending / near-parity).
+
+### 10c. Prerequisite Before Implementation
+
+The Criteo v2.1 CSV must be downloaded locally. The implementation
+sprint should document the download path and verify the file hash.
+The raw file must not be committed to the repository.
+
+### 10d. Follow-On Run Candidates (Not In First Implementation)
+
+If the first run shows near-parity or IPS variance issues:
+
+1. **Synthesized segment from feature quantiles.** Tertiles of `f0`
+   mapped to `"high_value" / "medium" / "low"` to introduce uplift-
+   score heterogeneity.
+2. **Auto-discovered causal graph.** Enable `discovery_method=
+   "correlation"` at the exploration-to-optimization phase transition.
+   First real-data test of `GraphLearner`.
+3. **Full 14M-row run.** If 1M rows produce marginal ESS, scaling to
+   the full dataset increases control-arm count from ~150K to ~2.1M.
+4. **Tunable `min_propensity_clip`.** If IPS variance is the bottleneck,
+   tuning the clip to `[0.05, 0.20]` trades bias for variance reduction.
+5. **Doubly robust estimation.** Adapter extension to combine IPS
+   weighting with an outcome model for variance reduction. This is a
+   Sprint 34+ consideration.
+6. **Wider search space.** Add `min_propensity_clip` as a tuned variable
+   to create a 4-dimensional search, or synthesize additional policy
+   levers from Criteo features.
+
+## 11. References
+
+1. Diemert, E., Betlei, A., Renaudin, C., & Amini, M.-R. (2018). "A Large Scale Benchmark for Uplift Modeling." AdKDD 2018, KDD London.
+2. Diemert, E., Betlei, A., Renaudin, C., & Amini, M.-R. (2021). "A Large Scale Benchmark for Individual Treatment Effect Prediction and Uplift Modeling." arXiv:2111.10106.
+3. [Sprint 31 Hillstrom Lessons Learned](sprint-31-hillstrom-lessons-learned.md)
+4. [Sprint 31 Hillstrom Benchmark Report](sprint-31-hillstrom-benchmark-report.md)
+5. [Sprint 31 Criteo Uplift Access and Adapter-Gap Audit](sprint-31-criteo-uplift-access-and-gap-audit.md)
+6. [Sprint 31 Hillstrom Benchmark Contract](sprint-31-hillstrom-benchmark-contract.md)
+7. [Sprint 31 Generalization Research Plan](../plans/22-sprint-31-generalization-research-plan.md)
+8. [Real-Data Adapter Requirements](../plans/04-real-data-adapter-requirements.md)
+9. [MarketingLogAdapter Documentation](marketing-log-adapter.md)

--- a/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
+++ b/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
@@ -51,9 +51,11 @@ This contract builds on those lessons rather than relitigating them.
 
 ### 1b. Why Criteo Is Not Trivial
 
-1. **85:15 treatment imbalance.** Control observations carry IPS weight
-   `1 / (1 - 0.85) = 6.67`. This is 3.3x higher than Hillstrom's
-   maximum weight of 2.0. The IPS stack will be under real stress.
+1. **85:15 treatment imbalance.** Control-arm observations carry IPS
+   weight `1 / (1 - 0.85) = 6.67` (treated-arm weight is only
+   `1 / 0.85 = 1.18`). The control-arm weight is 3.3x higher than
+   Hillstrom's maximum weight of 2.0. The IPS stack will be under real
+   stress.
 2. **Binary outcomes only.** `visit` (4.70% base rate) and `conversion`
    (0.29%) are both binary. IPS-weighted means of rare binary events
    are noisy. There is no continuous outcome like Hillstrom's `spend`
@@ -238,7 +240,11 @@ pass shows promise.
 
 At B80, each run executes up to 80 adapter calls. Worst-case total
 adapter calls: 150 x 80 = 12,000. At ~1M rows per call with vectorized
-numpy, this should complete within 1-2 hours on a modern machine.
+numpy, per-call latency should be sub-second. For reference, the
+Hillstrom benchmark (240 runs on 42-64K rows) completed in 1,303
+seconds (~22 minutes). Criteo's 150 runs on 1M rows will have higher
+per-call cost but fewer total runs; estimated wall-clock time is 1-3
+hours depending on machine and backend (RF vs Ax/BoTorch).
 
 ## 5. Wrapper Mapping Into MarketingLogAdapter
 
@@ -270,21 +276,19 @@ numpy, this should complete within 1-2 hours on a modern machine.
 
 ### 5d. Segment Column Decision
 
-Criteo has no natural segment column. Three options were considered:
+Criteo has no natural segment column. Two options were considered:
 
 1. **Omit segment entirely.** Adapter assigns all rows
    `segment_score = 0.2`. Uplift scores depend only on channel weight
    and regularization. Less heterogeneity for the optimizer to exploit.
+   Accept reduced heterogeneity and diagnose from results.
 2. **Synthesize from feature quantiles.** Map tertiles of `f0` to
    `"high_value" / "medium" / "low"`. Creates heterogeneity but is
-   arbitrary.
-3. **Defer.** Accept reduced heterogeneity and diagnose from results.
+   arbitrary — it fabricates structure that does not exist in the data.
 
-**Decision: Option 1 (omit segment) for the first run.** Rationale:
-synthesizing a segment from anonymized features would fabricate structure
-that does not exist in the data. If the first run shows all policies
-collapse to the same `policy_value`, the follow-on run should synthesize
-a segment and compare.
+**Decision: Option 1 (omit segment) for the first run.** If the first
+run shows all policies collapse to the same `policy_value`, the follow-on
+run should synthesize a segment and compare.
 
 ### 5e. Features Dropped On First Run
 
@@ -356,10 +360,18 @@ However, the `CriteoLoader` should explicitly add `propensity = 0.85`
 for clarity and provenance.
 
 Risk: if residual propensity heterogeneity remains after v2 rebalancing,
-the constant assumption introduces bias. The first run should monitor
-`weight_cv` and `max_ips_weight` to detect whether IPS weights are
-suspiciously variable despite the constant-propensity assumption. Under
-a true constant propensity of 0.85:
+the constant assumption introduces bias. **Pre-benchmark check
+(mandatory):** before running the 150-experiment benchmark, compute the
+empirical treatment rate by `f0` decile on the 1M subsample. If any
+decile's treatment rate deviates from 0.85 by more than 2 percentage
+points, propensity heterogeneity is present and the constant-propensity
+assumption must be revisited. This check is cheap (one groupby on the
+subsample) and catches the problem before wasting 150 runs.
+
+Additionally, the first run should monitor `weight_cv` and
+`max_ips_weight` per seed to detect whether IPS weights are suspiciously
+variable despite the constant-propensity assumption. Under a true
+constant propensity of 0.85:
 
 - Treated observations: IPS weight = `1 / 0.85 = 1.176`
 - Control observations: IPS weight = `1 / 0.15 = 6.667`
@@ -495,9 +507,12 @@ Permuted-outcome null control, following the Hillstrom discipline:
    a permutation of the same column values, `mu` is identical on `D`
    and `D_null`.
 
-**Failure criterion:** the null control fails if any strategy's mean
-`policy_value` across the 10 null-control seeds exceeds `1.05 * mu` at
-any budget.
+**Failure criterion (symmetric):** the null control fails if any
+strategy's mean `policy_value` across the 10 null-control seeds falls
+outside the interval `[0.95 * mu, 1.05 * mu]` at any budget. The lower
+bound catches strategies that systematically avoid treating high-visit
+users on permuted data, which would also indicate IPS estimation
+problems.
 
 Note: the tolerance is `5%`, wider than Hillstrom's initial `2%`
 threshold. Rationale: `visit` is a binary 0/1 column with a 4.70% base
@@ -508,8 +523,9 @@ tight on right-skewed zero-inflated data. Starting at `5%` on a sparse
 binary outcome avoids a predictable fallback-ladder invocation.
 
 **Pre-committed fallback:** if more than 3 of 10 null-control seeds for
-any strategy exceed `1.05 * mu`:
-  (a) widen to `1.10 * mu` and re-evaluate the same seeds (no new runs);
+any strategy fall outside `[0.95 * mu, 1.05 * mu]`:
+  (a) widen to `[0.90 * mu, 1.10 * mu]` and re-evaluate the same seeds
+  (no new runs);
   (b) if `10%` still fails, the null control fails and blocks the real
   verdict.
 
@@ -524,7 +540,9 @@ All four conditions must hold:
 
 1. Causal `policy_value` at B80 is strictly greater than surrogate_only
    at B80, with `p <= 0.05` under two-sided Mann-Whitney U.
-2. Causal is not statistically worse than random at B80.
+2. Causal is not statistically worse than random at B80 (i.e., the
+   two-sided MWU test of causal vs random does not show random > causal
+   at `p <= 0.05`).
 3. The null control passes.
 4. Median ESS at B80 is >= 100 for all strategies.
 
@@ -632,8 +650,15 @@ The implementation sprint should:
 ### 10c. Prerequisite Before Implementation
 
 The Criteo v2.1 CSV must be downloaded locally. The implementation
-sprint should document the download path and verify the file hash.
-The raw file must not be committed to the repository.
+sprint must:
+
+1. Document the download path used.
+2. Compute and record the SHA-256 hash of the downloaded file in the
+   benchmark report provenance section. (The direct download URL
+   `go.criteo.net/...` is a redirect that Criteo could change; the hash
+   is the authoritative identifier.)
+3. Verify the row count matches the expected 13,979,592.
+4. Not commit the raw file to the repository.
 
 ### 10d. Follow-On Run Candidates (Not In First Implementation)
 

--- a/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
+++ b/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
@@ -86,6 +86,15 @@ on the same data. **Criteo must attempt to run under the Ax/BoTorch
 backend.** If Ax is unavailable, the report must flag this as an open
 confound, exactly as the Hillstrom report did.
 
+**Mixed-backend policy:** if Ax/BoTorch is available but produces
+NaN/inf values or crashes on some seeds, the benchmark must not mix
+backends within a single verdict table. Either all 10 seeds run on Ax,
+or all 10 run on RF fallback. If Ax fails on any seed, rerun all 10
+seeds on RF and report the RF result as the primary verdict. If Ax
+succeeded on all seeds, report Ax as primary and optionally include RF
+as a secondary comparison. Mixed-backend results are not interpretable
+for strategy comparison because the surrogate quality differs.
+
 ### 2b. Null-Control Interpretation Matters
 
 Hillstrom's null-control pass showed that all three strategies can
@@ -385,6 +394,11 @@ problem before wasting 150 runs.
   propensities and add those as the `propensity` column, or
   (b) use a stratified constant propensity (per-decile treatment rate)
   as a coarser fix.
+  If option (a) is chosen, validate the fitted model with a calibration
+  check: compute predicted vs observed treatment rate by decile of
+  predicted propensity on a held-out fold. If any decile deviates by
+  more than 2pp, the model is miscalibrated and option (b) should be
+  used instead.
   Document whichever path is taken in the benchmark report provenance.
 
 Additionally, the first run should monitor `weight_cv` and
@@ -557,9 +571,14 @@ weight CV is ~1.3, giving `ESS_eff ≈ 1M / (1 + 1.69) ≈ 372K`. Per-seed
 SE ≈ `sqrt(0.047 * 0.953 / 372K) ≈ 0.00035`. Across 10 seeds, the SE
 of the mean is `0.00035 / sqrt(10) ≈ 0.00011`. The 5% band
 `±0.00235` is ~21 SEs wide, so the tolerance is conservative for
-well-behaved permuted data. If observed null-control variance is much
-larger than this (e.g., due to policy-search multiple comparisons or
-degenerate corner solutions), the fallback ladder handles it.
+well-behaved permuted data. This SE estimate assumes an always-treat policy (full weight
+distribution). Under policies with lower `treatment_budget_pct` or
+higher `eligibility_threshold`, the effective weight distribution
+changes and variance may increase. The estimate is therefore a
+best-case bound, not a worst-case bound. If observed null-control
+variance is much larger than this (e.g., due to policy-search multiple
+comparisons, degenerate corner solutions, or restrictive policies), the
+fallback ladder handles it.
 
 **Pre-committed fallback:** if more than 3 of 10 null-control seeds for
 any strategy fall outside `[0.95 * mu, 1.05 * mu]`:
@@ -624,6 +643,25 @@ This would mean: the IPS stack is under too much stress at 85:15
 imbalance with binary outcomes. The project should consider: (a) using
 the full 14M rows, (b) implementing doubly robust estimation, (c)
 tuning `min_propensity_clip` to a bias-accepting value.
+
+### 8e. Combined Run 1 + Run 2 Verdict Interpretation
+
+Because the contract requires a mandatory second batch with synthesized
+segments when Run 1 (degenerate surface) shows near-parity (Section 5f),
+the Criteo report may contain two sets of results. The combined verdict
+follows this table:
+
+| Run 1 (degenerate) | Run 2 (heterogeneous) | Combined verdict |
+|---------------------|-----------------------|------------------|
+| Certified causal win | N/A (not required) | **Certified Criteo win** |
+| Near-parity | Certified causal win | **Conditional Criteo win** — causal guidance adds value only when the search surface has structure to exploit |
+| Near-parity | Near-parity | **Criteo near-parity** — causal path does not differentiate on this dataset regardless of heterogeneity |
+| Near-parity | s.o. advantage | **Criteo negative** — synthesized heterogeneity hurts the causal path |
+| s.o. advantage | any | **Criteo s.o. advantage** — Run 1 dominates |
+
+The claim language must always specify which run (degenerate or
+heterogeneous) produced the result. A "conditional Criteo win" is not
+equivalent to a "certified Criteo win" and must not be reported as one.
 
 ## 9. What A Failure Would Mean
 
@@ -696,10 +734,11 @@ The Criteo v2.1 CSV must be downloaded locally. The implementation
 sprint must:
 
 1. Document the download path used.
-2. Compute and record the SHA-256 hash of the downloaded file in the
-   benchmark report provenance section. (The direct download URL
-   `go.criteo.net/...` is a redirect that Criteo could change; the hash
-   is the authoritative identifier.)
+2. Record the file size in bytes and the SHA-256 hash of the downloaded
+   file in the benchmark report provenance section. (The direct download
+   URL `go.criteo.net/...` is a redirect that Criteo could change; the
+   hash is the authoritative identifier. File size is a faster first
+   check that catches truncated downloads.)
 3. Verify the row count matches the expected 13,979,592.
 4. Not commit the raw file to the repository.
 

--- a/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
+++ b/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
@@ -137,7 +137,7 @@ flagged as unreliable.
 
 | Item | Value |
 |------|-------|
-| Official page | Criteo AI Lab |
+| Official page | [Criteo AI Lab](https://ailab.criteo.com/criteo-uplift-prediction-dataset/) |
 | Direct download (v2.1) | `http://go.criteo.net/criteo-research-uplift-v2.1.csv.gz` |
 | Hugging Face mirror | `criteo/criteo-uplift` on Hugging Face Datasets |
 | Reference paper | Diemert et al., "A Large Scale Benchmark for Uplift Modeling", AdKDD 2018, KDD London |
@@ -168,7 +168,7 @@ must be added alongside the fixture. This is stricter than Hillstrom
 | Rows | 13,979,592 |
 | Columns | 16 (12 features `f0`-`f11` + `treatment` + `exposure` + `visit` + `conversion`) |
 | Compressed size | ~297 MB (gzip CSV) |
-| Uncompressed size | ~311 MB |
+| Uncompressed size | ~3.25 GB |
 | In-memory (float64) | ~1.7 GB (full), ~120 MB (1M subsample) |
 
 ### 3d. Local-Data Expectations
@@ -580,12 +580,12 @@ variance is much larger than this (e.g., due to policy-search multiple
 comparisons, degenerate corner solutions, or restrictive policies), the
 fallback ladder handles it.
 
-**Pre-committed fallback:** if more than 3 of 10 null-control seeds for
-any strategy fall outside `[0.95 * mu, 1.05 * mu]`:
-  (a) widen to `[0.90 * mu, 1.10 * mu]` and re-evaluate the same seeds
-  (no new runs);
-  (b) if `10%` still fails, the null control fails and blocks the real
-  verdict.
+**Pre-committed fallback:** if the primary mean-based criterion fails
+(any strategy's mean falls outside `[0.95 * mu, 1.05 * mu]`):
+  (a) widen the band to `[0.90 * mu, 1.10 * mu]` and re-evaluate the
+  same strategy means (no new runs);
+  (b) if the mean still falls outside the widened `10%` band, the null
+  control fails and blocks the real verdict.
 
 If the null control fails, the implementation sprint must stop and
 diagnose before reporting any real-data verdict.

--- a/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
+++ b/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
@@ -235,7 +235,7 @@ pass shows promise.
 | Component | Count |
 |-----------|-------|
 | Real benchmark: 3 strategies x 3 budgets x 10 seeds | 90 runs |
-| Null control: 3 strategies x 2 budgets x 10 seeds | 60 runs |
+| Null control: 3 strategies x 2 budgets x 10 seeds (B80 excluded — see Section 7d) | 60 runs |
 | **Total** | **150 runs** |
 
 At B80, each run executes up to 80 adapter calls. Worst-case total
@@ -243,8 +243,9 @@ adapter calls: 150 x 80 = 12,000. At ~1M rows per call with vectorized
 numpy, per-call latency should be sub-second. For reference, the
 Hillstrom benchmark (240 runs on 42-64K rows) completed in 1,303
 seconds (~22 minutes). Criteo's 150 runs on 1M rows will have higher
-per-call cost but fewer total runs; estimated wall-clock time is 1-3
-hours depending on machine and backend (RF vs Ax/BoTorch).
+per-call cost (~15-24x more data) but fewer total runs (150 vs 240).
+Estimated wall-clock time: ~1 hour under the RF backend, ~2-3 hours
+under Ax/BoTorch (which adds per-step GP fitting overhead).
 
 ## 5. Wrapper Mapping Into MarketingLogAdapter
 
@@ -326,9 +327,19 @@ IPS weighting at 85:15 imbalance.
 The consequence is explicit: the first Criteo run tests whether the
 engine's phase transitions, surrogate modeling, and screening add value
 on a degenerate surface under heavy IPS variance. It does not test
-whether causal graph focus helps on a heterogeneous surface. That test
-requires a follow-on run with a synthesized segment or a wider search
-space.
+whether causal graph focus helps on a heterogeneous surface. A
+near-parity result on the degenerate surface is therefore expected and
+not informative about the causal path's value in general.
+
+**Mandatory second batch:** if the first run shows near-parity (all
+strategies converge to the same corner), the implementation sprint must
+also run a second batch with a synthesized segment column (tertiles of
+`f0` mapped to `"high_value" / "medium" / "low"`) before publishing the
+Criteo report. This is not a follow-on recommendation — it is a
+contract requirement. The degenerate-surface run establishes the
+baseline; the heterogeneous-surface run tests whether the causal path
+can exploit the additional structure. Both results are needed for an
+interpretable verdict.
 
 ## 6. Search-Space And Propensity Decisions
 
@@ -360,26 +371,40 @@ However, the `CriteoLoader` should explicitly add `propensity = 0.85`
 for clarity and provenance.
 
 Risk: if residual propensity heterogeneity remains after v2 rebalancing,
-the constant assumption introduces bias. **Pre-benchmark check
-(mandatory):** before running the 150-experiment benchmark, compute the
-empirical treatment rate by `f0` decile on the 1M subsample. If any
-decile's treatment rate deviates from 0.85 by more than 2 percentage
-points, propensity heterogeneity is present and the constant-propensity
-assumption must be revisited. This check is cheap (one groupby on the
-subsample) and catches the problem before wasting 150 runs.
+the constant assumption introduces bias. **Pre-benchmark gate
+(mandatory, hard stop):** before running the 150-experiment benchmark,
+compute the empirical treatment rate by `f0` decile on the 1M subsample.
+This check is cheap (one groupby on the subsample) and catches the
+problem before wasting 150 runs.
+
+- **Pass:** all deciles have treatment rate within 2 percentage points
+  of 0.85. Proceed with constant propensity.
+- **Fail:** any decile deviates by more than 2 percentage points. The
+  benchmark does not proceed. The implementation sprint must either:
+  (a) fit a logistic regression on `f0`-`f11` to estimate per-row
+  propensities and add those as the `propensity` column, or
+  (b) use a stratified constant propensity (per-decile treatment rate)
+  as a coarser fix.
+  Document whichever path is taken in the benchmark report provenance.
 
 Additionally, the first run should monitor `weight_cv` and
 `max_ips_weight` per seed to detect whether IPS weights are suspiciously
 variable despite the constant-propensity assumption. Under a true
 constant propensity of 0.85:
 
-- Treated observations: IPS weight = `1 / 0.85 = 1.176`
-- Control observations: IPS weight = `1 / 0.15 = 6.667`
+- Treated observations: raw IPS weight = `1 / 0.85 = 1.176`
+- Control observations: raw IPS weight = `1 / 0.15 = 6.667`
 
-Expected `weight_cv` under constant propensity and uniform policy
-assignment: calculable from the 85:15 mix. If observed `weight_cv`
-exceeds this expected value substantially, propensity heterogeneity may
-be present.
+Note: the `MarketingLogAdapter` uses **self-normalized IPS** (weights
+are rescaled so they sum to `N`; see `marketing_logs.py` line 322). The
+`max_ips_weight` and `weight_cv` diagnostics report **raw** (pre-
+normalization) weights. The diagnostic thresholds in Section 7a
+(`max_ips_weight > 20`, `weight_cv > 3.0`) are calibrated against raw
+weights. Under constant propensity with an always-treat policy, the
+expected raw `max_ips_weight` is 6.667 and the expected `weight_cv` is
+~1.3 (from the 85:15 weight mix). If observed values substantially
+exceed these, propensity heterogeneity or policy-induced weight
+concentration may be present.
 
 ### 6c. min_propensity_clip Decision
 
@@ -519,8 +544,22 @@ threshold. Rationale: `visit` is a binary 0/1 column with a 4.70% base
 rate. IPS-weighted means of sparse binary outcomes on permuted data are
 inherently noisier than IPS-weighted means of continuous `spend`. The
 Hillstrom null control already showed that the `2%` threshold can be
-tight on right-skewed zero-inflated data. Starting at `5%` on a sparse
-binary outcome avoids a predictable fallback-ladder invocation.
+tight on right-skewed zero-inflated data.
+
+**Back-of-envelope SE justification:** under permuted data with constant
+propensity 0.85, the self-normalized IPS-weighted mean of a binary
+outcome has approximate standard error
+`SE ≈ sqrt(p * (1-p) / ESS_eff)` where `p ≈ 0.047` and `ESS_eff` is
+the effective sample size under the IPS weights. On 1M rows with 85:15
+imbalance, the raw ESS from Kish's formula is approximately
+`N / (1 + CV^2_w)`. With 85% of weights at 1.176 and 15% at 6.667, the
+weight CV is ~1.3, giving `ESS_eff ≈ 1M / (1 + 1.69) ≈ 372K`. Per-seed
+SE ≈ `sqrt(0.047 * 0.953 / 372K) ≈ 0.00035`. Across 10 seeds, the SE
+of the mean is `0.00035 / sqrt(10) ≈ 0.00011`. The 5% band
+`±0.00235` is ~21 SEs wide, so the tolerance is conservative for
+well-behaved permuted data. If observed null-control variance is much
+larger than this (e.g., due to policy-search multiple comparisons or
+degenerate corner solutions), the fallback ladder handles it.
 
 **Pre-committed fallback:** if more than 3 of 10 null-control seeds for
 any strategy fall outside `[0.95 * mu, 1.05 * mu]`:
@@ -632,6 +671,10 @@ The implementation sprint should:
    - generates the permuted-outcome null control frame
 
 2. Commit a 3,000-row CI fixture with `LICENSE-CRITEO` attribution.
+   Include a unit test that validates
+   `abs(fixture['treatment'].mean() - 0.85) < 0.03` to prevent a
+   stratified-sampling bug from silently producing a fixture with the
+   wrong treatment ratio.
 
 3. Write a benchmark script modeled on `scripts/hillstrom_benchmark.py`.
 

--- a/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
+++ b/thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
@@ -107,13 +107,15 @@ treatment-effect evidence."
 
 ### 2c. Narrow Search Spaces Can Blunt Graph Value
 
-Hillstrom's 3-variable active search space is much narrower than the
-energy benchmarks where causal guidance had the clearest wins. The causal
-graph may have more leverage when the search problem contains more
-irrelevant or weakly relevant directions. **Criteo's first run uses the
-same 3-variable active space as Hillstrom** (for comparability), but a
-follow-on run should consider widening the search space if the first run
-shows near-parity.
+Hillstrom's nominal 3-variable active search space is much narrower than
+the energy benchmarks where causal guidance had the clearest wins (and
+one of those three — `regularization` — is inert under the current
+adapter math; see Section 6e). The causal graph may have more leverage
+when the search problem contains more irrelevant or weakly relevant
+directions. **Criteo's first run uses a 2-variable active space**
+(`eligibility_threshold`, `treatment_budget_pct`), which is even
+narrower. A follow-on run should consider widening the search space if
+the first run shows near-parity.
 
 ### 2d. A Wrapper That Runs Is Not A Benchmark That Proves Generality
 
@@ -289,8 +291,8 @@ under Ax/BoTorch (which adds per-step GP fitting overhead).
 Criteo has no natural segment column. Two options were considered:
 
 1. **Omit segment entirely.** Adapter assigns all rows
-   `segment_score = 0.2`. Uplift scores depend only on channel weight
-   and regularization. Less heterogeneity for the optimizer to exploit.
+   `segment_score = 0.2`. Uplift scores collapse to uniform after
+   normalization. Less heterogeneity for the optimizer to exploit.
    Accept reduced heterogeneity and diagnose from results.
 2. **Synthesize from feature quantiles.** Map tertiles of `f0` to
    `"high_value" / "medium" / "low"`. Creates heterogeneity but is
@@ -318,14 +320,15 @@ computation simplifies:
 - `channel_weight` = constant (all rows get `email_share + 0.1`)
 - `segment_score` = constant (all rows get `0.2`)
 - `raw_score` = constant for all rows
-- After regularization and normalization, `uplift_score` = `0.5` for
-  all rows (uniform)
+- After normalization, `uplift_score` = `0.5` for all rows (uniform;
+  `regularization` is inert — see Section 6e)
 
-This means `eligibility_threshold` becomes the sole policy lever that
-varies treatment assignment across observations. When
-`eligibility_threshold < 0.5`, all rows are eligible; when
-`eligibility_threshold > 0.5`, no rows are eligible. The optimizer
-searches a step-function response surface.
+This means the two active variables have distinct roles:
+`eligibility_threshold` is a step function (below 0.5, all rows are
+eligible; above 0.5, none are), and `treatment_budget_pct` controls
+what fraction of eligible rows are treated. The optimizer searches a
+surface that is piecewise-constant in `eligibility_threshold` and
+smooth in `treatment_budget_pct` within the eligible region.
 
 **This is a known limitation of the first run.** It mirrors the
 Hillstrom behavior where the optimal corner (`eligibility_threshold=0.0`,
@@ -333,12 +336,13 @@ Hillstrom behavior where the optimal corner (`eligibility_threshold=0.0`,
 discover the same corner if the treat-everyone policy is optimal under
 IPS weighting at 85:15 imbalance.
 
-The consequence is explicit: the first Criteo run tests whether the
-engine's phase transitions, surrogate modeling, and screening add value
-on a degenerate surface under heavy IPS variance. It does not test
-whether causal graph focus helps on a heterogeneous surface. A
-near-parity result on the degenerate surface is therefore expected and
-not informative about the causal path's value in general.
+The consequence is explicit: with only 2 active variables on a
+degenerate surface, the first Criteo run tests whether the engine's
+phase transitions and surrogate modeling add value under heavy IPS
+variance. The 5-edge projected graph has limited scope to demonstrate
+causal focus value. A near-parity result on the degenerate surface is
+therefore expected and not informative about the causal path's value
+in general.
 
 **Mandatory second batch:** if the first run shows near-parity (all
 strategies converge to the same corner), the implementation sprint must
@@ -360,12 +364,13 @@ interpretable verdict.
 | `email_share` | **Fixed at `1.0`** | degenerate (single channel) |
 | `social_share_of_remainder` | **Fixed at `0.0`** | degenerate (single channel) |
 | `min_propensity_clip` | **Fixed at `0.01`** | see Section 6c |
-| `regularization` | **Tuned** | [0.001, 10.0] |
+| `regularization` | **Fixed at `1.0`** | inert under current adapter (see Section 6e) |
 | `treatment_budget_pct` | **Tuned** | [0.1, 1.0] |
 
-Effective active search space: **3 tuned continuous variables**
-(`eligibility_threshold`, `regularization`, `treatment_budget_pct`).
-Same dimensionality as Hillstrom, for direct comparability.
+Effective active search space: **2 tuned continuous variables**
+(`eligibility_threshold`, `treatment_budget_pct`). This is narrower
+than Hillstrom's nominal 3-variable space because `regularization` is
+inert under the current adapter math (see Section 6e).
 
 ### 6b. Propensity Decision
 
@@ -449,23 +454,23 @@ fixing it at a higher value (e.g., `0.10`).
 ### 6d. Prior Causal Graph
 
 The Hillstrom contract projected the full 14-edge adapter graph to a
-7-edge subgraph over active variables. The same projection applies on
-Criteo:
+7-edge subgraph over active variables. Criteo projects further because
+`regularization` is also frozen (inert, see Section 6e), yielding a
+**5-edge** subgraph:
 
 ```text
 eligibility_threshold  --> treated_fraction
 treatment_budget_pct   --> treated_fraction
-regularization         --> treated_fraction
-regularization         --> policy_value
 treated_fraction       --> total_cost
 treated_fraction       --> policy_value
 treated_fraction       --> effective_sample_size
 ```
 
-Dropped edges (7 total): `email_share -> {total_cost, policy_value}`,
+Dropped edges (9 total): `email_share -> {total_cost, policy_value}`,
 `social_share_of_remainder -> {total_cost, policy_value}`,
 `min_propensity_clip -> {total_cost, policy_value,
-effective_sample_size}`.
+effective_sample_size}`, `regularization -> {treated_fraction,
+policy_value}`.
 
 **Alternative: empty graph + auto-discovery.** Because Criteo features
 are anonymized, no domain-knowledge prior graph over features is
@@ -475,9 +480,53 @@ run could test `discovery_method="correlation"` at the exploration-to-
 optimization phase transition to learn a data-driven graph. This would
 be the first real-data test of the `GraphLearner` pathway.
 
-**Decision for first run:** use the projected 7-edge policy-variable
-graph, same as Hillstrom. This preserves comparability. Document the
-auto-discovery alternative as a follow-on recommendation.
+**Decision for first run:** use the projected 5-edge policy-variable
+graph. Document the auto-discovery alternative as a follow-on
+recommendation.
+
+### 6e. Regularization Is Inert Under The Current Adapter
+
+The `MarketingLogAdapter` computes uplift scores as:
+
+```
+raw_score = channel_weight * segment_score
+reg_factor = 1.0 / (1.0 + regularization)
+uplift_score = reg_factor * raw_score + (1 - reg_factor) * mean(raw_score)
+```
+
+It then applies min/max normalization to `[0, 1]`:
+
+```
+uplift_score = (uplift_score - min) / (max - min)
+```
+
+The regularization step is a positive affine transform of `raw_score`:
+`a * raw_score + b` where `a = reg_factor` and
+`b = (1 - reg_factor) * mean(raw_score)`. Min/max normalization of a
+positive affine transform produces the same normalized ranking
+regardless of `a` and `b`:
+
+```
+(a*x + b - (a*min + b)) / (a*max + b - (a*min + b))
+  = a*(x - min) / (a*(max - min))
+  = (x - min) / (max - min)
+```
+
+The `reg_factor` cancels algebraically. When `raw_score` is constant
+(the Run 1 degenerate case), the adapter falls back to
+`uplift_score = 0.5` for all rows, which is also independent of
+`regularization`.
+
+**Consequence:** `regularization` has no effect on `policy_value`,
+`treated_fraction`, or any other metric under the current adapter math.
+It is frozen at `1.0` (the adapter default) and excluded from the
+active search space.
+
+**Note:** this finding retroactively applies to the Hillstrom benchmark
+(Sprint 31), where `regularization` was nominally tuned but was
+similarly inert after normalization. The Hillstrom benchmark report
+should be annotated in a follow-on PR. For Criteo, the contract
+reflects the corrected understanding.
 
 ## 7. Diagnostics And Null-Control Requirements
 
@@ -526,7 +575,7 @@ The benchmark report must record:
 7. Fixed parameter values (`email_share=1.0`,
    `social_share_of_remainder=0.0`, `min_propensity_clip=0.01`,
    `cost=0.01/0.0`, `propensity=0.85`)
-8. Projected prior graph (7 edges)
+8. Projected prior graph (5 edges)
 9. Diemert et al. 2018 citation
 
 ### 7d. Null Control
@@ -760,8 +809,16 @@ If the first run shows near-parity or IPS variance issues:
    weighting with an outcome model for variance reduction. This is a
    Sprint 34+ consideration.
 6. **Wider search space.** Add `min_propensity_clip` as a tuned variable
-   to create a 4-dimensional search, or synthesize additional policy
+   to create a 3-dimensional search, or synthesize additional policy
    levers from Criteo features.
+7. **Fix `regularization` in the adapter.** The current
+   `MarketingLogAdapter` applies regularization before min/max
+   normalization, which algebraically cancels the regularization effect
+   (see Section 6e). A future adapter fix could either (a) apply
+   regularization after normalization, or (b) replace the affine
+   smoothing with a nonlinear shrinkage that survives normalization.
+   This would make `regularization` a true active variable and widen the
+   effective search space on all marketing benchmarks retroactively.
 
 ## 11. References
 


### PR DESCRIPTION
## Summary

- Define the first executable Criteo Uplift benchmark contract for the project's second marketing benchmark
- Primary outcome: `visit` (4.70% base rate); secondary: `conversion` (reported, not optimized)
- 1M-row fixed-seed subsample, CriteoLoader wrapper over existing `MarketingLogAdapter` (no adapter code changes)
- 3 tuned variables (`eligibility_threshold`, `regularization`, `treatment_budget_pct`), same as Hillstrom for comparability
- IPS-variance diagnostics (ESS, max weight, weight CV) with explicit thresholds for flagging unreliable cells
- Permuted-outcome null control with 5% tolerance (wider than Hillstrom's 2% due to sparse binary outcome)
- Explicit pass/fail criteria and follow-on recommendations for the implementation sprint
- Builds directly on Sprint 31 Hillstrom lessons: backend sensitivity, null-control discipline, degenerate search surface consequences

Resolves #177.

## Test plan

- [x] No source code changes — docs-only PR
- [x] Lint: `uv run ruff check .` passes
- [x] Format: `uv run ruff format --check .` passes
- [x] Unit tests: 1077 passed, 12 skipped
- [x] Type check: mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the Sprint 32 Criteo Uplift benchmark contract — a docs-only planning document that pins dataset provenance, column mapping, search-space decisions, IPS diagnostics, null-control protocol, and pass/fail criteria for the implementation sprint. No source code is changed.

- **P1 (Section 3c):** The stated uncompressed CSV size (~311 MB) is ~10× lower than the actual value (~3.25 GB per the Kaggle-hosted file); the compressed size (~297 MB) and in-memory float64 size (~1.7 GB) are both correct. An engineer planning disk space from this spec will severely underallocate.
- **P2 (Section 7d):** The primary failure criterion and the pre-committed fallback use different aggregation units (mean-across-seeds vs. count-of-seeds-exceeding-threshold), which can produce conflicting signals; the fallback phrase \"if `10%` still fails\" is additionally ambiguous.

<h3>Confidence Score: 4/5</h3>

Safe to merge after correcting the uncompressed file size; remaining finding is P2 documentation ambiguity.

One P1 factual error: the uncompressed CSV size is stated as ~311 MB when the actual value is ~3.25 GB. This is a docs-only PR, so it cannot break code, but the wrong size will mislead engineers planning storage in the implementation sprint. All other math, IPS weight calculations, row counts, strategy/budget/seed arithmetic, and column mappings check out correctly.

thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md — Section 3c (uncompressed size) and Section 7d (null-control protocol).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md | New 669-line benchmark contract for the Criteo Uplift run; one P1 factual error (uncompressed file size ~311 MB vs actual ~3.25 GB) and one P2 ambiguity in the null-control failure/fallback protocol. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CriteoLoader] -->|1M-row fixed-seed subsample| B[MarketingLogAdapter]
    A -->|permuted visit column| C[Null Control Frame D_null]
    B --> D{Benchmark Runner\n3 strategies × 3 budgets × 10 seeds}
    C --> E{Null Control Runner\n3 strategies × 2 budgets × 10 seeds}
    D --> F[policy_value / ESS / weight_cv\nper seed]
    E --> G[null policy_value per seed]
    F --> H{Aggregate Diagnostics\nMWU p-value, Cohen d}
    G --> I{Null Control Check\nmean ≤ 1.05·mu?}
    I -->|Pass| H
    I -->|Fail: >3 seeds exceed threshold| J[Fallback: widen to 1.10·mu]
    J -->|Still fails| K[Block verdict]
    J -->|Pass| H
    H --> L{Verdict\ncertified / trending / near-parity / IPS failure}
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Athoughts%2Fshared%2Fdocs%2Fsprint-32-criteo-benchmark-contract.md%3A160%0A**Uncompressed%20file%20size%20is%2010%C3%97%20off**%0A%0AThe%20stated%20uncompressed%20CSV%20size%20%28~311%20MB%29%20is%20near-identical%20to%20the%20compressed%20size%20%28~297%20MB%29%2C%20implying%20essentially%20no%20compression%20%E2%80%94%20which%20is%20impossible%20for%20a%20gzip%20CSV.%20Kaggle's%20hosted%20copy%20lists%20the%20uncompressed%20file%20at%20**3.25%20GB**%2C%20consistent%20with%20the%20separately-correct%20in-memory%20figure%20%28~1.7%20GB%20as%20float64%29.%20An%20engineer%20provisioning%20disk%20space%20for%20this%20dataset%20would%20underallocate%20by%20roughly%2010%C3%97.%0A%0A%60%60%60suggestion%0A%7C%20Uncompressed%20size%20%7C%20~3.25%20GB%20%7C%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Athoughts%2Fshared%2Fdocs%2Fsprint-32-criteo-benchmark-contract.md%3A504-521%0A**Null-control%20failure%20criterion%20and%20fallback%20use%20different%20aggregation%20units**%0A%0AThe%20primary%20failure%20criterion%20is%20mean-based%20%28%22any%20strategy's%20**mean**%20%60policy_value%60%20%E2%80%A6%20exceeds%20%601.05%20*%20mu%60%22%29%2C%20but%20the%20Pre-committed%20fallback%20is%20triggered%20by%20an%20individual-seed%20count%20%28%22more%20than%20**3%20of%2010**%20seeds%20exceed%20%601.05%20*%20mu%60%22%29.%20These%20are%20logically%20independent%20%E2%80%94%20it%20is%20possible%20for%204%20seeds%20to%20individually%20exceed%20the%20threshold%20while%20the%20mean%20stays%20below%20it%20%28e.g.%2C%204%20seeds%20at%20%601.06%20*%20mu%60%2C%206%20at%20%600.80%20*%20mu%60%20%E2%86%92%20mean%20%E2%89%88%20%600.90%20*%20mu%20%3C%201.05%20*%20mu%60%29%2C%20causing%20the%20fallback%20to%20fire%20without%20triggering%20the%20primary%20failure.%20The%20fallback%20phrase%20%22if%20%6010%25%60%20still%20fails%22%20is%20also%20ambiguous%20%2810%25%20of%20seeds%3F%20the%201.10%C3%97mu%20threshold%3F%29.%20Consider%20aligning%20both%20conditions%20on%20the%20same%20unit%20%28e.g.%2C%20mean%29%20or%20explicitly%20stating%20the%20priority%20order%3A%20primary%20mean-test%20%E2%86%92%20fallback%20seed-count%20check.%0A%0A%23%23%23%20Issue%203%20of%203%0Athoughts%2Fshared%2Fdocs%2Fsprint-32-criteo-benchmark-contract.md%3A133-139%0A**Official%20page%20entry%20missing%20URL**%0A%0AThe%20%22Official%20page%22%20row%20lists%20%22Criteo%20AI%20Lab%22%20as%20the%20value%20but%20gives%20no%20navigable%20URL.%20Every%20other%20row%20in%20this%20table%20has%20a%20concrete%20value%20an%20engineer%20can%20act%20on.%20Adding%20the%20URL%20ensures%20the%20implementation%20sprint%20has%20an%20unambiguous%20canonical%20source%20to%20verify%20the%20dataset%20and%20check%20for%20updates.%0A%0A%60%60%60suggestion%0A%7C%20Official%20page%20%7C%20%5BCriteo%20AI%20Lab%5D%28https%3A%2F%2Failab.criteo.com%2Fcriteo-uplift-prediction-dataset%2F%29%20%7C%0A%60%60%60%0A%0A&repo=datablogin%2Fcausal-optimizer"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
Line: 160

Comment:
**Uncompressed file size is 10× off**

The stated uncompressed CSV size (~311 MB) is near-identical to the compressed size (~297 MB), implying essentially no compression — which is impossible for a gzip CSV. Kaggle's hosted copy lists the uncompressed file at **3.25 GB**, consistent with the separately-correct in-memory figure (~1.7 GB as float64). An engineer provisioning disk space for this dataset would underallocate by roughly 10×.

```suggestion
| Uncompressed size | ~3.25 GB |
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
Line: 504-521

Comment:
**Null-control failure criterion and fallback use different aggregation units**

The primary failure criterion is mean-based ("any strategy's **mean** `policy_value` … exceeds `1.05 * mu`"), but the Pre-committed fallback is triggered by an individual-seed count ("more than **3 of 10** seeds exceed `1.05 * mu`"). These are logically independent — it is possible for 4 seeds to individually exceed the threshold while the mean stays below it (e.g., 4 seeds at `1.06 * mu`, 6 at `0.80 * mu` → mean ≈ `0.90 * mu < 1.05 * mu`), causing the fallback to fire without triggering the primary failure. The fallback phrase "if `10%` still fails" is also ambiguous (10% of seeds? the 1.10×mu threshold?). Consider aligning both conditions on the same unit (e.g., mean) or explicitly stating the priority order: primary mean-test → fallback seed-count check.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: thoughts/shared/docs/sprint-32-criteo-benchmark-contract.md
Line: 133-139

Comment:
**Official page entry missing URL**

The "Official page" row lists "Criteo AI Lab" as the value but gives no navigable URL. Every other row in this table has a concrete value an engineer can act on. Adding the URL ensures the implementation sprint has an unambiguous canonical source to verify the dataset and check for updates.

```suggestion
| Official page | [Criteo AI Lab](https://ailab.criteo.com/criteo-uplift-prediction-dataset/) |
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["address claude review feedback (claudelo..."](https://github.com/datablogin/causal-optimizer/commit/86e832d33581b737c1515405319cc4498c04497d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28707997)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->