### PR TITLE
Sprint 35.A: Open Bandit DomainAdapter and Men/Random smoke test

### DIFF
--- a/causal_optimizer/domain_adapters/__init__.py
+++ b/causal_optimizer/domain_adapters/__init__.py
@@ -1,5 +1,6 @@
 """Domain adapters — plug in different experiment domains."""
 
+from causal_optimizer.domain_adapters.bandit_log import BanditLogAdapter
 from causal_optimizer.domain_adapters.base import DomainAdapter
 from causal_optimizer.domain_adapters.energy_load import EnergyLoadAdapter
 from causal_optimizer.domain_adapters.marketing import MarketingAdapter
@@ -7,6 +8,7 @@ from causal_optimizer.domain_adapters.marketing_logs import MarketingLogAdapter
 from causal_optimizer.domain_adapters.ml_training import MLTrainingAdapter
 
 __all__ = [
+    "BanditLogAdapter",
     "DomainAdapter",
     "EnergyLoadAdapter",
     "MarketingAdapter",

--- a/causal_optimizer/domain_adapters/bandit_log.py
+++ b/causal_optimizer/domain_adapters/bandit_log.py
@@ -563,3 +563,15 @@ class BanditLogAdapter(DomainAdapter):
                 f"bandit_feedback['action'] values must be in [0, {n_actions}); "
                 f"found range [{int(action.min())}, {int(action.max())}]"
             )
+
+        # The adapter only interprets ``position == 0`` as "position 1"
+        # (mirroring OBP's ``rankdata`` convention). Negative position
+        # values would silently distort the ``position_1_only`` subset
+        # without raising, so reject them at construction.
+        position = np.asarray(bandit_feedback["position"])
+        if position.min() < 0:
+            raise ValueError(
+                "bandit_feedback['position'] values must be non-negative; "
+                f"found min={int(position.min())}. OBP stores positions "
+                "as 0-indexed integers after ``rankdata(..., 'dense')``."
+            )

--- a/causal_optimizer/domain_adapters/bandit_log.py
+++ b/causal_optimizer/domain_adapters/bandit_log.py
@@ -1,0 +1,523 @@
+"""Open Bandit ``DomainAdapter`` for logged multi-action policy data.
+
+Implements the Sprint 34 Open Bandit contract (Sections 4 and 8) for the
+ZOZOTOWN Men / uniform-random slice. Parameterizes a contextual
+item-scoring policy in a six-variable search space (``tau`` softmax
+temperature, ``eps`` exploration epsilon, three context-feature weights,
+a ``position_handling_flag``) and evaluates it against a logged
+bandit-feedback dict with a minimal in-house SNIPW-style estimator.
+
+**Track A scope.** This adapter ships the Section 4 interface surface
+and a narrow first-pass SNIPW-style ``policy_value`` calculation so the
+adapter is reviewable end-to-end without blocking on the OPE stack.
+Track B (Sprint 35.B, issue #186) owns the production OPE stack:
+the OBP-backed SNIPW / DM / DR estimators, the Section 7 support gates,
+and the cross-estimator cross-check.
+
+Sprint 35.A smoke-test findings (Sprint 34 contract Section 10.A)
+-----------------------------------------------------------------
+
+1. **Row count.** The ``obp==0.4.1`` wheel bundles a 10,000-row sample
+   of the Men/Random slice at
+   ``site-packages/obp/dataset/obd/random/men/men.csv``. The full
+   ~452,949-row slice from Saito et al. 2021 Table 1 must be loaded
+   separately by passing ``data_path=`` to :meth:`from_obp`; Issue C
+   will exercise that path, Issue A's smoke test pins only the bundled
+   sample.
+
+2. **``action_prob`` / ``pscore`` schema.** Confirmed as **conditional
+   ``P(item | position)``**. The empirical mean of
+   ``propensity_score`` on the bundled slice is ``0.0294117...``, which
+   matches ``1/n_items = 1/34`` to floating-point precision. It does
+   not match joint ``P(item, position) = 1/(n_items * n_positions) =
+   1/102 ≈ 0.0098``. All three positions report the same constant
+   propensity, consistent with the conditional interpretation under
+   uniform-random logging. Section 7d's propensity-mean sanity gate
+   should therefore use the ``1/n_items`` target on Men/Random.
+
+3. **Chosen context features (three).** The adapter's search space
+   pins three context-feature weights:
+
+   - ``w_item_feature_0`` — multiplies the per-item continuous
+     ``item_feature_0`` column from ``item_context.csv``
+     (range ≈ ``[-0.73, 0.75]`` on Men/Random).
+   - ``w_user_item_affinity`` — multiplies the per-row, per-candidate
+     ``user-item_affinity_<k>`` lookup (34 columns, one per item id).
+   - ``w_item_popularity`` — multiplies the per-item log-normalized
+     in-log appearance count, pre-computed at adapter construction
+     from ``bandit_feedback["action"]`` so the score is deterministic
+     across policy evaluations.
+
+   Rationale: these three features are the minimum honest subset that
+   (i) exposes per-item continuous signal, (ii) exposes per-(row, item)
+   heterogeneity, and (iii) anchors to an empirical popularity prior
+   without blowing up the search dimensionality. Each weight has a
+   continuous bound of ``[-3.0, 3.0]``.
+
+Public interface
+----------------
+
+:class:`BanditLogAdapter` takes a pre-materialized OBP-style
+bandit-feedback dict directly (the common case for unit tests and
+downstream OPE harnesses). Use :meth:`BanditLogAdapter.from_obp` to
+load the Men/Random slice through OBP; this path requires the optional
+``bandit`` extra (``uv sync --extra bandit``) and fails fast with an
+actionable error if ``obp`` is missing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from causal_optimizer.domain_adapters.base import DomainAdapter
+from causal_optimizer.types import SearchSpace, Variable, VariableType
+
+if TYPE_CHECKING:
+    from causal_optimizer.types import CausalGraph
+
+__all__ = ["BanditLogAdapter"]
+
+
+# ── Constants ────────────────────────────────────────────────────────
+
+_REQUIRED_FEEDBACK_KEYS: frozenset[str] = frozenset(
+    {
+        "n_rounds",
+        "n_actions",
+        "action",
+        "position",
+        "reward",
+        "pscore",
+        "context",
+        "action_context",
+    }
+)
+
+_CONTEXT_WEIGHT_NAMES: tuple[str, ...] = (
+    "w_item_feature_0",
+    "w_user_item_affinity",
+    "w_item_popularity",
+)
+
+_POSITION_HANDLING_CHOICES: tuple[str, ...] = ("marginalize", "position_1_only")
+
+# Search-space bounds — see Sprint 34 contract Section 4c.
+_TAU_LOWER: float = 0.1
+_TAU_UPPER: float = 10.0
+_EPS_LOWER: float = 0.0
+_EPS_UPPER: float = 0.5
+_WEIGHT_LOWER: float = -3.0
+_WEIGHT_UPPER: float = 3.0
+
+# Effective-action mass threshold: n_effective_actions is the smallest
+# k such that the top-k actions' combined policy mass exceeds this
+# threshold. Pinned at 0.95 per Sprint 34 contract Section 4d.
+_EFFECTIVE_ACTIONS_MASS_THRESHOLD: float = 0.95
+
+# Minimum tau used inside the softmax. If a caller passes ``tau=0`` (or
+# numerically close) the adapter floors the temperature to keep the
+# softmax numerically stable; the search space bounds already forbid
+# zero, this is a defence against numerical edge cases inside the
+# optimizer.
+_TAU_FLOOR: float = 1e-6
+
+
+# ── Adapter ──────────────────────────────────────────────────────────
+
+
+class BanditLogAdapter(DomainAdapter):
+    """``DomainAdapter`` for logged multi-action bandit-feedback data.
+
+    Parameters
+    ----------
+    bandit_feedback:
+        OBP-shaped ``dict`` with the keys ``n_rounds``, ``n_actions``,
+        ``action``, ``position``, ``reward``, ``pscore``, ``context``,
+        and ``action_context``. Use :meth:`from_obp` to build this
+        dict from OBP's ``OpenBanditDataset``; pass one directly in
+        unit tests and when consuming a pre-cached slice.
+    seed:
+        Reproducibility seed. Accepted for API consistency with
+        other adapters — evaluation is fully deterministic given
+        the bandit-feedback dict and parameters, so this value is
+        forwarded to :class:`numpy.random.Generator` only if future
+        stochastic diagnostics are added.
+
+    Notes
+    -----
+    Sprint 34 contract Section 4a forbids subclassing
+    ``MarketingLogAdapter``. This class inherits directly from
+    :class:`DomainAdapter` and exposes the Section 4d diagnostic dict
+    (``policy_value``, ``ess``, ``weight_cv``, ``max_weight``,
+    ``zero_support_fraction``, ``n_effective_actions``).
+    """
+
+    def __init__(
+        self,
+        *,
+        bandit_feedback: dict[str, Any],
+        seed: int | None = None,
+    ) -> None:
+        self._validate_feedback(bandit_feedback)
+        self._seed = seed
+
+        self._n_rounds: int = int(bandit_feedback["n_rounds"])
+        self._n_actions: int = int(bandit_feedback["n_actions"])
+        self._action: np.ndarray = np.asarray(bandit_feedback["action"], dtype=np.int64)
+        self._position: np.ndarray = np.asarray(bandit_feedback["position"], dtype=np.int64)
+        self._reward: np.ndarray = np.asarray(bandit_feedback["reward"], dtype=np.int64)
+        self._pscore: np.ndarray = np.asarray(bandit_feedback["pscore"], dtype=float)
+        self._context: np.ndarray = np.asarray(bandit_feedback["context"], dtype=float)
+        self._action_context: np.ndarray = np.asarray(
+            bandit_feedback["action_context"], dtype=float
+        )
+
+        # Pre-compute per-item score components once. These are
+        # independent of the policy parameters, so hoisting them out of
+        # run_experiment keeps the optimizer loop cheap.
+        self._item_feature_0: np.ndarray = self._action_context[:, 0].astype(float)
+
+        # Per-row, per-candidate affinity matrix. The raw log's
+        # ``user-item_affinity_<k>`` columns are per-row lookups for
+        # candidate item k; ``context`` is therefore expected to have
+        # one column per action. When ``context`` has fewer columns the
+        # adapter falls back to a zero-affinity surface (still valid,
+        # the search space's ``w_user_item_affinity`` weight then has
+        # no effect — useful for small synthetic fixtures).
+        if self._context.shape[1] >= self._n_actions:
+            self._affinity: np.ndarray = self._context[:, : self._n_actions]
+        else:
+            self._affinity = np.zeros((self._n_rounds, self._n_actions), dtype=float)
+
+        # Per-item popularity prior (log-normalized appearance count).
+        # Computed once at construction from ``action`` so the prior is
+        # deterministic across policy evaluations.
+        counts = np.bincount(self._action, minlength=self._n_actions).astype(float)
+        raw_max = float(counts.max())
+        max_count = raw_max if raw_max > 0.0 else 1.0
+        self._item_popularity: np.ndarray = np.log1p(counts) / np.log1p(max_count)
+
+    # ── Constructor from OBP ──────────────────────────────────────────
+
+    @classmethod
+    def from_obp(
+        cls,
+        *,
+        campaign: str = "men",
+        behavior_policy: str = "random",
+        data_path: Any | None = None,
+        seed: int | None = None,
+    ) -> BanditLogAdapter:
+        """Build an adapter from an OBP ``OpenBanditDataset``.
+
+        Loads the requested campaign / logger slice via OBP, extracts
+        the bandit-feedback dict, and returns a ready-to-use adapter.
+        Requires the optional ``bandit`` extra (``uv sync --extra
+        bandit``); raises a clear :class:`ImportError` if the extra is
+        not installed.
+
+        Parameters
+        ----------
+        campaign:
+            ZOZOTOWN campaign name. Must be one of ``"all"``, ``"men"``,
+            or ``"women"``. Defaults to ``"men"`` per the Sprint 34
+            first-slice decision.
+        behavior_policy:
+            Logging policy. Must be ``"random"`` or ``"bts"``. Defaults
+            to ``"random"`` per the Sprint 34 first-slice decision.
+        data_path:
+            Optional ``pathlib.Path`` to the full released dataset.
+            When ``None`` the OBP bundled small-sized sample is used
+            (10,000 rows on Men/Random as of obp 0.4.1).
+        seed:
+            Reproducibility seed; forwarded to the adapter constructor.
+        """
+        try:
+            # Inside-function import is deliberate: the ``obp`` package
+            # is the optional ``bandit`` extra, and keeping this import
+            # lazy is what lets the core adapter module stay importable
+            # without the extra installed.
+            from obp.dataset import OpenBanditDataset
+        except ImportError as exc:  # pragma: no cover - exercised by monkeypatched test
+            msg = (
+                "BanditLogAdapter.from_obp requires the 'bandit' extra. "
+                "Install it with: uv sync --extra bandit  "
+                "(or: pip install 'causal-optimizer[bandit]')."
+            )
+            raise ImportError(msg) from exc
+
+        dataset = OpenBanditDataset(
+            behavior_policy=behavior_policy,
+            campaign=campaign,
+            data_path=data_path,
+        )
+        bandit_feedback = dataset.obtain_batch_bandit_feedback()
+        # OBP's obtain_batch_bandit_feedback returns a dict with exactly
+        # the keys we require; validate defensively so a future OBP
+        # upgrade does not silently break us.
+        assert isinstance(bandit_feedback, dict)
+        return cls(bandit_feedback=bandit_feedback, seed=seed)
+
+    # ── DomainAdapter interface ────────────────────────────────────────
+
+    def get_search_space(self) -> SearchSpace:
+        variables: list[Variable] = [
+            Variable(
+                name="tau",
+                variable_type=VariableType.CONTINUOUS,
+                lower=_TAU_LOWER,
+                upper=_TAU_UPPER,
+            ),
+            Variable(
+                name="eps",
+                variable_type=VariableType.CONTINUOUS,
+                lower=_EPS_LOWER,
+                upper=_EPS_UPPER,
+            ),
+        ]
+        for name in _CONTEXT_WEIGHT_NAMES:
+            variables.append(
+                Variable(
+                    name=name,
+                    variable_type=VariableType.CONTINUOUS,
+                    lower=_WEIGHT_LOWER,
+                    upper=_WEIGHT_UPPER,
+                )
+            )
+        variables.append(
+            Variable(
+                name="position_handling_flag",
+                variable_type=VariableType.CATEGORICAL,
+                choices=list(_POSITION_HANDLING_CHOICES),
+            )
+        )
+        return SearchSpace(variables=variables)
+
+    def run_experiment(self, parameters: dict[str, Any]) -> dict[str, float]:
+        tau = float(parameters.get("tau", 1.0))
+        eps = float(parameters.get("eps", 0.0))
+        w_item = float(parameters.get("w_item_feature_0", 0.0))
+        w_affinity = float(parameters.get("w_user_item_affinity", 0.0))
+        w_popularity = float(parameters.get("w_item_popularity", 0.0))
+        position_flag = str(parameters.get("position_handling_flag", "position_1_only"))
+
+        if position_flag not in _POSITION_HANDLING_CHOICES:
+            msg = (
+                f"position_handling_flag must be one of "
+                f"{list(_POSITION_HANDLING_CHOICES)!r}, got {position_flag!r}"
+            )
+            raise ValueError(msg)
+
+        # Row mask: restrict to position index 0 when requested. The
+        # incoming ``position`` array is 0-indexed after ``rankdata``
+        # re-ranking in the raw OBP loader, so position_1 ↔ index 0.
+        if position_flag == "position_1_only":
+            mask = self._position == 0
+        else:
+            mask = np.ones(self._n_rounds, dtype=bool)
+
+        n_active = int(mask.sum())
+        if n_active == 0:
+            # No rows survive the position subset — return a
+            # pessimistic but well-defined result.
+            return {
+                "policy_value": 0.0,
+                "ess": 0.0,
+                "weight_cv": 0.0,
+                "max_weight": 0.0,
+                "zero_support_fraction": 1.0,
+                "n_effective_actions": 1.0,
+            }
+
+        # ── Score each (row, candidate action) ────────────────────────
+        # Shape: (n_active, n_actions)
+        item_term = w_item * self._item_feature_0[None, :]
+        pop_term = w_popularity * self._item_popularity[None, :]
+        affinity_term = w_affinity * self._affinity[mask]
+        scores = item_term + pop_term + affinity_term
+
+        # ── Softmax with temperature and epsilon mixing ───────────────
+        safe_tau = max(tau, _TAU_FLOOR)
+        scaled = scores / safe_tau
+        scaled -= scaled.max(axis=1, keepdims=True)  # numerical stability
+        exp_scores = np.exp(scaled)
+        softmax = exp_scores / exp_scores.sum(axis=1, keepdims=True)
+        uniform = np.full_like(softmax, 1.0 / self._n_actions)
+        policy = (1.0 - eps) * softmax + eps * uniform
+        # policy is shape (n_active, n_actions) and sums to 1 along axis 1.
+
+        # ── SNIPW-style policy value ──────────────────────────────────
+        active_action = self._action[mask]
+        active_reward = self._reward[mask].astype(float)
+        active_pscore = self._pscore[mask]
+
+        # Evaluation-policy probability of the logged action.
+        row_idx = np.arange(n_active)
+        pi_logged = policy[row_idx, active_action]
+
+        # Importance weights w_i = pi_e(a_i | x_i) / pi_b(a_i | x_i).
+        weights = pi_logged / active_pscore
+
+        weight_sum = float(weights.sum())
+        if weight_sum > 0.0:
+            # Self-normalized IPW: V_hat = sum(w_i r_i) / sum(w_i).
+            policy_value = float((weights * active_reward).sum() / weight_sum)
+            # Kish ESS: (sum w)^2 / sum(w^2).
+            ess = float(weight_sum * weight_sum / float((weights * weights).sum()))
+        else:
+            policy_value = 0.0
+            ess = 0.0
+
+        # ── Weight statistics ─────────────────────────────────────────
+        max_weight = float(weights.max()) if weights.size > 0 else 0.0
+        positive = weights[weights > 0.0]
+        # Use population std (ddof=0) so the CV is well defined even at
+        # tiny n_active; fall back to 0.0 when fewer than two positive
+        # weights survive (no variability to report).
+        weight_cv = float(positive.std(ddof=0) / positive.mean()) if positive.size > 1 else 0.0
+
+        # ── Zero-support fraction ─────────────────────────────────────
+        # A logged row has "structurally zero support" under the
+        # evaluation policy when pi_e(a_logged | x) == 0 exactly.
+        # Under eps > 0 this is impossible; we still compute the
+        # fraction defensively.
+        zero_support_fraction = float((pi_logged <= 0.0).mean())
+
+        # ── n_effective_actions ───────────────────────────────────────
+        # Count actions that carry non-negligible mass: the smallest k
+        # such that the top-k sorted policy-mass items on average
+        # exceed 0.95. Equivalently, count the per-row top-k until the
+        # threshold is crossed, averaged over rows. We compute the
+        # average directly via cumulative-sum-of-sorted-mass.
+        sorted_mass = -np.sort(-policy, axis=1)
+        cum_mass = np.cumsum(sorted_mass, axis=1)
+        # Per-row: smallest k with cum_mass[k-1] >= threshold.
+        # np.argmax returns the first True along axis; if all False
+        # (shouldn't happen because cum_mass ends at ~1), fall back to
+        # n_actions.
+        crosses = cum_mass >= _EFFECTIVE_ACTIONS_MASS_THRESHOLD
+        any_cross = crosses.any(axis=1)
+        first_cross = np.where(
+            any_cross,
+            crosses.argmax(axis=1) + 1,
+            self._n_actions,
+        )
+        n_effective_actions = float(first_cross.mean())
+
+        return {
+            "policy_value": policy_value,
+            "ess": ess,
+            "weight_cv": weight_cv,
+            "max_weight": max_weight,
+            "zero_support_fraction": zero_support_fraction,
+            "n_effective_actions": n_effective_actions,
+        }
+
+    def get_prior_graph(self) -> CausalGraph | None:
+        """Sprint 34 contract Section 4e: prior graph is optional, minimal,
+        or deferred. Returns ``None`` for the first implementation.
+
+        Authoring a multi-action prior graph is a Sprint 36+ decision —
+        see contract Section 4e. The engine will run without a graph;
+        ``focus_variables`` degrades to the full search space.
+        """
+        return None
+
+    def get_objective_name(self) -> str:
+        return "policy_value"
+
+    def get_minimize(self) -> bool:
+        return False  # maximize SNIPW-estimated CTR
+
+    def get_strategy(self) -> str:
+        return "bayesian"
+
+    def get_descriptor_names(self) -> list[str]:
+        # Descriptors for MAP-Elites diversity: n_effective_actions
+        # (policy concentration) and zero_support_fraction
+        # (coverage) are the two most behavior-meaningful axes for
+        # multi-action policies. They are already returned by
+        # run_experiment so MAP-Elites can read them without
+        # re-evaluating.
+        return ["n_effective_actions", "zero_support_fraction"]
+
+    # ── Validation ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _validate_feedback(bandit_feedback: dict[str, Any]) -> None:
+        """Fail fast with actionable errors on malformed bandit-feedback.
+
+        Checks keys, array lengths, reward binary-ness, and non-zero
+        propensity. Raises :class:`ValueError` on any violation so
+        downstream callers see a clear failure site instead of an
+        opaque numpy error deep inside :meth:`run_experiment`.
+        """
+        missing = _REQUIRED_FEEDBACK_KEYS - set(bandit_feedback)
+        if missing:
+            msg = (
+                "bandit_feedback is missing required key(s): "
+                f"{sorted(missing)!r}. Required keys: "
+                f"{sorted(_REQUIRED_FEEDBACK_KEYS)!r}."
+            )
+            raise ValueError(msg)
+
+        n_rounds = int(bandit_feedback["n_rounds"])
+        if n_rounds <= 0:
+            raise ValueError(f"n_rounds must be positive, got {n_rounds}")
+
+        n_actions = int(bandit_feedback["n_actions"])
+        if n_actions < 2:
+            raise ValueError(f"n_actions must be >= 2 for a multi-action bandit, got {n_actions}")
+
+        for key in ("action", "position", "reward", "pscore"):
+            arr = np.asarray(bandit_feedback[key])
+            if arr.shape != (n_rounds,):
+                raise ValueError(
+                    f"bandit_feedback[{key!r}] has shape {arr.shape}, expected ({n_rounds},)"
+                )
+
+        context = np.asarray(bandit_feedback["context"])
+        if context.ndim != 2 or context.shape[0] != n_rounds:
+            raise ValueError(
+                f"bandit_feedback['context'] has shape {context.shape}, "
+                f"expected ({n_rounds}, d_context)"
+            )
+
+        action_context = np.asarray(bandit_feedback["action_context"])
+        if action_context.ndim != 2 or action_context.shape[0] != n_actions:
+            raise ValueError(
+                f"bandit_feedback['action_context'] has shape {action_context.shape}, "
+                f"expected ({n_actions}, d_action). ``action_context`` must contain "
+                "at least one column; the adapter uses column 0 as ``item_feature_0``."
+            )
+        if action_context.shape[1] < 1:
+            raise ValueError(
+                "bandit_feedback['action_context'] must have >= 1 column; the adapter "
+                "reads column 0 as ``item_feature_0``."
+            )
+
+        reward = np.asarray(bandit_feedback["reward"])
+        unique = np.unique(reward)
+        if not set(unique.astype(float).tolist()).issubset({0.0, 1.0}):
+            raise ValueError(
+                "bandit_feedback['reward'] must be binary (0/1); "
+                f"found unique values {unique.tolist()}"
+            )
+
+        pscore = np.asarray(bandit_feedback["pscore"], dtype=float)
+        if (pscore <= 0.0).any():
+            raise ValueError(
+                "bandit_feedback['pscore'] must be strictly positive for SNIPW; "
+                f"found min={float(pscore.min())}. The Sprint 34 contract "
+                "Section 5c clip is applied downstream by the OPE stack, but the "
+                "adapter rejects a zero-propensity row at construction."
+            )
+
+        action = np.asarray(bandit_feedback["action"])
+        if action.min() < 0 or action.max() >= n_actions:
+            raise ValueError(
+                f"bandit_feedback['action'] values must be in [0, {n_actions}); "
+                f"found range [{int(action.min())}, {int(action.max())}]"
+            )

--- a/causal_optimizer/domain_adapters/bandit_log.py
+++ b/causal_optimizer/domain_adapters/bandit_log.py
@@ -75,6 +75,8 @@ from causal_optimizer.domain_adapters.base import DomainAdapter
 from causal_optimizer.types import SearchSpace, Variable, VariableType
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from causal_optimizer.types import CausalGraph
 
 __all__ = ["BanditLogAdapter"]
@@ -102,6 +104,13 @@ _CONTEXT_WEIGHT_NAMES: tuple[str, ...] = (
 )
 
 _POSITION_HANDLING_CHOICES: tuple[str, ...] = ("marginalize", "position_1_only")
+
+# Accepted values for :meth:`BanditLogAdapter.from_obp`. These mirror
+# the values validated inside ``OpenBanditDataset.__post_init__``; we
+# check them up-front so the adapter fails fast with a consistent error
+# message regardless of which OBP version is installed.
+_OBP_CAMPAIGNS: frozenset[str] = frozenset({"all", "men", "women"})
+_OBP_BEHAVIOR_POLICIES: frozenset[str] = frozenset({"random", "bts"})
 
 # Search-space bounds — see Sprint 34 contract Section 4c.
 _TAU_LOWER: float = 0.1
@@ -167,7 +176,11 @@ class BanditLogAdapter(DomainAdapter):
         self._n_actions: int = int(bandit_feedback["n_actions"])
         self._action: np.ndarray = np.asarray(bandit_feedback["action"], dtype=np.int64)
         self._position: np.ndarray = np.asarray(bandit_feedback["position"], dtype=np.int64)
-        self._reward: np.ndarray = np.asarray(bandit_feedback["reward"], dtype=np.int64)
+        # Store reward as float64 (binary rewards are checked in
+        # ``_validate_feedback`` before this line). Storing as float
+        # avoids a per-call ``.astype(float)`` in ``run_experiment`` and
+        # matches ``pscore``'s dtype convention.
+        self._reward: np.ndarray = np.asarray(bandit_feedback["reward"], dtype=float)
         self._pscore: np.ndarray = np.asarray(bandit_feedback["pscore"], dtype=float)
         self._context: np.ndarray = np.asarray(bandit_feedback["context"], dtype=float)
         self._action_context: np.ndarray = np.asarray(
@@ -207,7 +220,7 @@ class BanditLogAdapter(DomainAdapter):
         *,
         campaign: str = "men",
         behavior_policy: str = "random",
-        data_path: Any | None = None,
+        data_path: Path | str | None = None,
         seed: int | None = None,
     ) -> BanditLogAdapter:
         """Build an adapter from an OBP ``OpenBanditDataset``.
@@ -234,6 +247,16 @@ class BanditLogAdapter(DomainAdapter):
         seed:
             Reproducibility seed; forwarded to the adapter constructor.
         """
+        if campaign not in _OBP_CAMPAIGNS:
+            msg = f"campaign must be one of {sorted(_OBP_CAMPAIGNS)!r}, got {campaign!r}"
+            raise ValueError(msg)
+        if behavior_policy not in _OBP_BEHAVIOR_POLICIES:
+            msg = (
+                "behavior_policy must be one of "
+                f"{sorted(_OBP_BEHAVIOR_POLICIES)!r}, got {behavior_policy!r}"
+            )
+            raise ValueError(msg)
+
         try:
             # Inside-function import is deliberate: the ``obp`` package
             # is the optional ``bandit`` extra, and keeping this import
@@ -358,7 +381,7 @@ class BanditLogAdapter(DomainAdapter):
 
         # ── SNIPW-style policy value ──────────────────────────────────
         active_action = self._action[mask]
-        active_reward = self._reward[mask].astype(float)
+        active_reward = self._reward[mask]
         active_pscore = self._pscore[mask]
 
         # Evaluation-policy probability of the logged action.
@@ -371,6 +394,12 @@ class BanditLogAdapter(DomainAdapter):
         weight_sum = float(weights.sum())
         if weight_sum > 0.0:
             # Self-normalized IPW: V_hat = sum(w_i r_i) / sum(w_i).
+            # For binary rewards in {0, 1}, SNIPW is a weighted average
+            # of {0, 1} values and is bounded in [0, 1]. It is *not*
+            # bounded in [0, 1] for non-binary rewards, so downstream
+            # callers that want a strict unit-interval guarantee should
+            # clip. Track A keeps binary-reward validation at
+            # ``_validate_feedback`` so this bound holds by construction.
             policy_value = float((weights * active_reward).sum() / weight_sum)
             # Kish ESS: (sum w)^2 / sum(w^2).
             ess = float(weight_sum * weight_sum / float((weights * weights).sum()))
@@ -384,6 +413,11 @@ class BanditLogAdapter(DomainAdapter):
         # Use population std (ddof=0) so the CV is well defined even at
         # tiny n_active; fall back to 0.0 when fewer than two positive
         # weights survive (no variability to report).
+        # NOTE: ``MarketingLogAdapter`` uses ``ddof=1`` for its
+        # ``weight_cv``. ``weight_cv`` values from the two adapters are
+        # therefore not directly comparable at small n; this adapter
+        # optimizes for stability under the ``position_1_only`` subset,
+        # not for cross-adapter parity.
         weight_cv = float(positive.std(ddof=0) / positive.mean()) if positive.size > 1 else 0.0
 
         # ── Zero-support fraction ─────────────────────────────────────

--- a/causal_optimizer/domain_adapters/bandit_log.py
+++ b/causal_optimizer/domain_adapters/bandit_log.py
@@ -254,10 +254,18 @@ class BanditLogAdapter(DomainAdapter):
             data_path=data_path,
         )
         bandit_feedback = dataset.obtain_batch_bandit_feedback()
-        # OBP's obtain_batch_bandit_feedback returns a dict with exactly
-        # the keys we require; validate defensively so a future OBP
-        # upgrade does not silently break us.
-        assert isinstance(bandit_feedback, dict)
+        # OBP's ``obtain_batch_bandit_feedback`` returns a dict under the
+        # default call path, but it can return a ``(train, test)`` tuple
+        # when ``is_timeseries_split=True`` — we never pass that flag,
+        # but guard with a real TypeError (not ``assert``) so the check
+        # survives ``python -O`` / ``PYTHONOPTIMIZE=1``.
+        if not isinstance(bandit_feedback, dict):
+            raise TypeError(
+                "OpenBanditDataset.obtain_batch_bandit_feedback did not return a "
+                f"dict; got {type(bandit_feedback).__name__!r}. This likely means "
+                "the OBP API changed or timeseries splitting was accidentally "
+                "enabled."
+            )
         return cls(bandit_feedback=bandit_feedback, seed=seed)
 
     # ── DomainAdapter interface ────────────────────────────────────────

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,17 @@ doe = [
 causal = [
     "dowhy>=0.11",
 ]
+bandit = [
+    # Open Bandit Pipeline. Powers the ``BanditLogAdapter.from_obp``
+    # data loader and the Sprint 35.B OPE stack (SNIPW / DM / DR).
+    # Pinned to the 0.4.x series: ``obp==0.4.1`` is the last release as
+    # of the Sprint 34 Open Bandit contract (issue #182). Apache 2.0;
+    # dataset is not redistributed by this repo. Upgrading OBP is an
+    # explicit sprint decision per contract Section 8c.
+    "obp>=0.4.1,<0.5",
+]
 all = [
-    "causal-optimizer[bayesian,doe,causal]",
+    "causal-optimizer[bayesian,doe,causal,bandit]",
 ]
 dev = [
     "pytest>=7.0",
@@ -111,4 +120,5 @@ testpaths = ["tests"]
 addopts = "-v --tb=short"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "obp: marks tests as requiring the optional 'bandit' extra (obp)",
 ]

--- a/tests/integration/test_bandit_log_adapter_smoke.py
+++ b/tests/integration/test_bandit_log_adapter_smoke.py
@@ -41,12 +41,11 @@ def _load_men_random_raw() -> tuple[Any, Any]:
     Issue B / Issue C can switch to a patched loader later; for the
     Sprint 35.A smoke test we only need the raw column shapes.
     """
-    import os
     from pathlib import Path
 
     import pandas as pd
 
-    root = Path(os.path.dirname(obp.__file__)) / "dataset" / "obd" / "random" / "men"
+    root = Path(obp.__file__).parent / "dataset" / "obd" / "random" / "men"
     data = pd.read_csv(root / "men.csv", index_col=0)
     item_context = pd.read_csv(root / "item_context.csv", index_col=0)
     return data, item_context

--- a/tests/integration/test_bandit_log_adapter_smoke.py
+++ b/tests/integration/test_bandit_log_adapter_smoke.py
@@ -24,7 +24,7 @@ from typing import Any
 import numpy as np
 import pytest
 
-pytestmark = pytest.mark.slow
+pytestmark = [pytest.mark.slow, pytest.mark.obp]
 
 # Skip cleanly if the optional extra is not installed. This keeps the
 # suite honest when running under ``uv sync`` without ``--extra bandit``.

--- a/tests/integration/test_bandit_log_adapter_smoke.py
+++ b/tests/integration/test_bandit_log_adapter_smoke.py
@@ -1,0 +1,197 @@
+"""Sprint 34 contract Section 10.A smoke test for ``BanditLogAdapter``.
+
+Loads the ZOZOTOWN Men / uniform-random slice bundled in the ``obp``
+package and confirms the three Sprint 34 findings required before
+Issue B and Issue C can land:
+
+1. row count matches the Saito et al. 2021 Table 1 order of magnitude
+   (for the bundled small-sized slice shipped with OBP 0.4.1 the row
+   count is 10,000; the full released slice is ~452,949)
+2. whether ``pscore`` / ``action_prob`` is stored as conditional
+   ``P(item | position)`` (= ``1/n_actions``) or as joint
+   ``P(item, position)`` (= ``1/(n_actions * n_positions)``)
+3. the 3-to-5 context features chosen by the adapter are documented in
+   the adapter docstring
+
+Marked ``slow`` and ``obp`` so it is skipped in the default fast suite
+and only runs when the optional ``bandit`` extra is installed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+pytestmark = pytest.mark.slow
+
+# Skip cleanly if the optional extra is not installed. This keeps the
+# suite honest when running under ``uv sync`` without ``--extra bandit``.
+obp = pytest.importorskip("obp")
+
+
+def _load_men_random_raw() -> tuple[Any, Any]:
+    """Return the raw Men/Random ``data`` and ``item_context`` frames.
+
+    We read the CSVs directly rather than calling
+    ``OpenBanditDataset.load_raw_data`` + ``pre_process`` because the
+    pinned ``obp==0.4.1`` pre-processor calls ``DataFrame.drop(..., 1)``
+    with a positional ``axis`` argument that modern pandas rejects.
+    Issue B / Issue C can switch to a patched loader later; for the
+    Sprint 35.A smoke test we only need the raw column shapes.
+    """
+    import os
+    from pathlib import Path
+
+    import pandas as pd
+
+    root = Path(os.path.dirname(obp.__file__)) / "dataset" / "obd" / "random" / "men"
+    data = pd.read_csv(root / "men.csv", index_col=0)
+    item_context = pd.read_csv(root / "item_context.csv", index_col=0)
+    return data, item_context
+
+
+class TestMenRandomSmoke:
+    """Three Section 10.A findings required by the Sprint 34 contract."""
+
+    def test_bundled_men_random_row_count(self) -> None:
+        # OBP 0.4.1 ships a 10,000-row sample of the Men/Random slice
+        # (a deterministic downsample of the ~452,949-row full slice).
+        # The full slice must be loaded separately via ``data_path=``;
+        # the bundled sample is what ships with the package.
+        data, _ = _load_men_random_raw()
+        assert len(data) == 10_000, (
+            f"Bundled Men/Random row count changed: expected 10,000, got {len(data)}. "
+            "Full Men/Random slice (~452,949 rows per Saito et al. 2021 Table 1) "
+            "requires ``data_path=`` pointing at the released dataset."
+        )
+
+    def test_men_random_action_and_position_cardinality(self) -> None:
+        data, item_context = _load_men_random_raw()
+        # 34 items, 3 positions (Saito et al. 2021 Table 1)
+        assert data["item_id"].nunique() == 34
+        assert data["position"].nunique() == 3
+        assert len(item_context) == 34
+
+    def test_action_prob_is_conditional_not_joint(self) -> None:
+        # Sprint 34 contract Section 5c / Section 7d: confirm whether
+        # ``action_prob`` (= ``pscore``) is conditional ``P(item|position)``
+        # or joint ``P(item, position)``.
+        # Under the Random logger, conditional ``P(item|position)``
+        # would be ``1/34 ≈ 0.0294``, and joint ``P(item, position)``
+        # would be ``1/(34*3) ≈ 0.0098``.
+        data, _ = _load_men_random_raw()
+        n_items = int(data["item_id"].nunique())
+        n_positions = int(data["position"].nunique())
+        conditional_target = 1.0 / n_items
+        joint_target = 1.0 / (n_items * n_positions)
+        empirical_mean = float(data["propensity_score"].mean())
+
+        # Use a tight 1% relative band to assert which schema is live.
+        assert abs(empirical_mean - conditional_target) / conditional_target < 0.01, (
+            f"propensity_score mean {empirical_mean:.6f} does not match conditional "
+            f"P(item|position) = {conditional_target:.6f}"
+        )
+        assert abs(empirical_mean - joint_target) / joint_target > 0.5, (
+            f"propensity_score mean {empirical_mean:.6f} unexpectedly close to joint "
+            f"P(item, position) = {joint_target:.6f}"
+        )
+
+    def test_chosen_context_features_are_present(self) -> None:
+        # Sprint 34 contract Section 4c: adapter's 3-to-5 context-feature
+        # weights must reference columns that actually exist in the OBD
+        # schema.
+        data, item_context = _load_men_random_raw()
+
+        # Feature 1: ``item_feature_0`` is a per-item continuous feature
+        # in ``item_context`` (range ~[-0.7, 0.7]).
+        assert "item_feature_0" in item_context.columns
+        assert np.issubdtype(item_context["item_feature_0"].dtype, np.floating)
+
+        # Feature 2: ``user-item_affinity_<k>`` are 34 per-row continuous
+        # columns, one per candidate item id k.
+        affinity_cols = [c for c in data.columns if c.startswith("user-item_affinity_")]
+        assert len(affinity_cols) == 34
+
+        # Feature 3: per-item popularity (log-count of appearances in the
+        # log) can be computed from ``item_id`` value counts, which the
+        # adapter pre-computes at load time.
+        counts = data["item_id"].value_counts()
+        assert counts.min() > 0  # every item appeared at least once
+
+
+class TestAdapterAcceptsBundledFeedback:
+    """End-to-end: the adapter can consume a bandit-feedback dict
+    materialized from the bundled Men/Random slice."""
+
+    def test_adapter_runs_on_bundled_men_random(self) -> None:
+        # Build a bandit-feedback dict directly (the OBP pre_process path
+        # is broken against modern pandas in 0.4.1; we bypass it here by
+        # using the raw CSVs).
+        from scipy.stats import rankdata
+
+        from causal_optimizer.domain_adapters.bandit_log import BanditLogAdapter
+
+        data, item_context = _load_men_random_raw()
+        data = data.sort_values("timestamp").reset_index(drop=True)
+
+        action = data["item_id"].to_numpy().astype(int)
+        position = (rankdata(data["position"].to_numpy(), "dense") - 1).astype(int)
+        reward = data["click"].to_numpy().astype(int)
+        pscore = data["propensity_score"].to_numpy().astype(float)
+
+        # Build per-row "context" and per-item "action_context" from the
+        # raw CSVs. Full feature engineering is Issue B's territory; the
+        # adapter only needs well-shaped arrays for the smoke run.
+        affinity_cols = [c for c in data.columns if c.startswith("user-item_affinity_")]
+        # Context: the 34 affinity columns. (User feature columns are
+        # hashed strings in the raw CSV; the adapter does not need them
+        # for this smoke test.)
+        context = data[affinity_cols].to_numpy().astype(float)
+
+        # action_context: per-item continuous feature ``item_feature_0``
+        # aligned to ``item_id``.
+        item_context = item_context.sort_values("item_id")
+        action_context = item_context[["item_feature_0"]].to_numpy().astype(float)
+
+        bandit_feedback: dict[str, Any] = {
+            "n_rounds": int(len(data)),
+            "n_actions": int(data["item_id"].nunique()),
+            "action": action,
+            "position": position,
+            "reward": reward,
+            "pscore": pscore,
+            "context": context,
+            "action_context": action_context,
+        }
+
+        adapter = BanditLogAdapter(bandit_feedback=bandit_feedback, seed=0)
+        metrics = adapter.run_experiment(
+            {
+                "tau": 1.0,
+                "eps": 0.1,
+                "w_item_feature_0": 0.5,
+                "w_user_item_affinity": 0.5,
+                "w_item_popularity": 0.0,
+                "position_handling_flag": "position_1_only",
+            }
+        )
+        # Must satisfy the Section 4d interface on real data.
+        for key in (
+            "policy_value",
+            "ess",
+            "weight_cv",
+            "max_weight",
+            "zero_support_fraction",
+            "n_effective_actions",
+        ):
+            assert key in metrics
+        # Sanity: policy value in [0, 1] on binary rewards.
+        assert 0.0 <= metrics["policy_value"] <= 1.0
+        # ESS floor per Section 7b for position_1_only on ~10K rows / 3:
+        # ``max(1000, n_rows/100)`` = max(1000, ~33) = 1000.
+        # Under a random-ish policy with eps=0.1 the ESS should be well
+        # above a few hundred; we only assert strict positivity here,
+        # because the support gate itself is Issue B's responsibility.
+        assert metrics["ess"] > 0.0

--- a/tests/unit/test_bandit_log_adapter.py
+++ b/tests/unit/test_bandit_log_adapter.py
@@ -327,6 +327,46 @@ class TestRunExperimentSemantics:
         )
         assert 0.0 <= metrics["policy_value"] <= 1.0
 
+    def test_eps_zero_uniform_scores_produces_uniform_policy(
+        self, feedback: dict[str, Any]
+    ) -> None:
+        # With every weight zero and ``eps=0``, the softmax over a row
+        # of identical scores must be uniform (no numerical blow-up).
+        # n_effective_actions should equal the smallest k with
+        # cum_mass >= 0.95 under a uniform distribution: for n=5,
+        # 4/5=0.80 < 0.95 but 5/5=1.00, so k=5.
+        adapter = BanditLogAdapter(bandit_feedback=feedback, seed=0)
+        metrics = adapter.run_experiment(
+            {
+                "tau": 1.0,
+                "eps": 0.0,
+                "w_item_feature_0": 0.0,
+                "w_user_item_affinity": 0.0,
+                "w_item_popularity": 0.0,
+                "position_handling_flag": "marginalize",
+            }
+        )
+        assert metrics["n_effective_actions"] == float(feedback["n_actions"])
+        assert metrics["zero_support_fraction"] == 0.0
+
+    def test_negative_feature_weights_produce_valid_policy(self, adapter: BanditLogAdapter) -> None:
+        # Negative weights penalize rather than reward items; the
+        # adapter must still produce valid diagnostics (no NaN, no
+        # probability outside [0, 1], finite ESS).
+        metrics = adapter.run_experiment(
+            {
+                "tau": 1.0,
+                "eps": 0.05,
+                "w_item_feature_0": -2.0,
+                "w_user_item_affinity": -1.5,
+                "w_item_popularity": -0.5,
+                "position_handling_flag": "marginalize",
+            }
+        )
+        assert 0.0 <= metrics["policy_value"] <= 1.0
+        assert np.isfinite(metrics["ess"])
+        assert np.isfinite(metrics["weight_cv"])
+
     def test_sharp_softmax_reduces_n_effective_actions(self, adapter: BanditLogAdapter) -> None:
         # Small tau => sharp softmax => most mass on one action under
         # non-zero weights => n_effective_actions drops toward 1.
@@ -398,6 +438,14 @@ class TestFromObpConstructor:
         monkeypatch.setitem(sys.modules, "obp.dataset", None)
         with pytest.raises(ImportError, match="bandit"):
             BanditLogAdapter.from_obp(campaign="men", behavior_policy="random")
+
+    def test_from_obp_rejects_invalid_campaign(self) -> None:
+        with pytest.raises(ValueError, match="campaign"):
+            BanditLogAdapter.from_obp(campaign="bogus", behavior_policy="random")
+
+    def test_from_obp_rejects_invalid_behavior_policy(self) -> None:
+        with pytest.raises(ValueError, match="behavior_policy"):
+            BanditLogAdapter.from_obp(campaign="men", behavior_policy="epsilon_greedy")
 
     def test_from_obp_delegates_to_open_bandit_dataset(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/unit/test_bandit_log_adapter.py
+++ b/tests/unit/test_bandit_log_adapter.py
@@ -1,0 +1,456 @@
+"""Unit tests for ``BanditLogAdapter`` (Sprint 35.A).
+
+Uses a synthetic OBP-shaped ``bandit_feedback`` dict so these tests are
+fast and do not require the real Men/Random slice or the ``obp`` extra.
+The slow smoke test against the bundled OBP data lives in
+``tests/integration/test_bandit_log_adapter_smoke.py``.
+
+Covers the Sprint 34 Open Bandit contract, Sections 4b and 4d:
+the minimum ``DomainAdapter`` interface, the 3-to-5 context-feature
+weight search space, the ``policy_value`` objective and ``maximize``
+direction, and the full Section 4d diagnostic dict.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from causal_optimizer.domain_adapters.bandit_log import BanditLogAdapter
+from causal_optimizer.types import VariableType
+
+
+def _synthetic_bandit_feedback(
+    *,
+    n_rounds: int = 600,
+    n_actions: int = 5,
+    len_list: int = 3,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Build a small OBP-shaped ``bandit_feedback`` dict for unit tests.
+
+    Matches the OBP schema exactly:
+    - ``action``: shape (n_rounds,), int in [0, n_actions)
+    - ``position``: shape (n_rounds,), int in [0, len_list)
+    - ``reward``: shape (n_rounds,), binary {0, 1}
+    - ``pscore``: shape (n_rounds,), conditional ``P(item | position)``
+      fixed to ``1/n_actions`` (mirrors the Men/Random logger)
+    - ``context``: shape (n_rounds, d_context), user features
+    - ``action_context``: shape (n_actions, d_action), item features
+    """
+    rng = np.random.default_rng(seed)
+    action = rng.integers(0, n_actions, size=n_rounds)
+    position = rng.integers(0, len_list, size=n_rounds)
+    reward = (rng.random(n_rounds) < 0.01).astype(int)
+    pscore = np.full(n_rounds, 1.0 / n_actions, dtype=float)
+    context = rng.normal(size=(n_rounds, 4))
+    action_context = rng.normal(size=(n_actions, 3))
+    return {
+        "n_rounds": n_rounds,
+        "n_actions": n_actions,
+        "action": action,
+        "position": position,
+        "reward": reward,
+        "pscore": pscore,
+        "context": context,
+        "action_context": action_context,
+    }
+
+
+@pytest.fixture
+def feedback() -> dict[str, Any]:
+    return _synthetic_bandit_feedback()
+
+
+@pytest.fixture
+def adapter(feedback: dict[str, Any]) -> BanditLogAdapter:
+    return BanditLogAdapter(bandit_feedback=feedback, seed=7)
+
+
+@pytest.fixture
+def default_params() -> dict[str, Any]:
+    return {
+        "tau": 1.0,
+        "eps": 0.1,
+        "w_item_feature_0": 0.5,
+        "w_user_item_affinity": 0.5,
+        "w_item_popularity": 0.0,
+        "position_handling_flag": "position_1_only",
+    }
+
+
+class TestAdapterContract:
+    """Section 4b required interface methods."""
+
+    def test_adapter_subclasses_domain_adapter(self, adapter: BanditLogAdapter) -> None:
+        from causal_optimizer.domain_adapters.base import DomainAdapter
+
+        assert isinstance(adapter, DomainAdapter)
+
+    def test_adapter_does_not_subclass_marketing_log_adapter(
+        self, adapter: BanditLogAdapter
+    ) -> None:
+        # Sprint 34 contract Section 4a forbids subclassing
+        # ``MarketingLogAdapter``; the binary treatment path there is
+        # load-bearing and reshaping it to multi-action would hide the
+        # structural break.
+        from causal_optimizer.domain_adapters.marketing_logs import MarketingLogAdapter
+
+        assert not isinstance(adapter, MarketingLogAdapter)
+
+    def test_objective_name_is_policy_value(self, adapter: BanditLogAdapter) -> None:
+        assert adapter.get_objective_name() == "policy_value"
+
+    def test_minimize_is_false(self, adapter: BanditLogAdapter) -> None:
+        assert adapter.get_minimize() is False
+
+    def test_strategy_is_bayesian(self, adapter: BanditLogAdapter) -> None:
+        assert adapter.get_strategy() == "bayesian"
+
+    def test_prior_graph_is_none_by_default(self, adapter: BanditLogAdapter) -> None:
+        assert adapter.get_prior_graph() is None
+
+
+class TestSearchSpace:
+    """Section 4c item-scoring policy parameterization."""
+
+    def test_search_space_has_6_to_8_variables(self, adapter: BanditLogAdapter) -> None:
+        space = adapter.get_search_space()
+        assert 6 <= len(space.variables) <= 8
+
+    def test_search_space_contains_tau(self, adapter: BanditLogAdapter) -> None:
+        space = adapter.get_search_space()
+        tau = next((v for v in space.variables if v.name == "tau"), None)
+        assert tau is not None
+        assert tau.variable_type == VariableType.CONTINUOUS
+        assert tau.lower is not None and tau.upper is not None
+        assert tau.lower >= 0.1 and tau.upper <= 10.0
+
+    def test_search_space_contains_eps(self, adapter: BanditLogAdapter) -> None:
+        space = adapter.get_search_space()
+        eps = next((v for v in space.variables if v.name == "eps"), None)
+        assert eps is not None
+        assert eps.variable_type == VariableType.CONTINUOUS
+        assert eps.lower == 0.0
+        assert eps.upper == 0.5
+
+    def test_search_space_contains_position_handling_flag(self, adapter: BanditLogAdapter) -> None:
+        space = adapter.get_search_space()
+        flag = next(
+            (v for v in space.variables if v.name == "position_handling_flag"),
+            None,
+        )
+        assert flag is not None
+        assert flag.variable_type == VariableType.CATEGORICAL
+        assert set(flag.choices or []) == {"marginalize", "position_1_only"}
+
+    def test_search_space_contains_3_to_5_context_weights(self, adapter: BanditLogAdapter) -> None:
+        space = adapter.get_search_space()
+        weight_vars = [
+            v
+            for v in space.variables
+            if v.name.startswith("w_") and v.variable_type == VariableType.CONTINUOUS
+        ]
+        assert 3 <= len(weight_vars) <= 5
+
+
+class TestRunExperimentDiagnosticKeys:
+    """Section 4d: required keys in the ``run_experiment`` return dict."""
+
+    _REQUIRED = (
+        "policy_value",
+        "ess",
+        "weight_cv",
+        "max_weight",
+        "zero_support_fraction",
+        "n_effective_actions",
+    )
+
+    def test_run_returns_all_required_keys(
+        self, adapter: BanditLogAdapter, default_params: dict[str, Any]
+    ) -> None:
+        metrics = adapter.run_experiment(default_params)
+        missing = [k for k in self._REQUIRED if k not in metrics]
+        assert missing == [], f"Adapter omitted required keys: {missing}"
+
+    def test_run_returns_only_floats(
+        self, adapter: BanditLogAdapter, default_params: dict[str, Any]
+    ) -> None:
+        metrics = adapter.run_experiment(default_params)
+        for key in self._REQUIRED:
+            assert isinstance(metrics[key], float), f"{key}={metrics[key]!r} is not a float"
+
+
+class TestRunExperimentSemantics:
+    """Semantic invariants on the computed diagnostics."""
+
+    def test_policy_value_is_in_unit_interval(
+        self, adapter: BanditLogAdapter, default_params: dict[str, Any]
+    ) -> None:
+        # SNIPW estimates expected CTR; on binary rewards it must be in [0, 1].
+        metrics = adapter.run_experiment(default_params)
+        pv = metrics["policy_value"]
+        assert 0.0 <= pv <= 1.0, f"policy_value={pv} out of [0, 1]"
+
+    def test_ess_is_positive_when_support_exists(
+        self, adapter: BanditLogAdapter, default_params: dict[str, Any]
+    ) -> None:
+        metrics = adapter.run_experiment(default_params)
+        assert metrics["ess"] > 0.0
+
+    def test_zero_support_fraction_is_zero_when_eps_positive(
+        self, adapter: BanditLogAdapter
+    ) -> None:
+        # With eps > 0 the evaluation policy gives every action >= eps/n mass,
+        # so structurally zero support on the logged action is impossible.
+        metrics = adapter.run_experiment(
+            {
+                "tau": 1.0,
+                "eps": 0.1,
+                "w_item_feature_0": 0.0,
+                "w_user_item_affinity": 0.0,
+                "w_item_popularity": 0.0,
+                "position_handling_flag": "marginalize",
+            }
+        )
+        assert metrics["zero_support_fraction"] == 0.0
+
+    def test_uniform_policy_has_policy_value_near_logged_ctr(
+        self, feedback: dict[str, Any]
+    ) -> None:
+        # Under eps=0.5 with zero feature weights, the evaluation policy is
+        # uniform. SNIPW should then return a policy value close to the
+        # marginal logged reward mean (because every action has equal
+        # propensity under both policies).
+        adapter = BanditLogAdapter(bandit_feedback=feedback, seed=0)
+        metrics = adapter.run_experiment(
+            {
+                "tau": 1.0,
+                "eps": 0.5,
+                "w_item_feature_0": 0.0,
+                "w_user_item_affinity": 0.0,
+                "w_item_popularity": 0.0,
+                "position_handling_flag": "marginalize",
+            }
+        )
+        logged_ctr = float(feedback["reward"].mean())
+        # Wide tolerance — this is a sanity check on the sign/magnitude.
+        assert abs(metrics["policy_value"] - logged_ctr) < 0.01
+
+    def test_position_1_only_restricts_rows(self, feedback: dict[str, Any]) -> None:
+        # position_1_only must subset to position == 0 (0-indexed after rank).
+        # ESS under position_1_only is computed over ~n_rows / len_list rows,
+        # so it should be materially smaller than the marginalize ESS.
+        adapter = BanditLogAdapter(bandit_feedback=feedback, seed=0)
+        base_params: dict[str, Any] = {
+            "tau": 1.0,
+            "eps": 0.1,
+            "w_item_feature_0": 0.5,
+            "w_user_item_affinity": 0.0,
+            "w_item_popularity": 0.0,
+        }
+        m_marg = adapter.run_experiment({**base_params, "position_handling_flag": "marginalize"})
+        m_pos1 = adapter.run_experiment(
+            {**base_params, "position_handling_flag": "position_1_only"}
+        )
+        # Strict inequality would be flaky; check they differ by a
+        # meaningful margin. The marginalize ESS must be materially larger
+        # than the position_1_only ESS because it uses ~3x more rows.
+        assert m_marg["ess"] > m_pos1["ess"] * 1.5
+
+    def test_weight_cv_nonnegative(
+        self, adapter: BanditLogAdapter, default_params: dict[str, Any]
+    ) -> None:
+        metrics = adapter.run_experiment(default_params)
+        assert metrics["weight_cv"] >= 0.0
+
+    def test_max_weight_nonnegative(
+        self, adapter: BanditLogAdapter, default_params: dict[str, Any]
+    ) -> None:
+        metrics = adapter.run_experiment(default_params)
+        assert metrics["max_weight"] >= 0.0
+
+    def test_n_effective_actions_in_valid_range(
+        self, adapter: BanditLogAdapter, feedback: dict[str, Any], default_params: dict[str, Any]
+    ) -> None:
+        metrics = adapter.run_experiment(default_params)
+        n = metrics["n_effective_actions"]
+        assert 1.0 <= n <= float(feedback["n_actions"])
+
+    def test_position_1_only_with_no_matching_rows_returns_pessimistic(self) -> None:
+        # If every row sits at position > 0, position_1_only leaves no
+        # rows to estimate on; the adapter returns a deterministic
+        # pessimistic dict rather than crashing.
+        fb = _synthetic_bandit_feedback(n_rounds=200, n_actions=4, seed=1)
+        fb["position"] = np.full_like(fb["position"], 1)  # all at position 1 (index 1)
+        adapter = BanditLogAdapter(bandit_feedback=fb)
+        metrics = adapter.run_experiment(
+            {
+                "tau": 1.0,
+                "eps": 0.1,
+                "w_item_feature_0": 0.0,
+                "w_user_item_affinity": 0.0,
+                "w_item_popularity": 0.0,
+                "position_handling_flag": "position_1_only",
+            }
+        )
+        assert metrics["policy_value"] == 0.0
+        assert metrics["ess"] == 0.0
+        assert metrics["zero_support_fraction"] == 1.0
+
+    def test_invalid_position_handling_flag_raises(
+        self, adapter: BanditLogAdapter, default_params: dict[str, Any]
+    ) -> None:
+        bad = {**default_params, "position_handling_flag": "all_positions_please"}
+        with pytest.raises(ValueError, match="position_handling_flag"):
+            adapter.run_experiment(bad)
+
+    def test_zero_or_small_context_gracefully_handled(self) -> None:
+        # When ``context`` has fewer columns than n_actions (small
+        # synthetic fixtures), the affinity weight silently contributes
+        # zero. The adapter still returns a valid diagnostic dict.
+        fb = _synthetic_bandit_feedback(n_rounds=200, n_actions=4, seed=2)
+        # Drop context to a single column.
+        fb["context"] = fb["context"][:, :1]
+        adapter = BanditLogAdapter(bandit_feedback=fb)
+        metrics = adapter.run_experiment(
+            {
+                "tau": 1.0,
+                "eps": 0.1,
+                "w_item_feature_0": 0.2,
+                "w_user_item_affinity": 1.0,  # would normally dominate
+                "w_item_popularity": 0.0,
+                "position_handling_flag": "marginalize",
+            }
+        )
+        assert 0.0 <= metrics["policy_value"] <= 1.0
+
+    def test_sharp_softmax_reduces_n_effective_actions(self, adapter: BanditLogAdapter) -> None:
+        # Small tau => sharp softmax => most mass on one action under
+        # non-zero weights => n_effective_actions drops toward 1.
+        params_sharp = {
+            "tau": 0.1,
+            "eps": 0.0,
+            "w_item_feature_0": 2.0,
+            "w_user_item_affinity": 0.0,
+            "w_item_popularity": 0.0,
+            "position_handling_flag": "marginalize",
+        }
+        params_flat = {
+            "tau": 10.0,
+            "eps": 0.0,
+            "w_item_feature_0": 0.1,
+            "w_user_item_affinity": 0.0,
+            "w_item_popularity": 0.0,
+            "position_handling_flag": "marginalize",
+        }
+        m_sharp = adapter.run_experiment(params_sharp)
+        m_flat = adapter.run_experiment(params_flat)
+        assert m_sharp["n_effective_actions"] < m_flat["n_effective_actions"]
+
+
+class TestConstructorValidation:
+    """Clear errors when the input is malformed."""
+
+    def test_missing_required_key_raises(self) -> None:
+        # ``reward`` is required; dropping it must fail fast with a clear
+        # message, not an opaque KeyError deep inside run_experiment.
+        fb = _synthetic_bandit_feedback()
+        del fb["reward"]
+        with pytest.raises(ValueError, match="reward"):
+            BanditLogAdapter(bandit_feedback=fb)
+
+    def test_mismatched_array_length_raises(self) -> None:
+        fb = _synthetic_bandit_feedback()
+        fb["reward"] = fb["reward"][:-1]  # off-by-one
+        with pytest.raises(ValueError):
+            BanditLogAdapter(bandit_feedback=fb)
+
+    def test_non_binary_reward_raises(self) -> None:
+        fb = _synthetic_bandit_feedback()
+        fb["reward"] = fb["reward"].astype(float)
+        fb["reward"][0] = 2.5  # not binary
+        with pytest.raises(ValueError, match="binary"):
+            BanditLogAdapter(bandit_feedback=fb)
+
+    def test_pscore_with_zero_raises(self) -> None:
+        fb = _synthetic_bandit_feedback()
+        fb["pscore"] = fb["pscore"].copy()
+        fb["pscore"][0] = 0.0
+        with pytest.raises(ValueError, match="pscore"):
+            BanditLogAdapter(bandit_feedback=fb)
+
+
+class TestFromObpConstructor:
+    """Section 8c: adapter must fail fast with a clear error if OBP is
+    missing, and must delegate cleanly when OBP is present."""
+
+    def test_from_obp_raises_clear_error_when_obp_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force the adapter's import of obp to fail. The error must be
+        # actionable (name the extra), not a bare ImportError.
+        import sys
+
+        monkeypatch.setitem(sys.modules, "obp", None)
+        monkeypatch.setitem(sys.modules, "obp.dataset", None)
+        with pytest.raises(ImportError, match="bandit"):
+            BanditLogAdapter.from_obp(campaign="men", behavior_policy="random")
+
+    def test_from_obp_delegates_to_open_bandit_dataset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stub out OpenBanditDataset so the classmethod can be exercised
+        # end-to-end without depending on the (broken on modern pandas)
+        # pre_process step inside OBP 0.4.1. This covers the happy-path
+        # loader delegation without hitting real OBP code.
+        import sys
+        import types
+
+        fb = _synthetic_bandit_feedback(n_rounds=400, n_actions=4, len_list=3)
+
+        class _StubDataset:
+            def __init__(self, *, behavior_policy: str, campaign: str, data_path: Any) -> None:
+                self.behavior_policy = behavior_policy
+                self.campaign = campaign
+                self.data_path = data_path
+
+            def obtain_batch_bandit_feedback(self) -> dict[str, Any]:
+                return fb
+
+        fake_obp_module = types.ModuleType("obp")
+        fake_dataset_module = types.ModuleType("obp.dataset")
+        fake_dataset_module.OpenBanditDataset = _StubDataset  # type: ignore[attr-defined]
+        fake_obp_module.dataset = fake_dataset_module  # type: ignore[attr-defined]
+
+        monkeypatch.setitem(sys.modules, "obp", fake_obp_module)
+        monkeypatch.setitem(sys.modules, "obp.dataset", fake_dataset_module)
+
+        adapter = BanditLogAdapter.from_obp(campaign="men", behavior_policy="random", seed=3)
+        assert isinstance(adapter, BanditLogAdapter)
+        # Adapter picked up n_actions from the stubbed feedback dict.
+        assert adapter.get_search_space().dimensionality >= 6
+
+
+class TestPublicInterfaceDoesNotExposeObpTypes:
+    """Section 8c: the adapter must not expose OBP types at the public
+    interface."""
+
+    def test_run_experiment_returns_plain_dict(
+        self, adapter: BanditLogAdapter, default_params: dict[str, Any]
+    ) -> None:
+        metrics = adapter.run_experiment(default_params)
+        # Plain dict of floats, no OBP classes.
+        assert type(metrics) is dict  # noqa: E721 - exact-type check intentional
+        for k, v in metrics.items():
+            assert isinstance(k, str)
+            assert isinstance(v, float)
+
+    def test_get_search_space_returns_causal_optimizer_type(
+        self, adapter: BanditLogAdapter
+    ) -> None:
+        from causal_optimizer.types import SearchSpace
+
+        assert isinstance(adapter.get_search_space(), SearchSpace)

--- a/tests/unit/test_bandit_log_adapter.py
+++ b/tests/unit/test_bandit_log_adapter.py
@@ -422,6 +422,45 @@ class TestConstructorValidation:
         with pytest.raises(ValueError, match="pscore"):
             BanditLogAdapter(bandit_feedback=fb)
 
+    def test_action_out_of_range_raises(self) -> None:
+        fb = _synthetic_bandit_feedback()
+        fb["action"] = fb["action"].copy()
+        fb["action"][0] = fb["n_actions"]  # one past the last valid id
+        with pytest.raises(ValueError, match="action"):
+            BanditLogAdapter(bandit_feedback=fb)
+
+    def test_negative_action_raises(self) -> None:
+        fb = _synthetic_bandit_feedback()
+        fb["action"] = fb["action"].copy()
+        fb["action"][0] = -1
+        with pytest.raises(ValueError, match="action"):
+            BanditLogAdapter(bandit_feedback=fb)
+
+    def test_negative_position_raises(self) -> None:
+        fb = _synthetic_bandit_feedback()
+        fb["position"] = fb["position"].copy()
+        fb["position"][0] = -1
+        with pytest.raises(ValueError, match="position"):
+            BanditLogAdapter(bandit_feedback=fb)
+
+    def test_non_positive_n_rounds_raises(self) -> None:
+        fb = _synthetic_bandit_feedback()
+        fb["n_rounds"] = 0
+        with pytest.raises(ValueError, match="n_rounds"):
+            BanditLogAdapter(bandit_feedback=fb)
+
+    def test_too_few_actions_raises(self) -> None:
+        fb = _synthetic_bandit_feedback(n_actions=2)
+        fb["n_actions"] = 1  # a bandit with one arm is not multi-action
+        with pytest.raises(ValueError, match="n_actions"):
+            BanditLogAdapter(bandit_feedback=fb)
+
+    def test_action_context_with_zero_columns_raises(self) -> None:
+        fb = _synthetic_bandit_feedback()
+        fb["action_context"] = np.zeros((fb["n_actions"], 0))
+        with pytest.raises(ValueError, match="action_context"):
+            BanditLogAdapter(bandit_feedback=fb)
+
 
 class TestFromObpConstructor:
     """Section 8c: adapter must fail fast with a clear error if OBP is

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,11 @@ all = [
     { name = "dowhy", version = "0.12", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
     { name = "dowhy", version = "0.14", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "gpytorch" },
+    { name = "obp" },
     { name = "pydoe3" },
+]
+bandit = [
+    { name = "obp" },
 ]
 bayesian = [
     { name = "ax-platform", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -280,12 +284,13 @@ doe = [
 requires-dist = [
     { name = "ax-platform", marker = "extra == 'bayesian'", specifier = ">=0.4.0" },
     { name = "botorch", marker = "extra == 'bayesian'", specifier = ">=0.9.0" },
-    { name = "causal-optimizer", extras = ["bayesian", "doe", "causal"], marker = "extra == 'all'" },
+    { name = "causal-optimizer", extras = ["bayesian", "doe", "causal", "bandit"], marker = "extra == 'all'" },
     { name = "dowhy", marker = "extra == 'causal'", specifier = ">=0.11" },
     { name = "gpytorch", marker = "extra == 'bayesian'", specifier = ">=1.11" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
     { name = "networkx", specifier = ">=3.1" },
     { name = "numpy", specifier = ">=1.24.0" },
+    { name = "obp", marker = "extra == 'bandit'", specifier = ">=0.4.1,<0.5" },
     { name = "pandas", specifier = ">=2.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -297,7 +302,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.3.0" },
     { name = "scipy", specifier = ">=1.11.0" },
 ]
-provides-extras = ["bayesian", "doe", "causal", "all", "dev"]
+provides-extras = ["bayesian", "doe", "causal", "bandit", "all", "dev"]
 
 [[package]]
 name = "cffi"
@@ -2305,6 +2310,31 @@ wheels = [
 ]
 
 [[package]]
+name = "obp"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "mypy-extensions" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyyaml" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-learn", version = "1.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "seaborn" },
+    { name = "torch" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/82/05d52ac51c4c944fa297f69d4c5b99392cef1af5cbb078c836f774f71333/obp-0.4.1.tar.gz", hash = "sha256:4be96fae9ba4f7a0cff3e313209e767c466f1b940bbc203c4238cc23f1241d15", size = 1246136, upload-time = "2021-06-30T03:08:41.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/55/3df1cda2409f601c2414c74f9fbeb0f270edee62a13f7858d383f40aa87f/obp-0.4.1-py3-none-any.whl", hash = "sha256:87dec9caf4283c25ab13036532e0a24566f1c7bdcad1653a8ded43b2f5ef8208", size = 1338290, upload-time = "2021-06-30T03:08:37.374Z" },
+]
+
+[[package]]
 name = "opt-einsum"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3466,6 +3496,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/eb/2c07015938c50f46e9323e379e9799c3e28e0d07c9bae8b6735a6ecf1b6c/scs-3.2.11-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c166768dc87c389b2d000b5dcd472bb0ba40f96b4cf0e63c0fb603a4a5c80db", size = 12080259, upload-time = "2026-01-09T17:53:38.897Z" },
     { url = "https://files.pythonhosted.org/packages/f2/1b/d52e3b17554791726ba788abff053f4b27df157a49438f01134fec3c859d/scs-3.2.11-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f51a14a5315974fae4ca4e1b4dc8926f872eca7e66b42e070dbdcfa6904b7860", size = 11974311, upload-time = "2026-01-09T17:53:41.003Z" },
     { url = "https://files.pythonhosted.org/packages/cb/d7/023ba290cfaf97b21c710b675b8a860b97d8226f62e35d7a08e37ddbb6d3/scs-3.2.11-cp314-cp314t-win_amd64.whl", hash = "sha256:7fe26e8a0efc96232f4c5b7649817e48dae04a61be911417e925071091b8cbf6", size = 7570221, upload-time = "2026-01-09T17:53:42.845Z" },
+]
+
+[[package]]
+name = "seaborn"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "matplotlib" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "pandas", version = "3.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/86/59/a451d7420a77ab0b98f7affa3a1d78a313d2f7281a57afb1a34bae8ab412/seaborn-0.13.2.tar.gz", hash = "sha256:93e60a40988f4d65e9f4885df477e2fdaff6b73a9ded434c1ab356dd57eefff7", size = 1457696, upload-time = "2024-01-25T13:21:52.551Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/11/00d3c3dfc25ad54e731d91449895a79e4bf2384dc3ac01809010ba88f6d5/seaborn-0.13.2-py3-none-any.whl", hash = "sha256:636f8336facf092165e27924f223d3c62ca560b1f2bb5dff7ab7fad265361987", size = 294914, upload-time = "2024-01-25T13:21:49.598Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the Sprint 34 Open Bandit contract Sections 4 and 8 for Track A of issue #185. Ships a new `BanditLogAdapter` that does **not** subclass `MarketingLogAdapter` (contract Section 4a), parameterized as a six-variable contextual item-scoring policy (`tau`, `eps`, three context-feature weights, `position_handling_flag`) and evaluated with a minimal in-house SNIPW-style estimator over a logged multi-action bandit-feedback dict.

Also adds an optional `bandit` extra pinning `obp==0.4.1` (Apache 2.0) so the Open Bandit Pipeline data loader is available via `BanditLogAdapter.from_obp` while the core install stays OBP-free. The adapter fails fast with an actionable error when OBP is missing (contract Section 8c).

Track A scope boundary: the adapter ships the Section 4 interface surface and a narrow first-pass SNIPW-style `policy_value` calculation so the adapter is reviewable end-to-end without blocking on the OPE stack. Track B (issue #186) owns the production OPE stack (OBP-backed SNIPW / DM / DR + Section 7 support gates + DR/SNIPW cross-check).

Closes #185.

## Section 10.A smoke-test findings (pinned in the adapter docstring)

1. **Row count.** The `obp==0.4.1` wheel bundles a 10,000-row sample of the Men/Random slice. The full ~452,949-row slice (Saito et al. 2021 Table 1) requires passing `data_path=` to `BanditLogAdapter.from_obp`; Issue C will exercise that path.
2. **`action_prob` / `pscore` schema.** Confirmed as **conditional `P(item | position)`**. Empirical mean `0.029412` matches `1/n_items = 1/34` to floating-point precision; not joint `1/(34*3) ≈ 0.0098`. Section 7d's propensity-mean sanity gate should therefore use the `1/n_items` target on Men/Random.
3. **Chosen three context features** (Section 4c):
   - `w_item_feature_0` — per-item continuous feature from `item_context.csv` (range ≈ `[-0.73, 0.75]`).
   - `w_user_item_affinity` — per-row per-candidate affinity lookup (34 columns in the raw log).
   - `w_item_popularity` — per-item log-normalized in-log appearance count, pre-computed at construction.

## Files touched

- `pyproject.toml` — new `bandit` optional extra, new `obp` pytest marker.
- `causal_optimizer/domain_adapters/bandit_log.py` (new) — `BanditLogAdapter` implementation.
- `causal_optimizer/domain_adapters/__init__.py` — export `BanditLogAdapter`.
- `tests/unit/test_bandit_log_adapter.py` (new) — 32 fast tests against synthetic bandit-feedback dicts.
- `tests/integration/test_bandit_log_adapter_smoke.py` (new) — 5 slow tests against the bundled OBP Men/Random sample.

## Test plan

- [x] `uv run pytest tests/unit/test_bandit_log_adapter.py` — 32 passed
- [x] `uv run pytest tests/integration/test_bandit_log_adapter_smoke.py -m slow` — 5 passed
- [x] `uv run pytest -m "not slow"` — 1201 passed, 24 skipped (full fast suite green)
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — no diff
- [x] `uv run mypy causal_optimizer/` — 63 source files clean (strict mode)

## Known caveats

- OBP 0.4.1's `pre_process()` calls `DataFrame.drop(..., 1)` with a positional `axis` argument that modern pandas rejects. The smoke test reads the bundled CSVs directly to bypass that pre-processor. Issue B / Issue C can switch to a patched loader later; the adapter boundary does not depend on `pre_process()`.
- Coverage reporting (`--cov`) fails in the local dev environment under `numpy==2.4.2` with "cannot load module more than once per process" — pre-existing on `main` for every numpy-touching test file, not a regression. All meaningful branches in `bandit_log.py` are exercised by explicit tests (validation error paths, both position flags, zero-active-rows fallback, invalid flag, narrow-context fallback, `from_obp` missing + success-delegation stub).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR ships `BanditLogAdapter`, a new `DomainAdapter` for logged multi-action bandit-feedback data implementing the Sprint 34 Open Bandit contract Sections 4 and 8. It adds a six-variable contextual item-scoring policy with a self-normalized IPW-style estimator, optional OBP data-loading via `from_obp`, and 37 tests (32 unit + 5 integration smoke tests against the bundled Men/Random slice).

Both concerns flagged in the previous review are resolved — the `pytestmark` at line 27 now correctly applies both `slow` and `obp` marks, and the `isinstance` guard in `from_obp` uses a real `TypeError` rather than a strippable `assert`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 issues found; both prior review concerns are resolved.

Both previous findings (missing obp marker and assert-based runtime guard) are correctly addressed. The SNIPW estimator, softmax, validation logic, and all edge-case paths are sound. The 37-test suite is comprehensive and the integration smoke test now applies the correct dual slow+obp pytestmark. No new blocking issues identified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| causal_optimizer/domain_adapters/bandit_log.py | New BanditLogAdapter: thorough validation, numerically stable softmax, correct SNIPW estimator, and well-bounded diagnostic dict. No logic errors found. |
| tests/unit/test_bandit_log_adapter.py | 32 fast unit tests covering all validation paths, semantic invariants, position flag behavior, and the OBP lazy-import contract. Well-structured. |
| tests/integration/test_bandit_log_adapter_smoke.py | 5 smoke tests against bundled Men/Random slice; pytestmark now correctly applies both slow and obp markers (addresses previous review thread). |
| pyproject.toml | Adds bandit optional extra pinning obp>=0.4.1,<0.5 and registers the obp pytest marker. Upper-bound on obp protects against API churn. |
| causal_optimizer/domain_adapters/__init__.py | Exports BanditLogAdapter; alphabetically ordered and __all__ updated correctly. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant BanditLogAdapter
    participant OBP as OpenBanditDataset (optional)
    participant SNIPW as SNIPW Estimator

    alt Direct construction
        Caller->>BanditLogAdapter: __init__(bandit_feedback, seed)
        BanditLogAdapter->>BanditLogAdapter: _validate_feedback()
        BanditLogAdapter->>BanditLogAdapter: pre-compute item_feature_0, affinity, popularity
    else Via OBP loader
        Caller->>BanditLogAdapter: from_obp(campaign, behavior_policy, data_path)
        BanditLogAdapter->>OBP: lazy import obp.dataset (fails fast if missing)
        OBP-->>BanditLogAdapter: OpenBanditDataset
        BanditLogAdapter->>OBP: obtain_batch_bandit_feedback()
        OBP-->>BanditLogAdapter: bandit_feedback dict
        BanditLogAdapter->>BanditLogAdapter: __init__(bandit_feedback, seed)
    end

    Caller->>BanditLogAdapter: run_experiment(parameters)
    BanditLogAdapter->>BanditLogAdapter: apply position mask
    BanditLogAdapter->>BanditLogAdapter: score = item + affinity + popularity terms
    BanditLogAdapter->>BanditLogAdapter: policy = softmax(score/tau) mixed with eps*uniform
    BanditLogAdapter->>SNIPW: weights = pi_e(a|x) / pi_b(a|x)
    SNIPW-->>BanditLogAdapter: policy_value = sum(w*r) / sum(w)
    BanditLogAdapter-->>Caller: diagnostic dict (6 float keys)
```

<sub>Reviews (3): Last reviewed commit: ["address claude review feedback (claudelo..."](https://github.com/datablogin/causal-optimizer/commit/64d89ef834df4b6398814f5a53f9379e131e20d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28929664)</sub>

<!-- /greptile_comment -->