### PR TITLE
Sprint 35 bridge: wire BanditLogAdapter into the Open Bandit OPE path

### DIFF
--- a/causal_optimizer/benchmarks/open_bandit.py
+++ b/causal_optimizer/benchmarks/open_bandit.py
@@ -59,6 +59,9 @@ Public API
 - :class:`DrSnipwCrossCheckResult`
 - :class:`GateReport`
 - :data:`OBP_VERSION_PLACEHOLDER`
+- :data:`OBP_VERSION_UNAVAILABLE`
+- :func:`get_obp_version`
+- :func:`normalize_positions`
 """
 
 from __future__ import annotations
@@ -90,10 +93,82 @@ PropensitySchema = Literal["conditional", "joint"]
 OBP_VERSION_PLACEHOLDER: str = "<OBP version pin TBD — populate from obp.__version__ in Issue A>"
 """Provenance hook for the OBP version string.
 
-Issue A will replace this by reading ``obp.__version__`` from the
-optional extra at run time.  Track B keeps it as a static placeholder
-so the diagnostic dict always carries the key.
+Retained as a public constant so downstream callers can assert
+"provenance has been wired" by checking for inequality against this
+value.  The Sprint 35 bridge (issue #190) replaces it at runtime via
+:func:`get_obp_version`; Track B kept it as a static placeholder so the
+diagnostic dict always carries the key before the bridge landed.
 """
+
+OBP_VERSION_UNAVAILABLE: str = "obp-unavailable (bandit extra not installed)"
+"""Sentinel returned by :func:`get_obp_version` when ``obp`` is absent.
+
+The bandit extra is optional; a caller running without it still needs
+provenance to round-trip cleanly, so the helper returns this explicit
+string rather than raising.  It is deliberately distinct from
+:data:`OBP_VERSION_PLACEHOLDER` so tests can tell the two states apart.
+"""
+
+
+def get_obp_version() -> str:
+    """Return the installed OBP version string, or a graceful-degradation sentinel.
+
+    The Sprint 34 contract (Section 8c) pins OBP to the 0.4.x series
+    and records the exact version in every gate-report provenance dict
+    for reproducibility.  This helper is the single source of truth for
+    that lookup:
+
+    - When the ``bandit`` extra is installed, returns ``obp.__version__``
+      (e.g. ``"0.4.1"``).
+    - When the extra is missing, returns :data:`OBP_VERSION_UNAVAILABLE`
+      so the provenance dict keeps the key and any downstream report
+      reads an explicit sentinel rather than crashing.
+
+    The import is lazy: Track B core code must stay importable without
+    the optional extra, so the ``import`` lives inside the function.
+    """
+    try:
+        import obp  # noqa: PLC0415 — lazy import keeps ``bandit`` extra optional
+    except ImportError:
+        return OBP_VERSION_UNAVAILABLE
+    version = getattr(obp, "__version__", None)
+    if not isinstance(version, str) or not version:
+        # Defensive: a forked OBP with no __version__ attribute should
+        # still produce a usable provenance string rather than raising.
+        return OBP_VERSION_UNAVAILABLE
+    return version
+
+
+def normalize_positions(position: np.ndarray) -> np.ndarray:
+    """Remap any integer position labels to 0-indexed contiguous integers.
+
+    OBD-style loaders emit positions as ``{1, 2, 3}`` or
+    (post-filtering) as non-contiguous labels like ``{5, 10, 20}``.
+    Track B's :func:`_validate_positions` fails loudly on both, so the
+    Sprint 35 bridge pipes raw positions through this helper before the
+    OPE wrapper consumes them.
+
+    Ranks are assigned in ascending order of unique value, so the
+    relative order of position strata is preserved.  Shape and row
+    ordering are unchanged; dtype is coerced to ``int64`` so the
+    downstream validator sees the expected integer kind.
+
+    Args:
+        position: 1-D integer array of per-row position labels.
+
+    Returns:
+        A new array of the same shape whose values form 0-indexed
+        contiguous integers.  An empty input returns an empty array.
+    """
+    arr: np.ndarray = np.asarray(position, dtype=np.int64)
+    if arr.size == 0:
+        empty: np.ndarray = arr.copy()
+        return empty
+    unique_sorted = np.unique(arr)
+    # ``np.searchsorted`` maps each element to its 0-based index in the
+    # sorted unique list — the canonical dense-rank remap.
+    ranked: np.ndarray = np.searchsorted(unique_sorted, arr).astype(np.int64)
+    return ranked
 
 
 # ── Propensity clip floor ────────────────────────────────────────────
@@ -929,7 +1004,7 @@ def run_section_7_gates(
         tolerance_relative=dr_snipw_tolerance_relative,
     )
     provenance = {
-        "obp_version": OBP_VERSION_PLACEHOLDER,
+        "obp_version": get_obp_version(),
         "schema": schema,
         "n_actions": n_actions,
         "n_positions": n_positions,

--- a/causal_optimizer/benchmarks/open_bandit.py
+++ b/causal_optimizer/benchmarks/open_bandit.py
@@ -159,8 +159,19 @@ def normalize_positions(position: np.ndarray) -> np.ndarray:
     Returns:
         A new array of the same shape whose values form 0-indexed
         contiguous integers.  An empty input returns an empty array.
+
+    Raises:
+        ValueError: If ``position`` is not one-dimensional. A 2-D input
+            would silently pass through ``np.unique`` + ``np.searchsorted``
+            with flattening semantics and produce a misleading result, so
+            the helper fails fast instead.
     """
     arr: np.ndarray = np.asarray(position, dtype=np.int64)
+    if arr.ndim != 1:
+        raise ValueError(
+            "normalize_positions expects a 1-D array of per-row position "
+            f"labels; got ndim={arr.ndim} with shape {arr.shape!r}."
+        )
     if arr.size == 0:
         empty: np.ndarray = arr.copy()
         return empty

--- a/causal_optimizer/domain_adapters/bandit_log.py
+++ b/causal_optimizer/domain_adapters/bandit_log.py
@@ -71,6 +71,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from causal_optimizer.benchmarks.open_bandit import (
+    PROPENSITY_SCHEMA_CONDITIONAL,
+    PropensitySchema,
+    normalize_positions,
+)
 from causal_optimizer.domain_adapters.base import DomainAdapter
 from causal_optimizer.types import SearchSpace, Variable, VariableType
 
@@ -162,6 +167,12 @@ class BanditLogAdapter(DomainAdapter):
     (``policy_value``, ``ess``, ``weight_cv``, ``max_weight``,
     ``zero_support_fraction``, ``n_effective_actions``).
     """
+
+    # Sprint 35 bridge (issue #190): the Men/Random slice stores
+    # ``action_prob`` as conditional ``P(item | position) = 1 / n_items``.
+    # The adapter advertises this so callers threading feedback into
+    # :func:`run_section_7_gates` pass the right ``schema``.
+    propensity_schema: PropensitySchema = PROPENSITY_SCHEMA_CONDITIONAL
 
     def __init__(
         self,
@@ -455,6 +466,38 @@ class BanditLogAdapter(DomainAdapter):
             "max_weight": max_weight,
             "zero_support_fraction": zero_support_fraction,
             "n_effective_actions": n_effective_actions,
+        }
+
+    # ── Sprint 35 bridge: adapter → OPE feedback dict ─────────────────
+
+    def to_bandit_feedback(self) -> dict[str, Any]:
+        """Return an OBP-shaped ``bandit_feedback`` dict for the OPE stack.
+
+        Produces the exact dict shape that
+        :func:`causal_optimizer.benchmarks.open_bandit.evaluate_open_bandit_policy`
+        (and :func:`run_section_7_gates`) consume. Positions are piped
+        through :func:`normalize_positions` so Track B's
+        ``_validate_positions`` — which rejects anything that is not
+        0-indexed contiguous integers — accepts the output.
+
+        The dict uses fresh ndarray copies of the adapter's internal
+        arrays so the caller cannot mutate adapter state by editing the
+        returned dict.
+
+        Returns:
+            A dict with the keys ``n_rounds``, ``n_actions``, ``action``,
+            ``reward``, ``pscore``, ``position``, ``context``, and
+            ``action_context``.  ``position`` is 0-indexed contiguous.
+        """
+        return {
+            "n_rounds": int(self._n_rounds),
+            "n_actions": int(self._n_actions),
+            "action": self._action.copy(),
+            "reward": self._reward.copy(),
+            "pscore": self._pscore.copy(),
+            "position": normalize_positions(self._position),
+            "context": self._context.copy(),
+            "action_context": self._action_context.copy(),
         }
 
     def get_prior_graph(self) -> CausalGraph | None:

--- a/causal_optimizer/domain_adapters/bandit_log.py
+++ b/causal_optimizer/domain_adapters/bandit_log.py
@@ -67,7 +67,7 @@ actionable error if ``obp`` is missing.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import numpy as np
 
@@ -171,8 +171,11 @@ class BanditLogAdapter(DomainAdapter):
     # Sprint 35 bridge (issue #190): the Men/Random slice stores
     # ``action_prob`` as conditional ``P(item | position) = 1 / n_items``.
     # The adapter advertises this so callers threading feedback into
-    # :func:`run_section_7_gates` pass the right ``schema``.
-    propensity_schema: PropensitySchema = PROPENSITY_SCHEMA_CONDITIONAL
+    # :func:`run_section_7_gates` pass the right ``schema``. Typed as
+    # ``ClassVar`` to document that it is a per-class constant shared by
+    # all instances (not a per-instance attribute) and to let type
+    # checkers catch accidental instance-level shadowing.
+    propensity_schema: ClassVar[PropensitySchema] = PROPENSITY_SCHEMA_CONDITIONAL
 
     def __init__(
         self,
@@ -495,6 +498,10 @@ class BanditLogAdapter(DomainAdapter):
             "action": self._action.copy(),
             "reward": self._reward.copy(),
             "pscore": self._pscore.copy(),
+            # ``normalize_positions`` already returns a fresh ndarray
+            # (``np.searchsorted`` + ``.astype`` allocate a new array), so
+            # no extra ``.copy()`` is needed here. Do not add one — it
+            # would be a redundant allocation.
             "position": normalize_positions(self._position),
             "context": self._context.copy(),
             "action_context": self._action_context.copy(),

--- a/causal_optimizer/domain_adapters/bandit_log.py
+++ b/causal_optimizer/domain_adapters/bandit_log.py
@@ -175,6 +175,11 @@ class BanditLogAdapter(DomainAdapter):
     # ``ClassVar`` to document that it is a per-class constant shared by
     # all instances (not a per-instance attribute) and to let type
     # checkers catch accidental instance-level shadowing.
+    #
+    # Men/Random-specific. BTS (Bernoulli Thompson Sampling) and other
+    # logging policies may use joint ``P(item, position)`` propensities;
+    # a future BTS-specific subclass should override this constant at
+    # the class level rather than mutating it per-instance.
     propensity_schema: ClassVar[PropensitySchema] = PROPENSITY_SCHEMA_CONDITIONAL
 
     def __init__(

--- a/tests/integration/test_open_bandit_bridge.py
+++ b/tests/integration/test_open_bandit_bridge.py
@@ -56,12 +56,20 @@ def _build_men_random_like_feedback(
     Uses conditional ``P(item | position) = 1 / n_actions`` to mirror the
     empirical OBD finding from Sprint 35.A. Positions are deliberately
     emitted 1-indexed so the test can prove the bridge remaps them.
+
+    ``n_positions`` drives the number of distinct position labels
+    emitted; labels are 1-indexed (``1..n_positions``) so the bridge
+    test exercises the 1→0 remap of :func:`normalize_positions`.
     """
     rng = np.random.default_rng(seed)
     action = rng.integers(low=0, high=n_actions, size=n_rounds).astype(np.int64)
-    # Emit positions as 1-indexed + non-contiguous (1, 2, 3 with gaps
-    # later simulated by picking {1, 3}), to exercise the remap path.
-    raw_positions = rng.choice([1, 2, 3], size=n_rounds).astype(np.int64)
+    # Emit positions as 1-indexed contiguous integers in the range
+    # ``[1, n_positions]``. ``normalize_positions`` must remap these to
+    # 0-indexed contiguous integers before Track B's ``_validate_positions``
+    # consumes them.
+    raw_positions = rng.choice(np.arange(1, n_positions + 1, dtype=np.int64), size=n_rounds).astype(
+        np.int64
+    )
     reward = rng.binomial(n=1, p=0.03, size=n_rounds).astype(float)
     pscore = np.full(n_rounds, 1.0 / n_actions, dtype=float)
     context = rng.standard_normal((n_rounds, n_actions)).astype(float)
@@ -113,6 +121,15 @@ class TestPositionNormalization:
         raw = np.array([], dtype=np.int64)
         out = normalize_positions(raw)
         assert out.shape == (0,)
+
+    def test_normalize_positions_rejects_non_1d_input(self) -> None:
+        # A 2-D array would pass through ``np.unique`` + ``np.searchsorted``
+        # with flattening semantics and silently produce a misleading
+        # result, so the helper must fail fast with a ``ValueError`` that
+        # names the bad shape.
+        raw = np.array([[1, 2], [3, 4]], dtype=np.int64)
+        with pytest.raises(ValueError, match="1-D array"):
+            normalize_positions(raw)
 
 
 # ── Seam 2: OBP version provenance ────────────────────────────────────

--- a/tests/integration/test_open_bandit_bridge.py
+++ b/tests/integration/test_open_bandit_bridge.py
@@ -179,6 +179,13 @@ class TestObpVersionProvenance:
         # This test needs ``obp`` importable so we can strip the
         # attribute off a real module object; skip cleanly if the
         # optional ``bandit`` extra is not installed.
+        #
+        # Note: ``monkeypatch.delattr(obp, "__version__")`` mutates the
+        # same module object cached in ``sys.modules``. ``get_obp_version``
+        # re-imports via ``import obp``, which returns that cached object
+        # (not a reloaded one), so it sees the missing attribute. If
+        # :func:`get_obp_version` ever uses ``importlib.reload``, this
+        # test would need a ``sys.modules`` reset instead.
         obp = pytest.importorskip("obp", reason="requires optional 'bandit' extra")
 
         monkeypatch.delattr(obp, "__version__", raising=False)
@@ -346,6 +353,13 @@ class TestBridgeEndToEnd:
     """
 
     def test_full_bridge_flow_produces_clean_gate_report(self) -> None:
+        # The final provenance assertion pins against ``obp.__version__``,
+        # so skip the whole test cleanly up-front when the optional
+        # ``bandit`` extra is absent. Placing this at the top avoids
+        # burning CI compute on the Men/Random feedback build + gate run
+        # only to skip at the last line.
+        obp = pytest.importorskip("obp", reason="requires optional 'bandit' extra")
+
         n_rounds = 2_000
         n_actions = 34
         n_positions = 3
@@ -421,14 +435,11 @@ class TestBridgeEndToEnd:
         assert report.propensity_sanity.target == pytest.approx(1.0 / n_actions)
 
         # Seam: provenance carries a real OBP version, not the Track B
-        # placeholder.
+        # placeholder. ``obp`` was bound at the top of the test via
+        # ``pytest.importorskip``, so it's guaranteed importable here.
         provenance = report.provenance
         assert "obp_version" in provenance
         assert provenance["obp_version"] != OBP_VERSION_PLACEHOLDER
-        # Installed via the ``bandit`` extra (skip if someone runs this
-        # test without the extra, but the top-level pytest marker would
-        # have already excluded it — we guard defensively).
-        obp = pytest.importorskip("obp")
         assert provenance["obp_version"] == obp.__version__
         # Schema is recorded in provenance for reproducibility.
         assert provenance["schema"] == PROPENSITY_SCHEMA_CONDITIONAL

--- a/tests/integration/test_open_bandit_bridge.py
+++ b/tests/integration/test_open_bandit_bridge.py
@@ -122,7 +122,7 @@ class TestObpVersionProvenance:
     optional extra is installed and a sentinel otherwise."""
 
     def test_get_obp_version_returns_real_version_when_installed(self) -> None:
-        obp = pytest.importorskip("obp")
+        obp = pytest.importorskip("obp", reason="requires optional 'bandit' extra")
         version = get_obp_version()
         assert isinstance(version, str)
         assert version == obp.__version__
@@ -158,7 +158,10 @@ class TestObpVersionProvenance:
     ) -> None:
         # Defense-in-depth: a forked OBP without ``__version__`` must
         # still produce a usable provenance string rather than raising.
-        import obp
+        # This test needs ``obp`` importable so we can strip the
+        # attribute off a real module object; skip cleanly if the
+        # optional ``bandit`` extra is not installed.
+        obp = pytest.importorskip("obp", reason="requires optional 'bandit' extra")
 
         monkeypatch.delattr(obp, "__version__", raising=False)
         version = get_obp_version()

--- a/tests/integration/test_open_bandit_bridge.py
+++ b/tests/integration/test_open_bandit_bridge.py
@@ -157,6 +157,14 @@ class TestObpVersionProvenance:
         # sentinel string so downstream provenance dicts keep the key
         # under graceful-degradation conditions.
         import builtins
+        import sys
+
+        # Evict any previously-imported ``obp`` module from ``sys.modules``
+        # so the lazy ``import obp`` inside ``get_obp_version`` actually
+        # re-enters the import machinery and hits the patched
+        # ``__import__`` below.  Without this, a prior test that imported
+        # ``obp`` would leave it cached and the patch would be bypassed.
+        monkeypatch.delitem(sys.modules, "obp", raising=False)
 
         real_import = builtins.__import__
 

--- a/tests/integration/test_open_bandit_bridge.py
+++ b/tests/integration/test_open_bandit_bridge.py
@@ -170,6 +170,66 @@ class TestObpVersionProvenance:
         assert version != OBP_VERSION_PLACEHOLDER
         assert "unavailable" in version.lower() or "not installed" in version.lower()
 
+    def test_get_obp_version_returns_sentinel_when_version_attr_is_non_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # CI runs the default matrix without the ``bandit`` extra, so we
+        # inject a synthetic ``obp`` module into ``sys.modules`` to cover
+        # the defensive guard path (``isinstance(version, str)``) without
+        # depending on an installed OBP. Exercises the ``not isinstance``
+        # branch of :func:`get_obp_version`.
+        import sys
+        import types
+
+        fake_obp = types.ModuleType("obp")
+        fake_obp.__version__ = 0.41  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "obp", fake_obp)
+
+        version = get_obp_version()
+        assert isinstance(version, str)
+        assert version != OBP_VERSION_PLACEHOLDER
+        assert "unavailable" in version.lower() or "not installed" in version.lower()
+
+    def test_get_obp_version_returns_sentinel_when_version_attr_is_empty_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Exercises the ``not version`` branch of :func:`get_obp_version`:
+        # a module that ships with ``__version__ = ""`` must still yield
+        # the sentinel rather than the empty string, so provenance dicts
+        # never carry a blank version. Injects a synthetic module so the
+        # test runs on CI without the optional ``bandit`` extra.
+        import sys
+        import types
+
+        fake_obp = types.ModuleType("obp")
+        fake_obp.__version__ = ""  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "obp", fake_obp)
+
+        version = get_obp_version()
+        assert isinstance(version, str)
+        assert version != OBP_VERSION_PLACEHOLDER
+        assert "unavailable" in version.lower() or "not installed" in version.lower()
+
+    def test_get_obp_version_returns_version_string_from_synthetic_module(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Happy-path coverage on CI runners that do not install the
+        # ``bandit`` extra: inject a synthetic ``obp`` module exposing a
+        # non-empty string ``__version__`` and verify the helper returns
+        # it verbatim (not the sentinel). Mirrors what a real ``obp`` pin
+        # would produce, so the success branch of :func:`get_obp_version`
+        # is exercised regardless of extra availability.
+        import sys
+        import types
+
+        fake_obp = types.ModuleType("obp")
+        fake_obp.__version__ = "0.4.1"  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "obp", fake_obp)
+
+        version = get_obp_version()
+        assert version == "0.4.1"
+        assert version != OBP_VERSION_PLACEHOLDER
+
 
 # ── Seam 3: conditional schema propagation ────────────────────────────
 

--- a/tests/integration/test_open_bandit_bridge.py
+++ b/tests/integration/test_open_bandit_bridge.py
@@ -40,6 +40,7 @@ from causal_optimizer.benchmarks.open_bandit import (
     evaluate_open_bandit_policy,
     get_obp_version,
     normalize_positions,
+    peaked_policy,
     propensity_sanity_gate,
     run_section_7_gates,
     uniform_policy,
@@ -290,25 +291,33 @@ class TestBridgeEndToEnd:
             "random": uniform_policy(n_rounds=n_rows_used, n_actions=n_actions),
         }
 
-        # Seeded per-seed diagnostics so all gates have well-defined
-        # inputs. We evaluate the same uniform policy on the adapter's
-        # feedback so SNIPW ≈ mean reward, DR ≈ mean reward, and their
-        # relative divergence is ~0 — cross-check gate passes.
+        # Per-seed diagnostics: vary ``peak_mass`` across seeds so each
+        # iteration produces a distinct evaluation policy, giving the
+        # multi-seed ESS / zero-support / DR-SNIPW gates non-trivial
+        # inputs. Peak masses stay close to uniform so the uniform
+        # logger retains support on the peaked action — keeps
+        # zero_support ≈ 0 and SNIPW/DR aligned across seeds.
         clip = 1.0 / (2 * n_actions * n_positions)
         per_seed_ess: list[float] = []
         per_seed_zero_support: list[float] = []
         snipw_per_seed: list[float] = []
         dr_per_seed: list[float] = []
-        for _ in range(3):
-            out = evaluate_open_bandit_policy(
-                bf,
-                uniform_policy(n_rounds=n_rows_used, n_actions=n_actions),
-                min_propensity_clip=clip,
+        for seed_idx, peak_mass in enumerate([0.05, 0.08, 0.12]):
+            pol = peaked_policy(
+                n_rounds=n_rows_used,
+                n_actions=n_actions,
+                best_action=seed_idx % n_actions,
+                peak_mass=peak_mass,
             )
+            out = evaluate_open_bandit_policy(bf, pol, min_propensity_clip=clip)
             per_seed_ess.append(out["ess"])
             per_seed_zero_support.append(out["zero_support_fraction"])
             snipw_per_seed.append(out["policy_value"])
-            dr_per_seed.append(out["policy_value"])  # uniform ↔ uniform parity
+            # Near-uniform logger × near-uniform eval policy → DR ≈ SNIPW
+            # per-seed; reusing the SNIPW point here keeps the
+            # cross-check gate inside its 25% relative band while still
+            # exposing per-seed variation via distinct policies.
+            dr_per_seed.append(out["policy_value"])
 
         # Seam: conditional schema propagation into the gate bundle.
         report = run_section_7_gates(

--- a/tests/integration/test_open_bandit_bridge.py
+++ b/tests/integration/test_open_bandit_bridge.py
@@ -1,0 +1,358 @@
+"""Sprint 35 bridge integration test: wire ``BanditLogAdapter`` into the
+Open Bandit OPE path.
+
+Covers the three known seams in a single end-to-end flow so Issue #187
+(the Sprint 35.C benchmark report) can consume a ready-to-run path:
+
+1. **Position normalization.** Track B's ``_validate_positions`` fails
+   loudly on anything other than 0-indexed contiguous integers. The
+   bridge must remap OBD-style positions before the OPE wrapper (and
+   ``run_section_7_gates``) consume them.
+2. **Conditional propensity schema propagation.** Men/Random's
+   ``action_prob`` is conditional ``P(item | position)``; the
+   :func:`propensity_sanity_gate` default is joint. The bridge must
+   thread ``PROPENSITY_SCHEMA_CONDITIONAL`` into the gate when the
+   adapter was built for Men/Random so the gate targets ``1/n_items``
+   instead of ``1/(n_items * n_positions)``.
+3. **Non-placeholder OBP version provenance.** The merged Track B
+   placeholder (``OBP_VERSION_PLACEHOLDER``) must be swapped for the
+   real ``obp.__version__`` string in the ``GateReport.provenance``
+   dict. The bridge writes the version via a public helper so a missing
+   optional extra reports an explicit sentinel rather than crashing.
+
+The test also exercises the narrow ``BanditLogAdapter.to_bandit_feedback``
+helper surface, which converts adapter state into the OBP-shaped dict
+the Track B evaluator consumes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from causal_optimizer.benchmarks.open_bandit import (
+    OBP_VERSION_PLACEHOLDER,
+    PROPENSITY_SCHEMA_CONDITIONAL,
+    PROPENSITY_SCHEMA_JOINT,
+    GateReport,
+    evaluate_open_bandit_policy,
+    get_obp_version,
+    normalize_positions,
+    propensity_sanity_gate,
+    run_section_7_gates,
+    uniform_policy,
+)
+from causal_optimizer.domain_adapters.bandit_log import BanditLogAdapter
+
+
+def _build_men_random_like_feedback(
+    *, n_rounds: int, n_actions: int, n_positions: int, seed: int
+) -> dict[str, Any]:
+    """Return a Men/Random-shaped feedback dict for the bridge test.
+
+    Uses conditional ``P(item | position) = 1 / n_actions`` to mirror the
+    empirical OBD finding from Sprint 35.A. Positions are deliberately
+    emitted 1-indexed so the test can prove the bridge remaps them.
+    """
+    rng = np.random.default_rng(seed)
+    action = rng.integers(low=0, high=n_actions, size=n_rounds).astype(np.int64)
+    # Emit positions as 1-indexed + non-contiguous (1, 2, 3 with gaps
+    # later simulated by picking {1, 3}), to exercise the remap path.
+    raw_positions = rng.choice([1, 2, 3], size=n_rounds).astype(np.int64)
+    reward = rng.binomial(n=1, p=0.03, size=n_rounds).astype(float)
+    pscore = np.full(n_rounds, 1.0 / n_actions, dtype=float)
+    context = rng.standard_normal((n_rounds, n_actions)).astype(float)
+    action_context = rng.standard_normal((n_actions, 1)).astype(float)
+    return {
+        "n_rounds": int(n_rounds),
+        "n_actions": int(n_actions),
+        "action": action,
+        "position": raw_positions,
+        "reward": reward,
+        "pscore": pscore,
+        "context": context,
+        "action_context": action_context,
+    }
+
+
+# ── Seam 1: position normalization ────────────────────────────────────
+
+
+class TestPositionNormalization:
+    """``normalize_positions`` remaps any integer labels to 0-indexed
+    contiguous integers while preserving row-level ordering."""
+
+    def test_normalize_positions_remaps_one_indexed_to_zero_indexed(self) -> None:
+        raw = np.array([1, 2, 3, 1, 2, 3], dtype=np.int64)
+        out = normalize_positions(raw)
+        assert out.dtype == np.int64
+        # Minimum drops to 0; unique values become {0, 1, 2}.
+        assert int(out.min()) == 0
+        assert sorted(np.unique(out).tolist()) == [0, 1, 2]
+        # Row ordering of the *ranks* must be preserved.
+        # Position 1 rows map to rank 0, position 2 to rank 1, position 3 to 2.
+        assert out.tolist() == [0, 1, 2, 0, 1, 2]
+
+    def test_normalize_positions_handles_gaps(self) -> None:
+        # OBD loaders occasionally emit non-contiguous integer labels
+        # (e.g. after filtering a campaign). The remapped output must
+        # collapse the gap so Track B's ``_validate_positions`` passes.
+        raw = np.array([5, 5, 10, 10, 20], dtype=np.int64)
+        out = normalize_positions(raw)
+        assert out.tolist() == [0, 0, 1, 1, 2]
+
+    def test_normalize_positions_idempotent_on_already_normalized(self) -> None:
+        raw = np.array([0, 1, 2, 0, 1, 2], dtype=np.int64)
+        out = normalize_positions(raw)
+        assert out.tolist() == raw.tolist()
+
+    def test_normalize_positions_empty_array(self) -> None:
+        raw = np.array([], dtype=np.int64)
+        out = normalize_positions(raw)
+        assert out.shape == (0,)
+
+
+# ── Seam 2: OBP version provenance ────────────────────────────────────
+
+
+class TestObpVersionProvenance:
+    """``get_obp_version`` returns a real version string when the
+    optional extra is installed and a sentinel otherwise."""
+
+    def test_get_obp_version_returns_real_version_when_installed(self) -> None:
+        obp = pytest.importorskip("obp")
+        version = get_obp_version()
+        assert isinstance(version, str)
+        assert version == obp.__version__
+        # Most importantly: it is not the placeholder that Track B shipped.
+        assert version != OBP_VERSION_PLACEHOLDER
+        # Pinned to the 0.4.x series (see pyproject bandit extra).
+        assert version.startswith("0.4.")
+
+    def test_get_obp_version_returns_sentinel_when_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Simulate a caller without the ``bandit`` extra. The bridge
+        # helper must not raise; it must return a clearly-marked
+        # sentinel string so downstream provenance dicts keep the key
+        # under graceful-degradation conditions.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _reject_obp(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "obp" or name.startswith("obp."):
+                raise ImportError(f"simulated: {name} not installed")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", _reject_obp)
+        version = get_obp_version()
+        assert isinstance(version, str)
+        assert version != OBP_VERSION_PLACEHOLDER
+        assert "unavailable" in version.lower() or "not installed" in version.lower()
+
+    def test_get_obp_version_returns_sentinel_when_version_attr_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Defense-in-depth: a forked OBP without ``__version__`` must
+        # still produce a usable provenance string rather than raising.
+        import obp
+
+        monkeypatch.delattr(obp, "__version__", raising=False)
+        version = get_obp_version()
+        assert isinstance(version, str)
+        assert version != OBP_VERSION_PLACEHOLDER
+        assert "unavailable" in version.lower() or "not installed" in version.lower()
+
+
+# ── Seam 3: conditional schema propagation ────────────────────────────
+
+
+class TestConditionalSchemaPropagation:
+    """A Men/Random-shaped pscore must pass the propensity sanity gate
+    under the conditional schema (and fail under the default joint one)."""
+
+    def test_conditional_schema_passes_on_one_over_n_actions(self) -> None:
+        # Men/Random target: 1 / 34.
+        n_actions = 34
+        n_positions = 3
+        pscore = np.full(5_000, 1.0 / n_actions, dtype=float)
+        result = propensity_sanity_gate(
+            pscore=pscore,
+            schema=PROPENSITY_SCHEMA_CONDITIONAL,
+            n_actions=n_actions,
+            n_positions=n_positions,
+        )
+        assert result.passed is True
+        assert result.schema == PROPENSITY_SCHEMA_CONDITIONAL
+        assert result.target == pytest.approx(1.0 / n_actions)
+        assert result.relative_deviation < 0.10
+
+    def test_joint_schema_fails_on_conditional_shaped_pscore(self) -> None:
+        # Cross-check: the same pscore fails under the default joint
+        # schema, proving the schema parameter is actually consumed by
+        # the gate and not dropped silently. This is the regression that
+        # the bridge test guards against.
+        n_actions = 34
+        n_positions = 3
+        pscore = np.full(5_000, 1.0 / n_actions, dtype=float)
+        result = propensity_sanity_gate(
+            pscore=pscore,
+            schema=PROPENSITY_SCHEMA_JOINT,
+            n_actions=n_actions,
+            n_positions=n_positions,
+        )
+        assert result.passed is False
+
+
+# ── Adapter → bandit_feedback helper ──────────────────────────────────
+
+
+class TestToBanditFeedbackHelper:
+    """``BanditLogAdapter.to_bandit_feedback`` returns an OBP-shaped dict
+    with normalized positions so the Track B evaluator can consume it
+    without further re-shaping."""
+
+    def test_returns_dict_with_track_b_expected_keys(self) -> None:
+        bf = _build_men_random_like_feedback(n_rounds=200, n_actions=5, n_positions=3, seed=42)
+        adapter = BanditLogAdapter(bandit_feedback=bf, seed=42)
+        out = adapter.to_bandit_feedback()
+        # Track B's ``evaluate_open_bandit_policy`` reads these keys; the
+        # helper must emit them all.
+        for key in ("n_rounds", "n_actions", "action", "reward", "pscore", "position"):
+            assert key in out, f"missing key: {key}"
+        # Shape preservation.
+        assert out["n_rounds"] == 200
+        assert out["n_actions"] == 5
+        assert np.asarray(out["action"]).shape == (200,)
+        assert np.asarray(out["reward"]).shape == (200,)
+        assert np.asarray(out["pscore"]).shape == (200,)
+        assert np.asarray(out["position"]).shape == (200,)
+
+    def test_positions_are_normalized_to_zero_indexed_contiguous(self) -> None:
+        bf = _build_men_random_like_feedback(n_rounds=200, n_actions=5, n_positions=3, seed=42)
+        adapter = BanditLogAdapter(bandit_feedback=bf, seed=42)
+        out = adapter.to_bandit_feedback()
+        positions = np.asarray(out["position"], dtype=int)
+        # Post-condition: 0-indexed, contiguous. ``_validate_positions``
+        # in Track B would otherwise raise.
+        assert int(positions.min()) == 0
+        unique = np.unique(positions)
+        assert unique.tolist() == list(range(len(unique)))
+
+    def test_exposes_conditional_schema_for_men_random(self) -> None:
+        # Bridge contract: adapter advertises which propensity schema
+        # its feedback dict uses, so downstream callers threading the
+        # bandit_feedback dict into ``run_section_7_gates`` can pass the
+        # correct schema without out-of-band knowledge.
+        bf = _build_men_random_like_feedback(n_rounds=200, n_actions=5, n_positions=3, seed=42)
+        adapter = BanditLogAdapter(bandit_feedback=bf, seed=42)
+        assert adapter.propensity_schema == PROPENSITY_SCHEMA_CONDITIONAL
+
+
+# ── End-to-end bridge flow: all three seams together ──────────────────
+
+
+class TestBridgeEndToEnd:
+    """Exercises all three seams in a single integration pass.
+
+    - Build Men/Random-like feedback with *raw* 1-indexed positions.
+    - Hand the adapter state to ``to_bandit_feedback`` to normalize.
+    - Pass ``PROPENSITY_SCHEMA_CONDITIONAL`` into ``run_section_7_gates``.
+    - Assert the returned provenance dict carries a real OBP version.
+    """
+
+    def test_full_bridge_flow_produces_clean_gate_report(self) -> None:
+        n_rounds = 2_000
+        n_actions = 34
+        n_positions = 3
+        bf_raw = _build_men_random_like_feedback(
+            n_rounds=n_rounds,
+            n_actions=n_actions,
+            n_positions=n_positions,
+            seed=7,
+        )
+        adapter = BanditLogAdapter(bandit_feedback=bf_raw, seed=7)
+
+        # Seam: adapter → bandit_feedback with normalized positions.
+        bf = adapter.to_bandit_feedback()
+
+        # Build a uniform evaluation policy on the normalized feedback
+        # shape; this is the minimum honest stand-in for the optimized
+        # policy that the Sprint 35.C benchmark will compute.
+        n_rows_used = bf["n_rounds"]
+        policies = {
+            "random": uniform_policy(n_rounds=n_rows_used, n_actions=n_actions),
+        }
+
+        # Seeded per-seed diagnostics so all gates have well-defined
+        # inputs. We evaluate the same uniform policy on the adapter's
+        # feedback so SNIPW ≈ mean reward, DR ≈ mean reward, and their
+        # relative divergence is ~0 — cross-check gate passes.
+        clip = 1.0 / (2 * n_actions * n_positions)
+        per_seed_ess: list[float] = []
+        per_seed_zero_support: list[float] = []
+        snipw_per_seed: list[float] = []
+        dr_per_seed: list[float] = []
+        for _ in range(3):
+            out = evaluate_open_bandit_policy(
+                bf,
+                uniform_policy(n_rounds=n_rows_used, n_actions=n_actions),
+                min_propensity_clip=clip,
+            )
+            per_seed_ess.append(out["ess"])
+            per_seed_zero_support.append(out["zero_support_fraction"])
+            snipw_per_seed.append(out["policy_value"])
+            dr_per_seed.append(out["policy_value"])  # uniform ↔ uniform parity
+
+        # Seam: conditional schema propagation into the gate bundle.
+        report = run_section_7_gates(
+            bandit_feedback=bf,
+            strategy_policies=policies,
+            per_seed_ess=per_seed_ess,
+            per_seed_zero_support=per_seed_zero_support,
+            snipw_per_seed=snipw_per_seed,
+            dr_per_seed=dr_per_seed,
+            n_actions=n_actions,
+            n_positions=n_positions,
+            schema=PROPENSITY_SCHEMA_CONDITIONAL,
+            permutation_seed=1,
+        )
+        assert isinstance(report, GateReport)
+        # The ESS floor on 2_000 rows is max(1000, 20) = 1000; with a
+        # uniform-vs-uniform eval on conditional propensity the Kish
+        # ESS lands at n_rounds, so the ESS gate passes.
+        assert report.ess.passed
+        # Conditional schema: empirical mean of pscore (= 1/n_actions)
+        # matches the conditional target exactly.
+        assert report.propensity_sanity.passed
+        assert report.propensity_sanity.schema == PROPENSITY_SCHEMA_CONDITIONAL
+        assert report.propensity_sanity.target == pytest.approx(1.0 / n_actions)
+
+        # Seam: provenance carries a real OBP version, not the Track B
+        # placeholder.
+        provenance = report.provenance
+        assert "obp_version" in provenance
+        assert provenance["obp_version"] != OBP_VERSION_PLACEHOLDER
+        # Installed via the ``bandit`` extra (skip if someone runs this
+        # test without the extra, but the top-level pytest marker would
+        # have already excluded it — we guard defensively).
+        obp = pytest.importorskip("obp")
+        assert provenance["obp_version"] == obp.__version__
+        # Schema is recorded in provenance for reproducibility.
+        assert provenance["schema"] == PROPENSITY_SCHEMA_CONDITIONAL
+
+    def test_positions_pass_track_b_validator_after_bridge(self) -> None:
+        # Direct regression for seam 1: feed raw 1-indexed positions
+        # through the bridge and confirm the Track B null-control path
+        # (which invokes ``_validate_positions``) does not raise.
+        from causal_optimizer.benchmarks.open_bandit import permute_rewards_stratified
+
+        bf_raw = _build_men_random_like_feedback(n_rounds=500, n_actions=4, n_positions=3, seed=0)
+        adapter = BanditLogAdapter(bandit_feedback=bf_raw, seed=0)
+        bf = adapter.to_bandit_feedback()
+        # Would raise on raw 1-indexed positions.
+        permuted = permute_rewards_stratified(bf, seed=0)
+        assert permuted["reward"].shape == (500,)


### PR DESCRIPTION
## Summary

Closes three narrow seams between the merged Sprint 35.A adapter ([PR #189](https://github.com/datablogin/causal-optimizer/pull/189)) and the merged Sprint 35.B OPE stack ([PR #188](https://github.com/datablogin/causal-optimizer/pull/188)) so [Issue #187](https://github.com/datablogin/causal-optimizer/issues/187) (Sprint 35.C benchmark report) can consume a ready-to-run integration path.

- **Seam 1 — position normalization.** Adds `normalize_positions(position)` in [`open_bandit.py`](causal_optimizer/benchmarks/open_bandit.py) — a dense-rank remap that produces 0-indexed contiguous integers from any integer labels. OBD loaders emit `{1, 2, 3}` (or post-filter non-contiguous labels); Track B's `_validate_positions` rejects anything else, so the bridge routes positions through this helper before the OPE wrapper consumes them.
- **Seam 2 — conditional propensity schema.** Adds `BanditLogAdapter.propensity_schema` pinned to `PROPENSITY_SCHEMA_CONDITIONAL` (Men/Random stores `action_prob` as `P(item | position) = 1 / n_items`, per the Sprint 35.A smoke-test finding). Callers thread this into `run_section_7_gates(..., schema=...)` so `propensity_sanity_gate` targets `1/n_items` instead of the default joint `1/(n_items * n_positions)`.
- **Seam 3 — OBP version provenance.** Replaces the Track B `OBP_VERSION_PLACEHOLDER` in the `run_section_7_gates` provenance dict with a runtime lookup via a new `get_obp_version()` helper. Returns installed `obp.__version__` when the `bandit` extra is present and the explicit `OBP_VERSION_UNAVAILABLE` sentinel otherwise, so provenance round-trips cleanly under graceful-degradation.

Also adds a narrow `BanditLogAdapter.to_bandit_feedback()` helper that returns an OBP-shaped dict (with normalized positions) ready for `evaluate_open_bandit_policy` and `run_section_7_gates`.

No new estimators, gates, datasets, or search-space variables. `BanditLogAdapter` and `open_bandit.py` are not rewritten.

Closes #190

## Test plan

- [x] `uv run pytest tests/integration/test_open_bandit_bridge.py -v` — 14 new bridge tests pass (position normalization x4, OBP version lookup x3, conditional schema propagation x2, `to_bandit_feedback` helper x3, end-to-end bridge flow x2)
- [x] `uv run pytest tests/integration/test_open_bandit_gates.py tests/integration/test_bandit_log_adapter_smoke.py tests/unit/test_bandit_log_adapter.py tests/unit/test_open_bandit_ope.py` — existing 130 bandit-related tests still pass
- [x] `uv run pytest -m "not slow"` — fast suite (1306 tests) passes
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format .` clean
- [x] `uv run mypy causal_optimizer/` — no new type errors

## Files changed

- `causal_optimizer/benchmarks/open_bandit.py` — adds `OBP_VERSION_UNAVAILABLE`, `get_obp_version()`, `normalize_positions()`; wires `get_obp_version()` into provenance in `run_section_7_gates`.
- `causal_optimizer/domain_adapters/bandit_log.py` — adds `propensity_schema` class attribute and `to_bandit_feedback()` method.
- `tests/integration/test_open_bandit_bridge.py` — new focused bridge integration test.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes three integration seams between the Sprint 35.A adapter and Sprint 35.B OPE stack: it adds `normalize_positions()` to remap OBD 1-indexed positions, pins `BanditLogAdapter.propensity_schema` to `PROPENSITY_SCHEMA_CONDITIONAL`, and replaces the `OBP_VERSION_PLACEHOLDER` with a runtime `get_obp_version()` lookup. All three helpers are correctly implemented and covered by 14 new bridge tests that address the previous review's concerns (import guards, per-seed diversity).

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 design notes with no runtime impact on the OPE bridge path.

No P0 or P1 bugs found. The three seam-closers (normalize_positions, propensity_schema, get_obp_version) are correctly implemented. The single inline comment is a P2 design inconsistency between to_bandit_feedback and run_experiment that predates this PR and does not affect the OPE bridge path being wired here.

causal_optimizer/domain_adapters/bandit_log.py — note the position-handling inconsistency between run_experiment and to_bandit_feedback for future work.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| causal_optimizer/benchmarks/open_bandit.py | Adds `OBP_VERSION_UNAVAILABLE`, `get_obp_version()`, and `normalize_positions()`; wires OBP version into `run_section_7_gates` provenance — all three helpers are well-guarded and correct. |
| causal_optimizer/domain_adapters/bandit_log.py | Adds `propensity_schema` ClassVar and `to_bandit_feedback()` helper; minor design inconsistency between `to_bandit_feedback` (normalizes positions) and `run_experiment` (uses raw stored positions). |
| tests/integration/test_open_bandit_bridge.py | 14 focused bridge tests covering all three seams; prior review concerns (bare `import obp`, constant per-seed values) are fully addressed with `pytest.importorskip` guards and varied `peaked_policy` per seed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant OBP as OBP Dataset
    participant Adapter as BanditLogAdapter
    participant Bridge as to_bandit_feedback()
    participant Norm as normalize_positions()
    participant OPE as evaluate_open_bandit_policy()
    participant Gates as run_section_7_gates()
    participant Ver as get_obp_version()

    OBP->>Adapter: bandit_feedback (raw 1-indexed positions)
    Note over Adapter: _validate_feedback (accepts non-negative)
    Adapter->>Bridge: to_bandit_feedback()
    Bridge->>Norm: normalize_positions(self._position)
    Norm-->>Bridge: 0-indexed contiguous int64 array
    Bridge-->>OPE: bf dict (normalized positions)
    OPE-->>Gates: per_seed_ess, snipw_per_seed, dr_per_seed
    Gates->>Ver: get_obp_version()
    Ver-->>Gates: obp.__version__ or OBP_VERSION_UNAVAILABLE
    Gates-->>Gates: GateReport with propensity_schema=CONDITIONAL
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Acausal_optimizer%2Fdomain_adapters%2Fbandit_log.py%3A479-513%0A**Position%20normalization%20inconsistency%20between%20%60to_bandit_feedback%60%20and%20%60run_experiment%60**%0A%0A%60to_bandit_feedback%28%29%60%20pipes%20%60self._position%60%20through%20%60normalize_positions%60%2C%20so%20the%20returned%20dict%20is%20always%200-indexed%20contiguous.%20However%2C%20%60run_experiment%60%20reads%20%60self._position%60%20directly%20and%20uses%20%60self._position%20%3D%3D%200%60%20for%20the%20%60position_1_only%60%20mask.%20An%20adapter%20constructed%20with%20non-0-indexed%20positions%20%28e.g.%20OBD%201-indexed%20%60%7B1%2C%202%2C%203%7D%60%29%20will%20silently%20return%20%60n_active%20%3D%3D%200%60%20from%20%60run_experiment%60%20under%20%60position_1_only%60%2C%20producing%20a%20pessimistic%20all-zero%20result%2C%20while%20%60to_bandit_feedback%28%29%60%20returns%20a%20correctly%20normalized%20dict%20for%20the%20OPE%20stack.%0A%0A%60_validate_feedback%60%20only%20rejects%20negative%20positions%20%28%60position.min%28%29%20%3C%200%60%29%2C%20so%20construction%20succeeds%20with%20any%20non-negative%20layout.%20The%20bridge%20test%20fixture%20deliberately%20passes%201-indexed%20positions%20to%20the%20constructor%2C%20so%20a%20future%20reader%20may%20reasonably%20assume%20both%20%60run_experiment%60%20and%20%60to_bandit_feedback%60%20handle%20non-0-indexed%20input%20consistently.%0A%0AA%20lightweight%20guard%20%E2%80%94%20either%20normalizing%20%60self._position%60%20at%20construction%20time%2C%20or%20documenting%20in%20%60_validate_feedback%60%20that%20positions%20must%20already%20be%200-indexed%20%E2%80%94%20would%20close%20the%20silent-failure%20path%20in%20%60run_experiment%60.%0A%0A&repo=datablogin%2Fcausal-optimizer&pr=191&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: causal_optimizer/domain_adapters/bandit_log.py
Line: 479-513

Comment:
**Position normalization inconsistency between `to_bandit_feedback` and `run_experiment`**

`to_bandit_feedback()` pipes `self._position` through `normalize_positions`, so the returned dict is always 0-indexed contiguous. However, `run_experiment` reads `self._position` directly and uses `self._position == 0` for the `position_1_only` mask. An adapter constructed with non-0-indexed positions (e.g. OBD 1-indexed `{1, 2, 3}`) will silently return `n_active == 0` from `run_experiment` under `position_1_only`, producing a pessimistic all-zero result, while `to_bandit_feedback()` returns a correctly normalized dict for the OPE stack.

`_validate_feedback` only rejects negative positions (`position.min() < 0`), so construction succeeds with any non-negative layout. The bridge test fixture deliberately passes 1-indexed positions to the constructor, so a future reader may reasonably assume both `run_experiment` and `to_bandit_feedback` handle non-0-indexed input consistently.

A lightweight guard — either normalizing `self._position` at construction time, or documenting in `_validate_feedback` that positions must already be 0-indexed — would close the silent-failure path in `run_experiment`.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["test: evict obp from sys.modules before ..."](https://github.com/datablogin/causal-optimizer/commit/e334229293b23a684d7d73c5f9137aeb29480637) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28938389)</sub>

<!-- /greptile_comment -->