### PR TITLE
docs: sprint 38 post-A1 recommendation (option B)

### DIFF
--- a/thoughts/shared/plans/27-sprint-38-recommendation.md
+++ b/thoughts/shared/plans/27-sprint-38-recommendation.md
@@ -4,10 +4,35 @@ Updated: 2026-04-22
 
 ## Sprint Theme
 
-**Option B — graph widening. Add one non-ancestor structural node
-(`logged_position_distribution`) to the Open Bandit prior graph so
-`_get_focus_variables` returns a real proper subset directly, instead
-of relying on the A1 screening intersection to do the restriction.**
+**Option B — graph widening. Add one non-search-space structural node
+(`logged_position_distribution`) to the Open Bandit prior graph. The
+widening is a preregistered structural test of the Sprint 37
+engine-surface analysis — confirmed below as a predicted no-op along
+every engine path that already existed under the Sprint 37
+`pomis_minimal_focus=True` wiring. Under the widened graph,
+`_get_focus_variables` still returns the full search space (the new
+node is not a search-space variable), `_apply_minimal_focus_a1` still
+binds and still returns the same `screened ∩ ancestors` intersection
+as Sprint 37, and the soft-causal reranker's alignment score is
+unchanged. The no-op prediction *is* the falsifiable claim — a B80
+certified or trending row in either direction would prove the
+Sprint 37 engine-path analysis incomplete.**
+
+**Terminology note.** The Sprint 38 orchestration prompt and the
+Sprint 36 plan both used the phrase "non-ancestor structural node"
+as shorthand for "a structural node that is not itself a
+search-space knob." That shorthand is graph-theoretically imprecise
+once the edge
+`logged_position_distribution -> position_handling_flag` is added,
+because `logged_position_distribution` then *is* an ancestor of
+`policy_value` via the two-hop path through `position_handling_flag`.
+To keep the engine-path reasoning unambiguous, this recommendation
+uses **"non-search-space structural node"** (or simply "structural
+node") instead of "non-ancestor" from this point forward. The A1
+binding condition holds under the widened graph precisely because
+`logged_position_distribution` is not a search-space variable
+(`_ancestors_in_space` filters it out of its search-space
+intersection), not because it is a non-ancestor of the objective.
 
 Sprint 37 landed Option A1 cleanly (PR #198). The preregistered
 seven-node / six-edge graph is now live in
@@ -25,16 +50,17 @@ explicitly say not to chase. See
 
 Sprint 38 picks exactly one of the three follow-ups the Sprint 37
 report named. The pick is **Option B** — graph widening with one
-non-ancestor structural node, because it is the next structurally
-distinct test of whether the Men/Random slice can separate `causal`
-from `surrogate_only` under the verdict rule. Options C and D are
-rejected below, on the evidence, not queue pressure.
+non-search-space structural node, because it is the next
+structurally distinct test of whether the Men/Random slice can
+separate `causal` from `surrogate_only` under the verdict rule.
+Options C and D are rejected below, on the evidence, not queue
+pressure.
 
 ## Goal
 
 Sprint 38 should end with:
 
-1. one new non-ancestor structural node
+1. one new non-search-space structural node
    (`logged_position_distribution`) added to the preregistered graph
    returned by `BanditLogAdapter.get_prior_graph()`, with a single
    directed edge `logged_position_distribution -> position_handling_flag`
@@ -49,8 +75,10 @@ Sprint 38 should end with:
    `0.05 < p <= 0.15` at B80 — same two-sided MWU convention as
    Sprint 35 and Sprint 37
 4. a Sprint 38 report that answers one question end-to-end: does
-   graph widening change the B80 verdict or does it recapitulate the
-   Sprint 37 near-parity under a genuinely restricted focus set?
+   pure graph widening (one new non-search-space ancestor of
+   `policy_value`, same search space, same engine surface) move the
+   B80 verdict, or does it recapitulate the Sprint 37 near-parity as
+   the engine-path analysis predicts?
 
 No second node in Sprint 38. No bidirected edges. No new slice. No
 DRos-primary. No second dataset. No new heuristic. No power extension
@@ -58,7 +86,7 @@ on A1. The scope is one node, one edge, one rerun, one verdict row.
 
 ## Why This Sprint Now
 
-### Why Option B (this sprint, Men/Random, one non-ancestor node)
+### Why Option B (this sprint, Men/Random, one non-search-space structural node)
 
 Under the preregistered graph Sprint 37 landed, every search variable
 is already an ancestor of `policy_value`. That means
@@ -74,13 +102,21 @@ produce a different trajectory (the Sprint 35 exact tie is broken)
 but does not move the verdict-budget mean.
 
 The natural next test is to add structure to the graph itself —
-specifically, one non-ancestor node that makes the ancestor DAG
-non-trivial. This is Option B in the Sprint 36 plan and in the
-Sprint 37 "Sprint 38+ Implications" section. The Sprint 36 plan's
-"Exit Criterion" section names two candidate structural nodes:
-`logged_position_distribution` and `request_item_overlap`. Sprint 38
-commits to exactly one: `logged_position_distribution` with a
-directed edge `logged_position_distribution -> position_handling_flag`.
+specifically, one non-search-space structural node that makes the
+ancestor DAG non-trivial (some search-space variables gain
+non-search-space parents; the objective gains an ancestor that is
+not itself a knob). This is Option B in the Sprint 36 plan and in
+the Sprint 37 "Sprint 38+ Implications" section. The Sprint 36
+plan's "Exit Criterion" section names two candidate structural
+nodes: `logged_position_distribution` and `request_item_overlap`.
+Sprint 38 commits to exactly one: `logged_position_distribution`
+with a directed edge
+`logged_position_distribution -> position_handling_flag`. (The
+Sprint 36 plan and the Sprint 38 orchestration prompt called these
+"non-ancestor" nodes; after adding the two-hop edge,
+`logged_position_distribution` is in fact an ancestor of
+`policy_value`. The accurate term is "non-search-space" — see the
+Sprint Theme terminology note above.)
 
 **Honest prediction about what this widening changes.** Under the
 Sprint 37 engine surface, the widened graph is predicted to be a

--- a/thoughts/shared/plans/27-sprint-38-recommendation.md
+++ b/thoughts/shared/plans/27-sprint-38-recommendation.md
@@ -246,10 +246,10 @@ Sprint 38 adds exactly one new node and exactly one new directed edge.
 8. `logged_position_distribution`
 
 **Code-grounded justification.** The adapter's `run_experiment`
-branches on the `position_handling_flag` categorical to pick the
-logged-row subset that enters the SNIPW sum
 ([`causal_optimizer/domain_adapters/bandit_log.py`](../../causal_optimizer/domain_adapters/bandit_log.py)
-lines 352–369):
+lines 346–369) branches on the `position_handling_flag` categorical
+to pick the logged-row subset that enters the SNIPW sum. The
+row-mask branch itself is at lines 364–367:
 
 ```python
 if position_flag == "position_1_only":
@@ -278,12 +278,13 @@ bullet) and the Sprint 37 report's "Sprint 38+ Implications" section.
 
 **Code-grounded justification.** The flag's behavior is a direct
 function of `self._position`
-(`bandit_log.py` lines 352–369, cited above). Per the Sprint 36
-plan's edge-justification discipline, each added edge must cite a
-specific line that makes the upstream variable structural. The line
-range above — the row-mask branch inside `run_experiment` — is the
-site that makes `logged_position_distribution` structurally upstream
-of `position_handling_flag`.
+(`bandit_log.py` lines 364–367, cited above, inside
+`run_experiment` at lines 346–369). Per the Sprint 36 plan's
+edge-justification discipline, each added edge must cite a
+specific line that makes the upstream variable structural. The
+row-mask branch is the site that makes
+`logged_position_distribution` structurally upstream of
+`position_handling_flag`.
 
 No edge from `logged_position_distribution` directly to `policy_value`
 is added. The flow is:
@@ -685,8 +686,9 @@ that forced the choice.
 - Sprint 36 preregistration plan: [26-sprint-36-recommendation.md](26-sprint-36-recommendation.md)
 - Sprint 37 Open Bandit prior-graph report: [sprint-37-open-bandit-prior-graph-report.md](../docs/sprint-37-open-bandit-prior-graph-report.md)
 - `BanditLogAdapter`: `causal_optimizer/domain_adapters/bandit_log.py`
-  (see `get_prior_graph`, lines 513–541, and `run_experiment` row-mask
-  branch, lines 352–369, for the Option B node justification)
+  (see `get_prior_graph`, lines 513–541, and `run_experiment`
+  row-mask branch, lines 364–367 within `run_experiment` 346–369,
+  for the Option B node justification)
 - Open Bandit OPE stack and Section 7 gates: `causal_optimizer/benchmarks/open_bandit.py`
 - Open Bandit benchmark runner: `causal_optimizer/benchmarks/open_bandit_benchmark.py`
   (enables `pomis_minimal_focus` only on the `causal` arm, line 541)

--- a/thoughts/shared/plans/27-sprint-38-recommendation.md
+++ b/thoughts/shared/plans/27-sprint-38-recommendation.md
@@ -510,6 +510,21 @@ seeds. A Sprint 39 power-extension rerun is the explicit answer to
 that risk if Sprint 38 produces a trending row (H2); **Sprint 38
 itself does not extend power on A1 or on Option B**.
 
+**Null-result asymmetry.** H0 is also 10-seed-gated. If the true
+effect is null *and* the 10-seed test would be underpowered to
+certify a small true effect, H0 passes — but it can pass for two
+very different reasons: (a) the widening is genuinely a no-op along
+every engine path (the prediction), or (b) the widening produces a
+real but sub-power effect that 10 seeds cannot distinguish from a
+no-op. Sprint 38 partially guards against (b) by treating B20/B40
+near-parity *alongside* B80 near-parity as the exhaustion
+criterion. The Sprint 38 report's reconciliation section must
+address this asymmetry explicitly: a B80 near-parity that is paired
+with B20 and B40 near-parity reads as genuine no-op (path to
+Sprint 39 Option D); a B80 near-parity paired with non-trivial B20
+or B40 movement reads as a potential sub-power miss and should be
+flagged for Sprint 39 diagnostic triage rather than Option D.
+
 ## Recommended Issue Shape
 
 **One issue for Sprint 38.** The scope is a single graph widening

--- a/thoughts/shared/plans/27-sprint-38-recommendation.md
+++ b/thoughts/shared/plans/27-sprint-38-recommendation.md
@@ -340,23 +340,34 @@ engine or optimizer change):
    ancestor set inside the search space is unchanged, so the A1
    result is the same set the Sprint 37 rerun computed at every
    (seed, budget, phase) triple.
-3. Parent-weighted exploitation (`suggest.py` lines 569–586): uses
-   `causal_graph.parents(objective_name)`. Sprint 37 graph gave
-   `parents(policy_value) = 6` search-space vars → `weights = None`
-   (no restriction). Sprint 38 widened graph still gives
-   `parents(policy_value) = 6` search-space vars (the new edge
-   targets `position_handling_flag`, not `policy_value`) → still
-   `weights = None`, still no-op.
-4. Soft-causal reranker (`_rerank_alignment_only` +
-   `_causal_alignment_score`, `suggest.py` lines 751–812 and
-   982–1021): averages over ancestors of the objective. The
-   ancestor set grows by one (`logged_position_distribution`), but
-   that variable is not in the search space, so
-   `_causal_alignment_score` skips it when it iterates over
-   ancestors in the search space (the per-variable normalized
-   displacement loop at lines 1010–1019 only fires when the
-   ancestor name is a key in `candidate` and `best_params`). The
-   reranker's per-seed output is therefore identical to Sprint 37.
+3. Parent-weighted exploitation (`suggest.py` lines 604–619, inside
+   `_suggest_exploitation` which starts at line 532): uses
+   `causal_graph.parents(objective_name)`. The 70/30 weighting
+   activates only when `parent_focus` is a *proper* subset of
+   `eligible_vars` (line 608:
+   `if parent_focus and len(parent_focus) < len(eligible_vars)`).
+   Sprint 37 graph gave `parents(policy_value) = 6` search-space
+   vars → `weights = None` (no restriction). Sprint 38 widened
+   graph still gives `parents(policy_value) = 6` search-space vars
+   (the new edge targets `position_handling_flag`, not
+   `policy_value`) → still `weights = None`, still no-op.
+4. Soft-causal reranker (`_rerank_alignment_only` at `suggest.py`
+   lines 848–877, called from `_suggest_bayesian` at line 839; soft
+   path entered via `use_soft = causal_graph is not None and
+   causal_softness < _HARD_FOCUS_THRESHOLD` at line 784, with
+   ancestor set built at lines 810–813; alignment score function
+   `_causal_alignment_score` at lines 1015–1054): averages over
+   ancestors of the objective. The ancestor set grows by one
+   (`logged_position_distribution`), but that variable is not in
+   the search space, so `_causal_alignment_score` skips it in the
+   per-variable normalized-displacement loop at lines 1043–1052 —
+   the filter is search-space membership
+   (`var = var_map.get(name); if var is None: continue` at lines
+   1044–1046, where `var_map = {v.name: v for v in search_space.variables}`
+   at line 1040), not key-presence in `candidate`/`best_params`
+   (those fall back to `mid` via `candidate.get(name, mid)` at line
+   1050). The reranker's per-seed output is therefore identical to
+   Sprint 37.
 5. `_suggest_causal_gp`: inert (not requested by the benchmark).
 6. `causal_exploration_weight`: pinned to `0.0`, inert.
 
@@ -685,10 +696,16 @@ that forced the choice.
     (`_get_focus_variables`)
   - `causal_optimizer/optimizer/suggest.py` lines 1183–1236
     (`_apply_minimal_focus_a1`, Sprint 37 A1 helper)
-  - `causal_optimizer/optimizer/suggest.py` lines 751–812
-    (soft-causal reranker inside `_suggest_bayesian`)
-  - `causal_optimizer/optimizer/suggest.py` lines 982–1021
-    (`_causal_alignment_score`)
+  - `causal_optimizer/optimizer/suggest.py` lines 604–619
+    (parent-weighted 70/30 split inside `_suggest_exploitation`,
+    which starts at line 532)
+  - `causal_optimizer/optimizer/suggest.py` lines 848–877
+    (`_rerank_alignment_only`, called from `_suggest_bayesian` at
+    line 839 when `use_soft` is true at line 784)
+  - `causal_optimizer/optimizer/suggest.py` lines 1015–1054
+    (`_causal_alignment_score`; per-variable normalized-displacement
+    loop at 1043–1052 with search-space-membership filter at
+    1044–1046)
 - `CausalGraph` type: `causal_optimizer/types.py`
 - `DomainAdapter.get_prior_graph` contract:
   `causal_optimizer/domain_adapters/base.py`

--- a/thoughts/shared/plans/27-sprint-38-recommendation.md
+++ b/thoughts/shared/plans/27-sprint-38-recommendation.md
@@ -331,8 +331,11 @@ engine or optimizer change):
    `{v in search_space.variable_names | v in ancestors(policy_value)}`
    still equals the full search space, because
    `logged_position_distribution` is **not** itself a search-space
-   variable. So path 1 on its own remains a no-op — the full
-   search-space fallback triggers.
+   variable. `_get_focus_variables` returns that full-search-space
+   intersection verbatim (the intersection is truthy, so the
+   `focus if focus else search_space.variable_names` guard at line
+   1180 does not trigger a fallback — it just returns the already-equal
+   set). Path 1 on its own is therefore a no-op.
 2. A1 minimal-focus (`_apply_minimal_focus_a1`, `suggest.py` lines
    1183–1236): the binding condition — every search-space variable
    is an ancestor of `policy_value` — still holds, so the A1 helper
@@ -361,26 +364,56 @@ engine or optimizer change):
    ancestors of the objective. The ancestor set grows by one
    (`logged_position_distribution`), but that variable is not in
    the search space, so `_causal_alignment_score` skips it in the
-   per-variable normalized-displacement loop at lines 1043–1052 —
-   the filter is search-space membership
-   (`var = var_map.get(name); if var is None: continue` at lines
-   1044–1046, where `var_map = {v.name: v for v in search_space.variables}`
-   at line 1040), not key-presence in `candidate`/`best_params`
-   (those fall back to `mid` via `candidate.get(name, mid)` at line
-   1050). The reranker's per-seed output is therefore identical to
-   Sprint 37.
+   per-variable normalized-displacement loop at lines 1043–1052 via
+   the continue guard at line 1045:
+
+   ```python
+   if var is None or var.lower is None or var.upper is None:
+       continue
+   ```
+
+   `var_map = {v.name: v for v in search_space.variables}` at line
+   1040, so `var_map.get("logged_position_distribution")` returns
+   `None` and the loop continues before the `_normalize_value`
+   calls at lines 1050–1051 (which would otherwise fall back to
+   `mid` via `candidate.get(name, mid)` / `best_params.get(name, mid)`).
+   As an aside: the same guard already skips categorical variables
+   — `var.lower is None` is true for `position_handling_flag` — so
+   Sprint 37 was already computing the alignment score over the
+   five continuous ancestors only. That strengthens rather than
+   weakens the no-op claim: under the widened graph the reranker's
+   score is averaged over exactly the same five continuous
+   search-space ancestors as in Sprint 37.
 5. `_suggest_causal_gp`: inert (not requested by the benchmark).
 6. `causal_exploration_weight`: pinned to `0.0`, inert.
 
 So — honestly — the Sprint 38 widened graph is **predicted to be a
-no-op** along every engine path that already existed. That is
-exactly the point. Sprint 37 broke the Sprint 35 bit-identical tie
-by turning `pomis_minimal_focus` on; if Sprint 38's widened graph
-reproduces the Sprint 37 B80 near-parity, that is strong evidence
-the Open Bandit A1 lane is genuinely exhausted along the pure
-graph-widening axis under this engine surface, and Sprint 39 has
-clean grounds to pick between a bidirected-edge Option A2 variant
-or Option D.
+no-op** along every engine path that already existed. The prediction
+rests on exactly two structural conditions the Sprint 38 widening
+satisfies by design:
+
+1. the new node `logged_position_distribution` is **not** a
+   search-space variable, so `_ancestors_in_space` filters it out
+   of path 1 and `_causal_alignment_score` filters it out of path 4
+2. the new edge `logged_position_distribution -> position_handling_flag`
+   does **not** add a new parent to `policy_value`
+   (`parents(policy_value)` still equals the six search-space
+   vars), so path 3's `parent_focus` set does not change and
+   `weights = None` still holds
+
+If either condition were relaxed — a future sprint widens with a
+node that *is* a search-space variable, or with an edge whose
+target is `policy_value` — the no-op prediction does not transfer
+to that widening. A Sprint 39+ plan that copies this one must
+re-derive the per-path analysis, not reuse it.
+
+That is exactly the point. Sprint 37 broke the Sprint 35
+bit-identical tie by turning `pomis_minimal_focus` on; if Sprint
+38's widened graph reproduces the Sprint 37 B80 near-parity, that
+is strong evidence the Open Bandit A1 lane is genuinely exhausted
+along the pure graph-widening axis under this engine surface, and
+Sprint 39 has clean grounds to pick between a bidirected-edge
+Option A2 variant or Option D.
 
 **This is a preregistered no-op prediction, not a hidden one.** The
 value of running it is that the *prediction itself* is the

--- a/thoughts/shared/plans/27-sprint-38-recommendation.md
+++ b/thoughts/shared/plans/27-sprint-38-recommendation.md
@@ -1,0 +1,664 @@
+# Sprint 38 Recommendation
+
+Updated: 2026-04-22
+
+## Sprint Theme
+
+**Option B — graph widening. Add one non-ancestor structural node
+(`logged_position_distribution`) to the Open Bandit prior graph so
+`_get_focus_variables` returns a real proper subset directly, instead
+of relying on the A1 screening intersection to do the restriction.**
+
+Sprint 37 landed Option A1 cleanly (PR #198). The preregistered
+seven-node / six-edge graph is now live in
+[`BanditLogAdapter.get_prior_graph()`](../../causal_optimizer/domain_adapters/bandit_log.py),
+and the new `pomis_minimal_focus` flag on `ExperimentEngine`
+(default `False`) is enabled only on the Open Bandit `causal` arm. The
+rerun broke the Sprint 35 bit-identical `causal == surrogate_only` tie
+on every seed at every budget — the graph now matters mechanically —
+but the verdict-budget impact was null: B80 two-sided MWU
+`p = 0.7337`, means `0.006181` vs `0.006182`. The B20 row trended
+`causal < surrogate_only` (`p = 0.0820`, 8/10 seeds), which the
+Sprint 37 report and the Sprint 38 orchestration prompt both
+explicitly say not to chase. See
+[sprint-37-open-bandit-prior-graph-report.md](../docs/sprint-37-open-bandit-prior-graph-report.md).
+
+Sprint 38 picks exactly one of the three follow-ups the Sprint 37
+report named. The pick is **Option B** — graph widening with one
+non-ancestor structural node, because it is the next structurally
+distinct test of whether the Men/Random slice can separate `causal`
+from `surrogate_only` under the verdict rule. Options C and D are
+rejected below, on the evidence, not queue pressure.
+
+## Goal
+
+Sprint 38 should end with:
+
+1. one new non-ancestor structural node
+   (`logged_position_distribution`) added to the preregistered graph
+   returned by `BanditLogAdapter.get_prior_graph()`, with a single
+   directed edge `logged_position_distribution -> position_handling_flag`
+   and no bidirected edges
+2. a Sprint 37-shape rerun of Men/Random under that widened graph:
+   same budgets (20, 40, 80), same 10 seeds, same strategies
+   (`random`, `surrogate_only`, `causal`), same SNIPW-primary / DM /
+   DR estimators, same Section 7 gates, same null-control permutation
+   seed (`20260419`), Ax/BoTorch-only (no RF fallback mixing)
+3. a preregistered falsifiable outcome: H0 (predicted) = `p > 0.15`
+   at B80; H1 (alternative) = `p <= 0.05` at B80; H2 (trending) =
+   `0.05 < p <= 0.15` at B80 — same two-sided MWU convention as
+   Sprint 35 and Sprint 37
+4. a Sprint 38 report that answers one question end-to-end: does
+   graph widening change the B80 verdict or does it recapitulate the
+   Sprint 37 near-parity under a genuinely restricted focus set?
+
+No second node in Sprint 38. No bidirected edges. No new slice. No
+DRos-primary. No second dataset. No new heuristic. No power extension
+on A1. The scope is one node, one edge, one rerun, one verdict row.
+
+## Why This Sprint Now
+
+### Why Option B (this sprint, Men/Random, one non-ancestor node)
+
+Under the preregistered graph Sprint 37 landed, every search variable
+is already an ancestor of `policy_value`. That means
+`_get_focus_variables` at
+[`causal_optimizer/optimizer/suggest.py`](../../causal_optimizer/optimizer/suggest.py)
+lines 1170–1180 returns the full search space — the
+graph-ancestors path by itself is a no-op restriction. The A1 flag
+added a second step: when every search variable is an ancestor AND
+the screening intersection is a non-empty proper subset, return the
+intersection (`_apply_minimal_focus_a1`, `suggest.py` lines
+1183–1236). Sprint 37's B80 row says that indirect path does
+produce a different trajectory (the Sprint 35 exact tie is broken)
+but does not move the verdict-budget mean.
+
+The natural next test is to add structure to the graph itself —
+specifically, one non-ancestor node that makes the ancestor DAG
+non-trivial. This is Option B in the Sprint 36 plan and in the
+Sprint 37 "Sprint 38+ Implications" section. The Sprint 36 plan's
+"Exit Criterion" section names two candidate structural nodes:
+`logged_position_distribution` and `request_item_overlap`. Sprint 38
+commits to exactly one: `logged_position_distribution` with a
+directed edge `logged_position_distribution -> position_handling_flag`.
+
+**Honest prediction about what this widening changes.** Under the
+Sprint 37 engine surface, the widened graph is predicted to be a
+no-op along every path that already existed. The per-path breakdown
+(path 1 `_get_focus_variables`, path 4 soft-causal reranker, etc.)
+is in
+[What the engine would do with the widened graph, path by path](#what-the-engine-would-do-with-the-widened-graph-path-by-path)
+below. The mechanism is straightforward: the new node sits outside
+the search space, so `_get_focus_variables` (which filters ancestors
+through `search_space.variable_names`) still returns the six
+search-space variables; the A1 helper
+`_apply_minimal_focus_a1` checks
+`len(ancestors_in_space) == len(all_var_names)`, and the widened
+graph leaves that equal, so A1 still binds and still returns the
+same `screened ∩ ancestors` intersection it did in Sprint 37.
+
+**That is exactly the point.** Sprint 38's value is that the no-op
+prediction is preregistered and falsifiable. Sprint 37 broke the
+Sprint 35 bit-identical tie by turning `pomis_minimal_focus` on; if
+Sprint 38 produces a B80 certified or trending row in either
+direction, the Sprint 37 engine-surface analysis is provably
+incomplete and must be redone before any further Open Bandit sprint.
+If Sprint 38 reproduces the Sprint 37 B80 near-parity, that is
+strong evidence the Open Bandit A1 lane is exhausted along the pure
+graph-widening axis under this engine surface, and Sprint 39 has
+clean grounds to pick between a bidirected-edge A2 variant, Option
+C, or Option D (see
+[What Happens After Sprint 38](#what-happens-after-sprint-38)).
+
+The structural claim that justifies this node is narrow and
+code-grounded: the adapter's `position_handling_flag` knob chooses
+between two concrete row-mask behaviors (`marginalize` over all
+positions or `position_1_only`), and which of those dominates the
+SNIPW objective depends on the *logged* position distribution — a
+property of the data, not of any search-space knob. That property
+is structurally upstream of the search-space knob but is not itself
+a knob. See
+[Minimal Preregistered Graph (Sprint 38 widening)](#minimal-preregistered-graph-sprint-38-widening)
+for the line-level justification. No bidirected edges are added;
+the Sprint 34 contract Section 4e discipline holds.
+
+### Why not Option C (different heuristic on the existing graph)
+
+Option C swaps the A1 `screened ∩ ancestors` rule for another
+screening-derived heuristic — the Sprint 36 plan lists a
+magnitude-thresholded variant (drop ancestors whose screening
+importance is below some quantile). The Sprint 37 report's Sprint 38+
+implications section leaves this on the table but does not endorse
+it, and the orchestration prompt is explicit that Option C "carries a
+higher burden of proof than Option B; another heuristic tweak must
+show why it is not post-hoc tuning."
+
+Concretely, the evidence against spending Sprint 38 on Option C:
+
+1. **Option C tunes against the only non-certified trend Sprint 37
+   produced.** The B20 `p = 0.0820` row is the only budget where A1
+   moved a p-value near the certified band, and the direction is
+   *worse* (`causal < surrogate_only` on 8/10 seeds). A new heuristic
+   that "fixes" that row without a preregistered hypothesis would be
+   a direct post-hoc chase — exactly what the Sprint 36 plan and the
+   Sprint 37 report forbid.
+2. **Option B is structurally prior to Option C.** If graph widening
+   produces no verdict movement, a heuristic change on top of a
+   trivially-ancestored graph is even less likely to, because the
+   heuristic consumes the same screening output and the same
+   ancestor set.
+3. **The Sprint 37 near-parity is honest, not power-limited.** At
+   B80 the means agree to six decimals. Sprint 37's report calls
+   this out explicitly: "this is not a power-limited needs-more-seeds
+   result, it is an honest near-parity." A different heuristic on the
+   same graph would be fighting an empirical convergence, not a
+   power gap.
+
+Option C stays on the backlog. It becomes interesting *after* a
+Sprint 38 Option B rerun, if the widened graph produces a B80
+trending or certified row and Option C can then be framed as "pick
+between two heuristics that both see a non-trivial ancestor
+structure."
+
+### Why not Option D (move on, reopen another lane)
+
+Option D would declare the Open Bandit A1 lane exhausted and reopen
+Women, All, BTS-primary, slate OPE, DRos-primary, or a second dataset.
+The orchestration prompt is explicit: Option D "is acceptable only if
+argued directly from the evidence rather than from queue pressure or
+impatience."
+
+The evidence does not yet support Option D:
+
+1. **A1 is one structural test.** Sprint 37 ran exactly one prior
+   graph shape (the preregistered minimal seven-node / six-edge
+   graph) with exactly one focus-restriction heuristic
+   (`screened ∩ ancestors`) on exactly one slice (Men/Random) with
+   exactly one logger (uniform-random). The lane has not been
+   stress-tested along the graph-structure axis. Declaring it
+   exhausted after one shape is premature.
+2. **Option B is the canonical next test on this lane.** The Sprint
+   36 plan names it, the Sprint 37 report names it, and the Sprint
+   36 plan's "Why This Sprint Now" section walks through why graph
+   widening is the highest-signal next move after a no-op
+   ancestor-exclusive graph. Skipping it to reopen another slice
+   would leave a specific, preregistered question unanswered.
+3. **Moving on without Option B would leave an interpretive hole.**
+   If Sprint 38 opens Women/All/BTS/a second dataset without first
+   running Option B, a future null result on a new slice cannot
+   distinguish "causal advantage does not generalize" from "causal
+   advantage needs non-trivial graph structure to appear at all."
+   Option B disambiguates those before Sprint 39 picks where to go.
+4. **Option B fits in one implementation PR.** It is a single-edge
+   graph widening plus a 6,100-second rerun (Sprint 37's runtime
+   budget) — strictly smaller than any Option D lane reopen.
+
+Option D becomes the right move if Sprint 38's Option B result is
+itself near-parity at B80 *and* the widened-graph trajectory at
+B20/B40 is also near-parity. In that case the Open Bandit A1 lane is
+genuinely exhausted along the graph-structure axis under
+`pomis_minimal_focus=True`, and Sprint 39 reopens another slice or
+dataset. See [What Happens After Sprint 38](#what-happens-after-sprint-38).
+
+## Minimal Preregistered Graph (Sprint 38 widening)
+
+The Sprint 37 graph (seven nodes, six edges) is preserved verbatim.
+Sprint 38 adds exactly one new node and exactly one new directed edge.
+
+### Added node (1)
+
+8. `logged_position_distribution`
+
+**Code-grounded justification.** The adapter's `run_experiment`
+branches on the `position_handling_flag` categorical to pick the
+logged-row subset that enters the SNIPW sum
+([`causal_optimizer/domain_adapters/bandit_log.py`](../../causal_optimizer/domain_adapters/bandit_log.py)
+lines 352–369):
+
+```python
+if position_flag == "position_1_only":
+    mask = self._position == 0
+else:
+    mask = np.ones(self._n_rounds, dtype=bool)
+```
+
+`self._position` is the logged position array (line 195) — a
+property of the dataset, not of any knob. Which of the two
+`position_handling_flag` choices is better depends on the *logged*
+position distribution: if most logged clicks happen at position 1
+(index 0 after `rankdata`), `position_1_only` is the right mask; if
+clicks are roughly uniform across positions, `marginalize` is. That
+distribution is a structural upstream variable — it is not itself a
+knob, but it causally determines which `position_handling_flag`
+choice dominates the objective.
+
+Naming it `logged_position_distribution` matches the Sprint 36 plan's
+Option B candidate list (plan "Exit Criterion" section, Option B
+bullet) and the Sprint 37 report's "Sprint 38+ Implications" section.
+
+### Added edge (1)
+
+`logged_position_distribution -> position_handling_flag`
+
+**Code-grounded justification.** The flag's behavior is a direct
+function of `self._position`
+(`bandit_log.py` lines 352–369, cited above). Per the Sprint 36
+plan's edge-justification discipline, each added edge must cite a
+specific line that makes the upstream variable structural. The line
+range above — the row-mask branch inside `run_experiment` — is the
+site that makes `logged_position_distribution` structurally upstream
+of `position_handling_flag`.
+
+No edge from `logged_position_distribution` directly to `policy_value`
+is added. The flow is:
+`logged_position_distribution -> position_handling_flag -> policy_value`
+(the second edge already exists from Sprint 37).
+
+### Bidirected edges (none, still)
+
+The Sprint 34 contract Section 4e discipline holds. No bidirected
+edges are added in Sprint 38. The "Bidirected edges (none)"
+derivation in the Sprint 36 plan carries forward unchanged —
+Sprint 38's single new node and single new edge do not introduce any
+confounder structure.
+
+### Graph after widening (Sprint 38 state)
+
+```
+nodes (8):
+  tau, eps, w_item_feature_0, w_user_item_affinity, w_item_popularity,
+  position_handling_flag, policy_value,
+  logged_position_distribution  # NEW in Sprint 38
+
+directed edges (7):
+  tau                            -> policy_value
+  eps                            -> policy_value
+  w_item_feature_0               -> policy_value
+  w_user_item_affinity           -> policy_value
+  w_item_popularity              -> policy_value
+  position_handling_flag         -> policy_value
+  logged_position_distribution   -> position_handling_flag  # NEW in Sprint 38
+
+bidirected edges: none
+```
+
+### What the engine would do with the widened graph, path by path
+
+Under the Sprint 37 engine surface (unchanged — Sprint 38 ships no
+engine or optimizer change):
+
+1. `_get_focus_variables` (`suggest.py` lines 1170–1180): the ancestor
+   set `ancestors(policy_value)` still equals the six search-space
+   variables plus the new `logged_position_distribution`. The
+   search-space intersection
+   `{v in search_space.variable_names | v in ancestors(policy_value)}`
+   still equals the full search space, because
+   `logged_position_distribution` is **not** itself a search-space
+   variable. So path 1 on its own remains a no-op — the full
+   search-space fallback triggers.
+2. A1 minimal-focus (`_apply_minimal_focus_a1`, `suggest.py` lines
+   1183–1236): the binding condition — every search-space variable
+   is an ancestor of `policy_value` — still holds, so the A1 helper
+   still applies `screened ∩ ancestors` whenever the screening
+   result is a non-empty proper subset. Under the widened graph the
+   ancestor set inside the search space is unchanged, so the A1
+   result is the same set the Sprint 37 rerun computed at every
+   (seed, budget, phase) triple.
+3. Parent-weighted exploitation (`suggest.py` lines 569–586): uses
+   `causal_graph.parents(objective_name)`. Sprint 37 graph gave
+   `parents(policy_value) = 6` search-space vars → `weights = None`
+   (no restriction). Sprint 38 widened graph still gives
+   `parents(policy_value) = 6` search-space vars (the new edge
+   targets `position_handling_flag`, not `policy_value`) → still
+   `weights = None`, still no-op.
+4. Soft-causal reranker (`_rerank_alignment_only` +
+   `_causal_alignment_score`, `suggest.py` lines 751–812 and
+   982–1021): averages over ancestors of the objective. The
+   ancestor set grows by one (`logged_position_distribution`), but
+   that variable is not in the search space, so
+   `_causal_alignment_score` skips it when it iterates over
+   ancestors in the search space (the per-variable normalized
+   displacement loop at lines 1010–1019 only fires when the
+   ancestor name is a key in `candidate` and `best_params`). The
+   reranker's per-seed output is therefore identical to Sprint 37.
+5. `_suggest_causal_gp`: inert (not requested by the benchmark).
+6. `causal_exploration_weight`: pinned to `0.0`, inert.
+
+So — honestly — the Sprint 38 widened graph is **predicted to be a
+no-op** along every engine path that already existed. That is
+exactly the point. Sprint 37 broke the Sprint 35 bit-identical tie
+by turning `pomis_minimal_focus` on; if Sprint 38's widened graph
+reproduces the Sprint 37 B80 near-parity, that is strong evidence
+the Open Bandit A1 lane is genuinely exhausted along the pure
+graph-widening axis under this engine surface, and Sprint 39 has
+clean grounds to pick between a bidirected-edge Option A2 variant
+or Option D.
+
+**This is a preregistered no-op prediction, not a hidden one.** The
+value of running it is that the *prediction itself* is the
+falsifiable claim: if Sprint 38 produces a B80 certified or trending
+row in either direction, the Sprint 37 engine-surface analysis is
+incomplete and must be redone before any further Open Bandit sprint.
+
+## Exit Criterion
+
+Sprint 38 is successful if:
+
+1. `BanditLogAdapter.get_prior_graph()` returns the widened eight-node
+   / seven-edge graph above, with no bidirected edges and no other
+   structural changes
+2. A Sprint 37-shape rerun of Men/Random under that graph produces a
+   complete verdict table at B20 / B40 / B80 for `random` /
+   `surrogate_only` / `causal`, 10 seeds per cell, all five Section 7
+   gates PASS, Ax/BoTorch-only backend provenance on every verdict
+   cell
+3. The Sprint 38 report records the B80 verdict row under the Sprint
+   33 / Sprint 35 / Sprint 37 labels: certified (`p <= 0.05`),
+   trending (`0.05 < p <= 0.15`), or not significant (`p > 0.15`) —
+   with the two-sided MWU convention, same as Sprint 37
+4. The report reconciles the observed outcome against the
+   preregistered H0 / H1 / H2 below, and the Sprint 37 report's
+   per-path engine analysis
+5. The report calls the Option B Open Bandit A1 lane status for
+   Sprint 39: exhausted (go to Option D), or still productive (run
+   one more focused iteration — either A2 bidirected-edge variant or
+   Option C heuristic, with a preregistered hypothesis)
+
+### Preregistered H0 / H1 / H2 for the Sprint 38 rerun
+
+> **H0 (predicted).** On the Men/Random slice, B80 two-sided
+> Mann-Whitney U p-value on SNIPW policy values between `causal` and
+> `surrogate_only`, 10 seeds per arm, satisfies `p > 0.15` (Sprint 34
+> contract Section 6e "not significant" band). This is the same H0
+> Sprint 37 confirmed. The Sprint 38 engine-path analysis above
+> predicts the widened graph is a no-op along every path that
+> already existed under Sprint 37's minimal-focus wiring, so the B80
+> row should recapitulate the Sprint 37 near-parity.
+>
+> The prediction assumes `causal_softness = 0.5`,
+> `causal_exploration_weight = 0.0`, `strategy` routes through
+> `_suggest_bayesian` (not `_suggest_causal_gp`), Ax/BoTorch is
+> available (no RF fallback), `pomis_minimal_focus = True` on the
+> `causal` arm only, and no new engine path reads `causal_graph`
+> between Sprint 37 and the Sprint 38 rerun. If any of those change,
+> the prediction must be revisited before the verdict is quoted.
+
+> **H1 (alternative — certified).** `p <= 0.05` at B80. The
+> mean-SNIPW direction (`causal` higher or lower than
+> `surrogate_only`) is reported as observed; this is a "certified"
+> Sprint 33 label in either direction. A certified
+> `causal > surrogate_only` row would be the first graph-induced
+> multi-action causal advantage in the scorecard and would
+> immediately invalidate the Sprint 38 engine-path no-op prediction,
+> requiring a diagnostic rerun before Sprint 39 plans. A certified
+> `causal < surrogate_only` row would be a real regression and must
+> be diagnosed before any further Open Bandit iteration.
+
+> **H2 (trending).** `0.05 < p <= 0.15` at B80. Same two-sided
+> convention as H1: the direction is reported as observed. A
+> trending row in either direction is a soft signal the Sprint 37
+> engine-path analysis is incomplete and warrants a diagnostic
+> rerun, but does not, on its own, invalidate the Sprint 38 verdict
+> rule.
+
+B20 and B40 are reported for trajectory analysis but do not gate the
+Sprint 38 verdict, matching the Criteo / Sprint 35 / Sprint 37
+conventions. The B20 row is explicitly **not** the focus — Sprint 38
+is not a B20-chase sprint, and the Sprint 37 B20 trend (`p = 0.0820`,
+`causal < surrogate_only` on 8/10 seeds) is a trajectory artifact,
+not a Sprint 38 target.
+
+Success gates that must also hold for the Sprint 38 verdict row to
+publish (inherited from Sprint 34 contract Section 7 and Sprint 37):
+
+1. all five Section 7 gates PASS on the rerun (unchanged thresholds)
+2. `null_control` permutation seed is `20260419` (the same as
+   Sprint 35 and Sprint 37, taken from the committed Sprint 35 and
+   Sprint 37 reports)
+3. backend provenance records `ax_botorch` on every verdict cell; no
+   RF fallback mixing
+
+### Power and the H0-vs-H1 boundary
+
+Sprint 38 keeps the Sprint 33 / Sprint 35 / Sprint 37 convention of
+10 seeds per arm. At n=10 per arm, a two-sided Mann-Whitney U test
+has limited power to detect small SNIPW differences: Sprint 37's
+optimized-strategy B80 std is ≈ 8e-6, so a real but small (~1%)
+causal advantage could still land in H2 rather than H1 under 10
+seeds. A Sprint 39 power-extension rerun is the explicit answer to
+that risk if Sprint 38 produces a trending row (H2); **Sprint 38
+itself does not extend power on A1 or on Option B**.
+
+## Recommended Issue Shape
+
+**One issue for Sprint 38.** The scope is a single graph widening
+(one new node, one new edge) plus a Sprint 37-shape rerun and report.
+This fits cleanly in one implementation PR — same footprint as
+Sprint 37's PR #198 (adapter change + engine flag + rerun + report).
+Sprint 37 did two things (graph + engine flag); Sprint 38 does one
+thing (graph-only widening), so the scope is strictly smaller.
+
+The issue title should read roughly **"Sprint 38: Open Bandit prior
+graph widening (Option B — `logged_position_distribution`)"**. The
+issue body should pin the preregistered H0 / H1 / H2, the Option B
+guardrails (one node, one edge, no bidirected edges, no engine
+change, no new heuristic), and the exhaustion criterion for Sprint
+39.
+
+## Empirical Setup
+
+The Sprint 37 setup is the starting point for Sprint 38 and is
+preregistered here so Sprint 38 cannot silently drift:
+
+1. **Slice:** full Men/Random, 452,949 rows, SHA-256 match on
+   `men.csv` per the Sprint 35 report "Data Provenance" section
+2. **Budgets:** 20, 40, 80 (B80 gates the verdict)
+3. **Seeds:** 0..9 (10 seeds per cell)
+4. **Strategies:** `random`, `surrogate_only`, `causal`
+5. **Estimator (primary):** SNIPW, `min_propensity_clip =
+   1 / (2 · 34 · 3) ≈ 4.9019608e-03` (Sprint 34 contract Section 5c)
+6. **Estimators (secondary):** DM, DR (Dudík et al. 2011 in-module
+   form; OBP DR wrapper remains optional)
+7. **Backend:** Ax/BoTorch; no RF-fallback mixing in the verdict row
+8. **Section 7 gates:** all five, unchanged thresholds
+9. **Null-control permutation seed:** `20260419` (same as Sprint 35
+   and Sprint 37). The authoritative source is the committed
+   Sprint 35 report
+   (`thoughts/shared/docs/sprint-35-open-bandit-benchmark-report.md`,
+   "Permutation seed" line and the Section 7a header) and the
+   committed Sprint 37 report
+   (`thoughts/shared/docs/sprint-37-open-bandit-prior-graph-report.md`,
+   "Configuration" section)
+10. **Propensity schema:** conditional `P(item | position) = 1/34`
+    (confirmed Sprint 35.A smoke test;
+    `causal_optimizer/domain_adapters/bandit_log.py`
+    `propensity_schema` class constant line 181)
+11. **A1 flag:** `pomis_minimal_focus = True` only on the `causal`
+    arm; `False` for `surrogate_only` and `random` (unchanged from
+    Sprint 37)
+12. **Verdict rule:** two-sided Mann-Whitney U on B80 SNIPW values,
+    10 seeds per strategy; Sprint 33 scorecard labels unchanged
+    (`p <= 0.05` certified, `0.05 < p <= 0.15` trending,
+    `p > 0.15` not significant)
+
+## What Sprint 38 Must Not Do
+
+Hard exclusions, inherited from the Sprint 34 contract Section 9,
+the Sprint 35 report, the Sprint 36 plan, and the Sprint 37 report:
+
+1. **No second new node.** The widened graph adds exactly one node
+   (`logged_position_distribution`) and exactly one edge. Any
+   additional node — including `request_item_overlap`, which the
+   Sprint 36 plan also listed as a candidate — is deferred to
+   Sprint 39+. Mid-sprint scope expansion into a two-node widening
+   is the exact anti-pattern the Sprint 36 review caught.
+2. **No bidirected edges.** The Sprint 34 contract Section 4e
+   discipline holds. Bidirected edges remain deferred.
+3. **No engine or optimizer change.** `pomis_minimal_focus` stays
+   default-off at the engine level and is enabled only for the
+   `causal` arm by the Open Bandit benchmark harness (unchanged from
+   Sprint 37). The soft-causal reranker, `_get_focus_variables`,
+   `_apply_minimal_focus_a1`, the parent-weighted exploitation
+   perturbation, and `_suggest_causal_gp` are not edited in
+   Sprint 38.
+4. **No new heuristic.** Option C (magnitude-thresholded minimality
+   heuristic or any other replacement for `screened ∩ ancestors`)
+   is deferred. Sprint 38 tests one axis at a time — graph
+   structure, not heuristic.
+5. **No new slice.** Women, All, BTS-primary, and cross-campaign
+   aggregation remain out of scope. Men/Random only.
+6. **No DRos-primary.** DRos remains on the Sprint 35+ shortlist;
+   the first Option B result must quote SNIPW.
+7. **No slate-level or ranking-aware OPE.**
+8. **No second dataset.** MovieLens, Outbrain, Yahoo! R6 stay on the
+   Sprint 39+ backlog.
+9. **No power extension on A1.** Sprint 37's B80 row is unambiguous;
+   a Sprint 38 power extension would re-open a settled question.
+10. **No B20 chase.** Sprint 37's B20 trend (`p = 0.0820`,
+    `causal < surrogate_only` on 8/10 seeds) is explicitly not the
+    Sprint 38 target. Sprint 38 reports B20 for trajectory analysis
+    only; the verdict row is B80.
+11. **No relaxation of any Section 7 gate.** Sprint 38's rerun must
+    hold all five gates as-is at Sprint 34 contract thresholds.
+12. **No auto-discovered graph overlay.** Hybrid mode remains unused.
+    The widened graph is preregistered, not learned.
+13. **No multi-objective extension.** The objective remains
+    `policy_value` maximize.
+14. **No force-push, no hook skipping, no auto-merge.** Standard
+    project rules.
+15. **No updates to `handoff.md` or `07-benchmark-state.md` from
+    Sprint 38's implementation PR** beyond the post-merge canonical
+    sync. Track A owns those; Sprint 38's implementation PR should
+    only touch adapter code, unit tests, the Sprint 38 report, and
+    the report-linked run command.
+
+## Strategy
+
+Sprint 38 runs in two stages inside one implementation PR:
+
+1. **Graph widening.** Edit
+   `BanditLogAdapter.get_prior_graph()` to return the eight-node /
+   seven-edge widened graph above. Add unit tests that pin the
+   added node, the added edge, the preserved existing edges, and
+   the absence of bidirected edges. Update the docstring to cite
+   the Sprint 38 plan (this document).
+2. **Rerun and report.** Execute the Sprint 37 reproducibility
+   command verbatim against the widened graph. Write the Sprint 38
+   report to
+   `thoughts/shared/docs/sprint-38-open-bandit-graph-widening-report.md`
+   in the Sprint 37 report's shape (summary, verdict rows,
+   per-budget tables, Section 7 gates, per-seed detail, ESS
+   diagnostics, hypothesis reconciliation, interpretation, scope
+   boundaries, attribution).
+
+The rerun command is the Sprint 37 command with no CLI-flag changes
+— graph widening lives inside `BanditLogAdapter.get_prior_graph()`,
+not at the benchmark surface:
+
+```bash
+uv run python scripts/open_bandit_benchmark.py \
+  --data-path /Users/robertwelborn/Projects/_local/causal-optimizer/data/open_bandit/open_bandit_dataset \
+  --budgets 20,40,80 \
+  --seeds 0,1,2,3,4,5,6,7,8,9 \
+  --strategies random,surrogate_only,causal \
+  --null-control \
+  --permutation-seed 20260419 \
+  --output /Users/robertwelborn/Projects/_local/causal-optimizer/artifacts/sprint-38-open-bandit-graph-widening/men_random_results.json
+```
+
+## Success Criteria
+
+Sprint 38 is successful if:
+
+1. this recommendation and its execution prompt merge (planning PR)
+2. a separate implementation PR lands the widened graph plus a
+   complete Sprint 38 rerun report
+3. the report's B80 row is labeled under the Sprint 33 / Sprint 35 /
+   Sprint 37 scorecard (certified / trending / not significant) with
+   the two-sided MWU convention
+4. the report reconciles the observed B80 outcome against the
+   preregistered H0 / H1 / H2 without re-tuning them to fit the
+   observation
+5. all five Section 7 gates PASS at Sprint 34 contract thresholds
+6. the report calls Sprint 39's next move explicitly: exhausted
+   (Option D), A2 bidirected-edge variant, Option C heuristic, or a
+   second Option B node (`request_item_overlap`)
+
+Sprint 38 is **not** successful if:
+
+1. the implementation PR adds more than one node or more than one
+   edge to the graph
+2. the implementation PR introduces a bidirected edge
+3. the implementation PR touches `causal_optimizer/optimizer/suggest.py`,
+   `causal_optimizer/engine/loop.py`, or any other engine surface
+4. the preregistered H0 / H1 / H2 text is tuned to match an
+   unpublished observation
+5. the Sprint 38 report reframes the B20 trend as a Sprint 38
+   target
+6. the rerun uses a permutation seed other than `20260419`
+7. any Section 7 gate is relaxed
+8. the rerun mixes RF-fallback and Ax/BoTorch verdict cells
+
+## What Happens After Sprint 38
+
+The Sprint 38 report must close by naming Sprint 39's next move, in
+one of four shapes. Sprint 38's job is to run the rerun and record
+the outcome; Sprint 39's issue body records the choice, the same
+way Sprint 36 recorded Sprint 37's Option A1 vs A2 pick.
+
+1. **Sprint 38 B80 is near-parity (H0 confirmed, same as Sprint 37).**
+   The Open Bandit A1 lane is exhausted along the pure graph-widening
+   axis. Sprint 39 goes to **Option D**: reopen Women, BTS-primary,
+   or a second dataset (MovieLens, Outbrain, Yahoo! R6) with a fresh
+   preregistered hypothesis.
+2. **Sprint 38 B80 is trending (H2, either direction).** The Sprint
+   37 engine-path no-op prediction was incomplete. Sprint 39 runs a
+   diagnostic rerun (5 extra seeds, same graph) before picking any
+   next structural move, to rule out a 10-seed power-limited H2
+   miss.
+3. **Sprint 38 B80 is certified `causal > surrogate_only` (H1,
+   positive).** First graph-induced multi-action causal advantage in
+   the scorecard. Sprint 39 replicates on a held-out slice (Women or
+   BTS-primary) before any Option C or Option A2 work, to confirm
+   the advantage is not Men/Random-specific.
+4. **Sprint 38 B80 is certified `causal < surrogate_only` (H1,
+   negative).** Real regression. Sprint 39 reverts Option B, reruns
+   Option A1 with the Sprint 37 graph as a sanity check, and opens a
+   diagnostic issue to attribute the regression before any further
+   Open Bandit iteration.
+
+In all four cases, the Sprint 39 issue body records which path
+Sprint 38's outcome selected and cites the specific rows / p-values
+that forced the choice.
+
+## References
+
+- Sprint 34 Open Bandit contract: [sprint-34-open-bandit-contract.md](../docs/sprint-34-open-bandit-contract.md)
+- Sprint 35 Open Bandit benchmark report: [sprint-35-open-bandit-benchmark-report.md](../docs/sprint-35-open-bandit-benchmark-report.md)
+- Sprint 36 preregistration plan: [26-sprint-36-recommendation.md](26-sprint-36-recommendation.md)
+- Sprint 37 Open Bandit prior-graph report: [sprint-37-open-bandit-prior-graph-report.md](../docs/sprint-37-open-bandit-prior-graph-report.md)
+- `BanditLogAdapter`: `causal_optimizer/domain_adapters/bandit_log.py`
+  (see `get_prior_graph`, lines 513–541, and `run_experiment` row-mask
+  branch, lines 352–369, for the Option B node justification)
+- Open Bandit OPE stack and Section 7 gates: `causal_optimizer/benchmarks/open_bandit.py`
+- Open Bandit benchmark runner: `causal_optimizer/benchmarks/open_bandit_benchmark.py`
+  (enables `pomis_minimal_focus` only on the `causal` arm, line 541)
+- Open Bandit CLI entry point: `scripts/open_bandit_benchmark.py`
+- Engine graph-usage sites:
+  - `causal_optimizer/optimizer/suggest.py` lines 1170–1180
+    (`_get_focus_variables`)
+  - `causal_optimizer/optimizer/suggest.py` lines 1183–1236
+    (`_apply_minimal_focus_a1`, Sprint 37 A1 helper)
+  - `causal_optimizer/optimizer/suggest.py` lines 751–812
+    (soft-causal reranker inside `_suggest_bayesian`)
+  - `causal_optimizer/optimizer/suggest.py` lines 982–1021
+    (`_causal_alignment_score`)
+- `CausalGraph` type: `causal_optimizer/types.py`
+- `DomainAdapter.get_prior_graph` contract:
+  `causal_optimizer/domain_adapters/base.py`
+- Existing prior-graph examples:
+  `causal_optimizer/domain_adapters/marketing_logs.py`
+  (`MarketingLogAdapter.get_prior_graph`),
+  `causal_optimizer/benchmarks/criteo.py`
+  (`criteo_projected_prior_graph`)
+- Sprint 38 tracked issue: `#201`

--- a/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
+++ b/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
@@ -38,7 +38,7 @@ Read first:
 8. `thoughts/shared/plans/07-benchmark-state.md`
 9. `causal_optimizer/domain_adapters/bandit_log.py`
    Specifically re-read `run_experiment` lines 346–475 (the row-mask
-   branch at 352–369 is the code site that grounds the
+   branch at 364–367 is the code site that grounds the
    `logged_position_distribution -> position_handling_flag` edge) and
    `get_prior_graph` lines 513–541 (the function you are editing).
 10. `causal_optimizer/benchmarks/open_bandit.py`
@@ -51,8 +51,10 @@ Read first:
     All the `causal_graph` read sites the Sprint 36 plan enumerated,
     in particular `_get_focus_variables` (lines 1170–1180),
     `_apply_minimal_focus_a1` (lines 1183–1236), and
-    `_causal_alignment_score` (lines 982–1021). Sprint 38 does **not**
-    edit any of these — the sprint is graph-only.
+    `_causal_alignment_score` (lines 1015–1054; the per-variable
+    displacement loop is at 1043–1052 with the search-space-membership
+    filter at 1044–1046). Sprint 38 does **not** edit any of these —
+    the sprint is graph-only.
 14. `tests/unit/test_bandit_log_prior_graph.py`
 15. `tests/unit/test_a1_minimal_focus.py`
 
@@ -230,8 +232,10 @@ Workflow (mandatory, in this order):
   simplify / lint / format / mypy / coverage issue it surfaces.
 - `gh pr create`: PR title under 70 characters, e.g.
   "feat: sprint 38 open bandit graph widening (option B)". Body
-  uses a HEREDOC, references the Sprint 38 issue, and includes a
-  Summary + Test plan.
+  uses a HEREDOC, references the Sprint 38 implementation issue
+  (opened by the orchestration coordinator after the Sprint 38
+  planning PR, which was tracked by issue `#201`, lands), and
+  includes a Summary + Test plan.
 - `/gauntlet`: run after the PR is open. Let it iterate until
   greploop + claudeloop + check-pr all pass.
 - **Do not merge.** Human review and explicit approval are required

--- a/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
+++ b/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
@@ -113,6 +113,24 @@ Produce in one PR:
      `position_handling_flag`).
    - Pin that `logged_position_distribution` is **not** a search-space
      variable.
+   - Concrete before/after edits required in this file:
+     - `test_graph_has_*_directed_edges` at line 71 — change
+       `assert len(graph.edges) == 6` to `assert len(graph.edges) == 7`
+       (and rename the test to match).
+     - `test_every_search_variable_is_an_ancestor_of_policy_value`
+       at line 92 — change
+       `assert ancestors == set(_SEARCH_VARIABLES)` to
+       `assert ancestors == set(_SEARCH_VARIABLES) | {"logged_position_distribution"}`.
+     - `test_no_chain_edges_between_search_variables` at line 94 —
+       the assertion `assert v == "policy_value"` for every edge no
+       longer holds because the new edge terminates at
+       `position_handling_flag`. Either narrow the assertion to the
+       six Sprint 37 edges, or replace with a shape-explicit edge-set
+       equality check.
+     - `test_graph_has_*_nodes` at line 66 — change
+       `assert len(graph.nodes) == 7` to `assert len(graph.nodes) == 8`
+       and add `"logged_position_distribution"` to the expected-node
+       set literal.
    - Keep every Sprint 37 assertion that is still true; update only
      the cells that changed.
 

--- a/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
+++ b/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
@@ -1,7 +1,17 @@
 Work on Sprint 38: land Option B — Open Bandit prior-graph widening
-with one non-ancestor structural node
+with one non-search-space structural node
 (`logged_position_distribution`) — and run the Sprint 37-shape rerun
 against the widened graph.
+
+**Terminology.** The orchestration prompt and the Sprint 36 plan
+used the phrase "non-ancestor structural node" for this
+(`logged_position_distribution`); the Sprint 38 recommendation
+retires that phrase because after adding the edge
+`logged_position_distribution -> position_handling_flag`, the node
+*is* an ancestor of `policy_value` via the two-hop path. The A1
+binding condition still holds because the node is not a
+search-space variable, not because it is a non-ancestor. See the
+Sprint 38 recommendation's "Sprint Theme" terminology note.
 
 Canonical source: the Sprint 38 recommendation is authoritative for
 every contract decision (graph shape, hard constraints,

--- a/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
+++ b/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
@@ -1,3 +1,10 @@
+> **If you edit anything in this prompt, edit
+> `thoughts/shared/plans/27-sprint-38-recommendation.md` first and
+> copy the change down.** The recommendation is the single source
+> of truth for graph shape, exclusion list, H0/H1/H2, and the
+> reproducibility command. Any conflict is resolved in favor of
+> the recommendation.
+
 Work on Sprint 38: land Option B — Open Bandit prior-graph widening
 with one non-search-space structural node
 (`logged_position_distribution`) — and run the Sprint 37-shape rerun

--- a/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
+++ b/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
@@ -74,6 +74,23 @@ Produce in one PR:
    - `get_prior_graph()` returns the eight-node / seven-edge widened
      graph from the Sprint 38 recommendation's "Minimal Preregistered
      Graph (Sprint 38 widening)" section, verbatim.
+   - **Implementation note.** The Sprint 37 `get_prior_graph` body
+     programmatically enumerates the search space:
+     `edges = [(name, "policy_value") for name in self.get_search_space().variable_names]`
+     (`bandit_log.py` line 540). That pattern cannot express the new
+     Sprint 38 edge, because
+     `logged_position_distribution -> position_handling_flag` has a
+     source that is not a search-space variable. The implementation
+     must switch to an explicit edge list — build
+     `search_edges = [(name, "policy_value") for name in self.get_search_space().variable_names]`
+     and then extend with the Sprint 38 edge, or write out all seven
+     edges as literal tuples. Do not keep the list-comprehension-only
+     pattern; it silently drops the new edge.
+   - Unit tests must pin edges by name tuple (see item 2 below), not
+     by counting `len(search_space.variables)`. The Sprint 37 shape of
+     `len(edges) == len(search_space.variables)` no longer holds
+     under the widened graph (seven edges, six search-space
+     variables).
    - The function's docstring cites Sprint 38 (this document and the
      plan) and keeps the Sprint 37 lane reference for context.
    - No other edits to `bandit_log.py`. The search space stays at six

--- a/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
+++ b/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
@@ -1,0 +1,273 @@
+Work on Sprint 38: land Option B — Open Bandit prior-graph widening
+with one non-ancestor structural node
+(`logged_position_distribution`) — and run the Sprint 37-shape rerun
+against the widened graph.
+
+Canonical source: the Sprint 38 recommendation is authoritative for
+every contract decision (graph shape, hard constraints,
+anti-patterns, Exit Criterion, what is in vs out of scope). This
+prompt duplicates those items so an implementation agent has a
+self-contained brief, but any conflict between the two documents is
+resolved in favor of the recommendation. If you amend this prompt,
+update the recommendation first.
+
+All paths below are **repo-relative** — resolve them from the root of
+your `causal-optimizer` checkout (or worktree).
+
+Primary recommendation:
+- `thoughts/shared/plans/27-sprint-38-recommendation.md`
+
+Read first:
+1. `CLAUDE.md`
+2. `thoughts/shared/plans/27-sprint-38-recommendation.md`
+3. `thoughts/shared/docs/sprint-37-open-bandit-prior-graph-report.md`
+4. `thoughts/shared/plans/26-sprint-36-recommendation.md`
+5. `thoughts/shared/docs/sprint-35-open-bandit-benchmark-report.md`
+6. `thoughts/shared/docs/sprint-34-open-bandit-contract.md`
+7. `thoughts/shared/docs/handoff.md`
+8. `thoughts/shared/plans/07-benchmark-state.md`
+9. `causal_optimizer/domain_adapters/bandit_log.py`
+   Specifically re-read `run_experiment` lines 346–475 (the row-mask
+   branch at 352–369 is the code site that grounds the
+   `logged_position_distribution -> position_handling_flag` edge) and
+   `get_prior_graph` lines 513–541 (the function you are editing).
+10. `causal_optimizer/benchmarks/open_bandit.py`
+11. `causal_optimizer/benchmarks/open_bandit_benchmark.py`
+    Specifically the `pomis_minimal_focus=(strategy == "causal")`
+    wiring at line 541 — Sprint 38 does not change this. The flag
+    stays on for the `causal` arm only.
+12. `causal_optimizer/types.py` (`CausalGraph`)
+13. `causal_optimizer/optimizer/suggest.py`
+    All the `causal_graph` read sites the Sprint 36 plan enumerated,
+    in particular `_get_focus_variables` (lines 1170–1180),
+    `_apply_minimal_focus_a1` (lines 1183–1236), and
+    `_causal_alignment_score` (lines 982–1021). Sprint 38 does **not**
+    edit any of these — the sprint is graph-only.
+14. `tests/unit/test_bandit_log_prior_graph.py`
+15. `tests/unit/test_a1_minimal_focus.py`
+
+Goal:
+- Ship an implementation PR that (a) widens the Open Bandit
+  preregistered prior graph by exactly one node
+  (`logged_position_distribution`) and exactly one directed edge
+  (`logged_position_distribution -> position_handling_flag`), (b)
+  updates the unit tests that pin the graph shape, and (c) reruns
+  the Sprint 37-shape Men/Random benchmark against the widened
+  graph and writes a Sprint 38 report.
+- No engine change, no optimizer change, no new heuristic, no new
+  slice, no second dataset, no new search-space variable, no
+  bidirected edge, no relaxation of any Section 7 gate.
+
+Produce in one PR:
+
+1. Updated adapter: `causal_optimizer/domain_adapters/bandit_log.py`
+   - `get_prior_graph()` returns the eight-node / seven-edge widened
+     graph from the Sprint 38 recommendation's "Minimal Preregistered
+     Graph (Sprint 38 widening)" section, verbatim.
+   - The function's docstring cites Sprint 38 (this document and the
+     plan) and keeps the Sprint 37 lane reference for context.
+   - No other edits to `bandit_log.py`. The search space stays at six
+     variables; `run_experiment` is not edited; `to_bandit_feedback`
+     is not edited.
+
+2. Updated unit tests: `tests/unit/test_bandit_log_prior_graph.py`
+   - Pin the eight-node graph: exactly
+     `{"tau", "eps", "w_item_feature_0", "w_user_item_affinity",
+     "w_item_popularity", "position_handling_flag", "policy_value",
+     "logged_position_distribution"}`.
+   - Pin the seven directed edges: the six Sprint 37 edges plus the
+     new `("logged_position_distribution", "position_handling_flag")`
+     edge.
+   - Pin `bidirected_edges` is empty.
+   - Pin `ancestors(policy_value)` to include
+     `logged_position_distribution` (via the two-hop path through
+     `position_handling_flag`).
+   - Pin that `logged_position_distribution` is **not** a search-space
+     variable.
+   - Keep every Sprint 37 assertion that is still true; update only
+     the cells that changed.
+
+3. Sprint 38 benchmark rerun:
+   - Execute the Sprint 37 reproducibility command verbatim
+     (reproduced in the Sprint 38 recommendation's "Strategy"
+     section). No CLI-flag changes; the widening lives inside
+     `BanditLogAdapter.get_prior_graph()`.
+   - Write the artifact JSON to the Sprint 38 path under
+     `artifacts/sprint-38-open-bandit-graph-widening/men_random_results.json`
+     (the `--output` flag in the reproducibility command already
+     points here).
+   - The artifact JSON is **local only**, not committed, matching the
+     Sprint 35 / Sprint 37 convention.
+
+4. Sprint 38 benchmark report:
+   `thoughts/shared/docs/sprint-38-open-bandit-graph-widening-report.md`
+   - Same shape as
+     `thoughts/shared/docs/sprint-37-open-bandit-prior-graph-report.md`.
+   - Summary names the Sprint 38 verdict row under the Sprint 33 /
+     Sprint 35 / Sprint 37 scorecard labels (certified / trending /
+     not significant), two-sided MWU convention.
+   - Verdict rows for B20 / B40 / B80, `causal` vs
+     `surrogate_only` vs `random`, 10 seeds each cell.
+   - Per-budget outcome tables (population std, ddof=0 — same as
+     Sprint 37).
+   - Per-seed detail tables at B80 and B20 (for trajectory
+     diagnosis, not for a B20 verdict).
+   - Secondary estimator rows (DM and DR), with the DR / SNIPW
+     cross-check number for Section 7e.
+   - Section 7 support gates, all five, with the same thresholds
+     and observed-value columns as Sprint 37.
+   - ESS diagnostics table at B80 (the five columns Sprint 37's
+     "ESS Diagnostics" table used).
+   - Hypothesis reconciliation against the preregistered H0 / H1 /
+     H2 copied verbatim from the Sprint 38 recommendation. **Do not
+     re-tune the hypothesis text.**
+   - Interpretation section: explicitly answer "did the Sprint 37
+     engine-path no-op prediction hold under the widened graph, yes
+     or no, and with what p-value?"
+   - Scope boundaries section: same list as Sprint 37's "Scope
+     Boundaries" section.
+   - Next-move section: name Sprint 39's next move under the four
+     branches the Sprint 38 recommendation's "What Happens After
+     Sprint 38" section enumerates (exhausted-D /
+     trending-diagnostic / certified-positive-H1 /
+     certified-negative-H1).
+
+5. Docstring + reference updates in the adapter:
+   - `BanditLogAdapter.get_prior_graph` docstring cites the Sprint 38
+     recommendation by path.
+   - Inline comment near the `get_prior_graph` return explains the
+     two-hop ancestor path through `logged_position_distribution`.
+
+6. Nothing else. In particular, do **not**:
+   - edit `causal_optimizer/optimizer/suggest.py`
+   - edit `causal_optimizer/engine/loop.py`
+   - edit `causal_optimizer/benchmarks/open_bandit.py` or
+     `causal_optimizer/benchmarks/open_bandit_benchmark.py`
+   - add any new engine flag
+   - add a second new node (including `request_item_overlap`)
+   - add any bidirected edge
+   - edit `tests/unit/test_a1_minimal_focus.py`
+     (the A1 helper behavior is unchanged under the widened graph
+     — the binding condition "every search-space variable is an
+     ancestor of `policy_value`" still holds)
+   - edit `thoughts/shared/docs/handoff.md` or
+     `thoughts/shared/plans/07-benchmark-state.md` (Track A will
+     sync those after Sprint 38 lands)
+   - edit `README.md`
+   - edit the Sprint 35 or Sprint 37 reports
+   - relax any Section 7 gate threshold
+   - change the null-control permutation seed away from `20260419`
+   - mix RF-fallback and Ax/BoTorch verdict cells in the report
+
+Hard constraints (inherited from the Sprint 38 recommendation's
+"What Sprint 38 Must Not Do" section):
+
+1. **Exactly one new node**, `logged_position_distribution`. No
+   `request_item_overlap`. No third node. Mid-sprint scope expansion
+   is the specific anti-pattern the Sprint 36 review caught.
+2. **Exactly one new edge**,
+   `logged_position_distribution -> position_handling_flag`. No edge
+   from the new node directly to `policy_value`. No reverse
+   direction.
+3. **No bidirected edges.** Sprint 34 contract Section 4e.
+4. **No engine or optimizer change.** `pomis_minimal_focus` stays
+   default-off at the engine level; the benchmark harness keeps it
+   `True` only on the `causal` arm — same wiring as Sprint 37
+   (`open_bandit_benchmark.py` line 541).
+5. **No new heuristic.** Option C is deferred to Sprint 39+ if
+   Sprint 38's outcome warrants it.
+6. **No new slice.** Men/Random only.
+7. **No DRos-primary.** SNIPW is the primary estimator.
+8. **No slate-level OPE.**
+9. **No second dataset.**
+10. **No power extension on A1.** Sprint 37's B80 row is unambiguous.
+11. **No B20 chase.** Sprint 38's verdict row is B80.
+12. **No Section 7 relaxation.**
+13. **No auto-discovery overlay.**
+14. **No multi-objective extension.**
+15. **No force-push, no hook skipping, no auto-merge.**
+
+Workflow (mandatory, in this order):
+
+```text
+/tdd -> implement -> /polish -> gh pr create -> /gauntlet -> report PR URL
+```
+
+- Start from a fresh worktree based on `origin/main` after the
+  Sprint 38 planning PR merges.
+- `/tdd`: write failing tests first that pin the widened graph shape
+  (node set, edge set, absence of bidirected edges, two-hop ancestor
+  path, `logged_position_distribution` not in search space). Then
+  implement the adapter change to make them pass.
+- `/polish`: run before creating the PR. Do not skip. Fix every
+  simplify / lint / format / mypy / coverage issue it surfaces.
+- `gh pr create`: PR title under 70 characters, e.g.
+  "feat: sprint 38 open bandit graph widening (option B)". Body
+  uses a HEREDOC, references the Sprint 38 issue, and includes a
+  Summary + Test plan.
+- `/gauntlet`: run after the PR is open. Let it iterate until
+  greploop + claudeloop + check-pr all pass.
+- **Do not merge.** Human review and explicit approval are required
+  per the PR merge policy in `CLAUDE.md`.
+
+Falsifiable outcome (copied verbatim from the Sprint 38 recommendation):
+
+> **H0 (predicted).** On the Men/Random slice, B80 two-sided
+> Mann-Whitney U p-value on SNIPW policy values between `causal` and
+> `surrogate_only`, 10 seeds per arm, satisfies `p > 0.15`. This is
+> the same H0 Sprint 37 confirmed. The Sprint 38 engine-path
+> analysis predicts the widened graph is a no-op along every path
+> that already existed under Sprint 37's minimal-focus wiring, so
+> the B80 row should recapitulate the Sprint 37 near-parity.
+>
+> The prediction assumes `causal_softness = 0.5`,
+> `causal_exploration_weight = 0.0`, `strategy` routes through
+> `_suggest_bayesian` (not `_suggest_causal_gp`), Ax/BoTorch is
+> available (no RF fallback), `pomis_minimal_focus = True` on the
+> `causal` arm only, and no new engine path reads `causal_graph`
+> between Sprint 37 and the Sprint 38 rerun.
+
+> **H1 (alternative — certified).** `p <= 0.05` at B80. A certified
+> row in either direction invalidates the Sprint 38 no-op
+> prediction and forces a diagnostic rerun before Sprint 39 plans.
+
+> **H2 (trending).** `0.05 < p <= 0.15` at B80. Two-sided; direction
+> reported as observed.
+
+Success gates that must hold for the Sprint 38 verdict row to
+publish:
+
+1. all five Section 7 gates PASS at Sprint 34 contract thresholds
+2. null-control permutation seed is `20260419`
+3. backend provenance is `ax_botorch` on every verdict cell; no
+   RF-fallback mixing
+
+Reproducibility command (Sprint 38):
+
+```bash
+uv run python scripts/open_bandit_benchmark.py \
+  --data-path /Users/robertwelborn/Projects/_local/causal-optimizer/data/open_bandit/open_bandit_dataset \
+  --budgets 20,40,80 \
+  --seeds 0,1,2,3,4,5,6,7,8,9 \
+  --strategies random,surrogate_only,causal \
+  --null-control \
+  --permutation-seed 20260419 \
+  --output /Users/robertwelborn/Projects/_local/causal-optimizer/artifacts/sprint-38-open-bandit-graph-widening/men_random_results.json
+```
+
+The CLI requires no new flags — the widening lives inside
+`BanditLogAdapter.get_prior_graph()` and the benchmark harness
+already enables `pomis_minimal_focus` only on the `causal` arm.
+
+Deliverables (report back in the PR body):
+
+1. PR URL
+2. the observed B80 verdict row and p-value
+3. whether H0 held, and with what Sprint 33 label
+4. all five Section 7 gate statuses
+5. the Sprint 39 next-move branch Sprint 38's outcome selected
+   (exhausted-D / trending-diagnostic / certified-positive-H1 /
+   certified-negative-H1)
+6. gauntlet status
+
+Do not merge. Leave the PR open for human review.

--- a/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
+++ b/thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md
@@ -114,9 +114,16 @@ Produce in one PR:
    - Pin that `logged_position_distribution` is **not** a search-space
      variable.
    - Concrete before/after edits required in this file:
-     - `test_graph_has_*_directed_edges` at line 71 — change
-       `assert len(graph.edges) == 6` to `assert len(graph.edges) == 7`
-       (and rename the test to match).
+     - `test_graph_has_seven_nodes` at line 66 (the count is in the
+       name) — change `assert len(graph.nodes) == 7` to
+       `assert len(graph.nodes) == 8`, add
+       `"logged_position_distribution"` to the expected-node set
+       literal, and rename the test to
+       `test_graph_has_eight_nodes`.
+     - `test_graph_has_six_directed_edges` at line 71 — change
+       `assert len(graph.edges) == 6` to
+       `assert len(graph.edges) == 7`, and rename the test to
+       `test_graph_has_seven_directed_edges`.
      - `test_every_search_variable_is_an_ancestor_of_policy_value`
        at line 92 — change
        `assert ancestors == set(_SEARCH_VARIABLES)` to
@@ -127,10 +134,20 @@ Produce in one PR:
        `position_handling_flag`. Either narrow the assertion to the
        six Sprint 37 edges, or replace with a shape-explicit edge-set
        equality check.
-     - `test_graph_has_*_nodes` at line 66 — change
-       `assert len(graph.nodes) == 7` to `assert len(graph.nodes) == 8`
-       and add `"logged_position_distribution"` to the expected-node
-       set literal.
+   - Add **one new test** with a dedicated positive assertion for
+     the new edge, so a typo in the added-node name (e.g.
+     `logged_position_distro`) does not slip past the count + chain
+     checks. Minimum shape:
+
+     ```python
+     def test_logged_position_distribution_parents_position_handling_flag(
+         self, adapter: BanditLogAdapter
+     ) -> None:
+         graph = adapter.get_prior_graph()
+         assert graph is not None
+         assert ("logged_position_distribution", "position_handling_flag") in graph.edges
+     ```
+
    - Keep every Sprint 37 assertion that is still true; update only
      the cells that changed.
 


### PR DESCRIPTION
## Summary

- Picks **Option B** for Sprint 38: widen the Open Bandit preregistered prior graph with one non-search-space structural node (`logged_position_distribution`) and one directed edge (`logged_position_distribution -> position_handling_flag`).
- Preserves the Sprint 37 engine surface verbatim: no edits to `suggest.py`, `loop.py`, `open_bandit.py`, or `open_bandit_benchmark.py`. `pomis_minimal_focus` stays default-off at the engine level and enabled only on the `causal` arm.
- Preregisters H0 (B80 `p > 0.15`, recapitulating Sprint 37 near-parity) as the *predicted* outcome and makes that no-op prediction the falsifiable claim — a B80 certified or trending row in either direction would prove the Sprint 37 engine-path analysis incomplete.
- Rejects **Option C** (different heuristic) because it would tune against the non-certified Sprint 37 B20 trend (`p = 0.0820`, `causal < surrogate_only` on 8/10 seeds). Rejects **Option D** (move on) because the Open Bandit A1 lane has not been stress-tested along the graph-structure axis after exactly one shape.
- Recommends one Sprint 38 implementation issue (not two): a single-edge graph widening plus a Sprint 37-shape rerun, strictly smaller than the Sprint 37 PR #198 footprint.

## Terminology note

The Sprint 36 plan and Sprint 38 orchestration prompt used the shorthand "non-ancestor structural node." The recommendation retires that phrase: once the edge `logged_position_distribution -> position_handling_flag` is added, `logged_position_distribution` *is* an ancestor of `policy_value` via the two-hop path. The accurate term is "non-search-space structural node" — the A1 binding condition (`len(ancestors_in_space) == len(all_var_names)`) holds because the new node is excluded from `_ancestors_in_space` by the `search_space.variable_names` filter, not because it is a non-ancestor. See the recommendation's Sprint Theme section for the full note.

## Files added

- `thoughts/shared/plans/27-sprint-38-recommendation.md` — the recommendation, grounded in `causal_optimizer/domain_adapters/bandit_log.py` lines 364–367 within `run_experiment` 346–369 and `get_prior_graph` 513–541 for the node/edge justification, and in Sprint 37 B80 `p = 0.7337` / B20 `p = 0.0820` for the option ranking.
- `thoughts/shared/prompts/sprint-38-open-bandit-post-a1-follow-up.md` — execution prompt for the next implementation lane, following the orchestration spec's `/tdd → implement → /polish → gh pr create → /gauntlet → report` workflow.

## TDD note (docs-only adaptation)

Per the Sprint 38 orchestration prompt for Track B, TDD for a planning-doc track is satisfied by defining an acceptance checklist the recommendation must satisfy before writing it. The checklist:

- picks exactly one option (B, C, or D)
- references Sprint 37 numbers, not queue pressure
- if B: names node, edge, code-grounded line citations, falsifiable rerun outcome
- does not chase the B20 trend
- does not propose a power-extension rerun for A1
- names one-issue-or-two sprint shape
- ships a matching execution prompt that does not silently widen scope

The two artifacts were written against that spec; both satisfy every item. No Python tests written.

## Gauntlet history

- `/greploop` — iteration 1 cleared 2 P2 comments (Sprint Theme self-contradiction + "non-ancestor" misnomer); re-review posted zero new inline comments.
- `/claudeloop` — 5 iterations (reached the max). Each iteration address real actionable items: `suggest.py` line-number drift (iter 1), prompt citation drift (iter 2), path-1/path-4 precision + scope dual-condition + concrete test edits (iter 3), test-file positive assertion for the new edge (iter 4), null-result asymmetry + drift-guard banner (iter 5). Iteration 5 explicitly said "minor nits above are polish, not blockers. Recommend merge after human sign-off."
- `/check-pr` — all 9 CI checks pass (lint, typecheck, build, test 3.10–3.13, test-bayesian, codecov/patch). Zero unresolved review threads.

## Test plan

- [ ] Reviewer confirms Option B is the named pick and the Option C / Option D rejections cite Sprint 37 evidence rather than impatience.
- [ ] Reviewer confirms the added node `logged_position_distribution` and the added edge `logged_position_distribution -> position_handling_flag` are each grounded in a specific `bandit_log.py` line range (364–367 within `run_experiment` 346–369 is cited in both the plan and the prompt).
- [ ] Reviewer confirms no bidirected edges are proposed.
- [ ] Reviewer confirms the falsifiable H0 / H1 / H2 block is preregistered and not tuned against an unpublished observation.
- [ ] Reviewer confirms the engine-path no-op prediction's dual scope conditions (new node non-search-space; new edge does not add a parent to `policy_value`) are stated explicitly so a Sprint 39+ plan cannot transplant the prediction to a different widening.
- [ ] Reviewer confirms the prompt's "do not" list forbids engine/optimizer edits, `request_item_overlap` (the deferred second candidate), second-dataset reopens, power extensions on A1, and B20 chasing.
- [ ] Reviewer confirms the Sprint 39 next-move branch map is preregistered (four outcomes → four Sprint 39 shapes).

Closes #201.

Planning PR only — no code changes. Implementation lands in a separate Sprint 38 PR after this planning PR is human-approved and merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)